### PR TITLE
RefDatasets, lower memory usage, and breaking changes to transforms

### DIFF
--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -12,11 +12,13 @@
 .. autofunction:: with_length
 
 .. autoclass:: BigWigs
-    :members:
-    :exclude-members: rev_strand_fn, chunked
+    :members: __init__, from_table
+    :exclude-members: __new__
 ```
 
 ## Reading
+
+### Personalized data
 
 ```{eval-rst}
 .. currentmodule:: genvarloader
@@ -27,22 +29,39 @@
 
 .. autofunction:: get_dummy_dataset
 
-.. autoclass:: Reference
-    :members:
-    :exclude-members: __new__, __init__
-
 .. autoclass:: RaggedDataset
     :exclude-members: __new__, __init__
 
 .. autoclass:: ArrayDataset
     :exclude-members: __new__, __init__
+```
+
+### Reference genome(s)
+
+```{eval-rst}
+.. currentmodule:: genvarloader
+
+.. autoclass:: Reference
+    :members:
+    :exclude-members: __new__, __init__
+
+.. autoclass:: RefDataset
+    :members:
+    :exclude-members: __new__
+```
+
+### Non-personal/site-only variants
+
+```{eval-rst}
+.. currentmodule:: genvarloader
+
+.. autoclass:: DatasetWithSites
+    :members:
+    :exclude-members: __new__
 
 .. autofunction:: sites_vcf_to_table
 
 .. autodata:: SitesSchema
-
-.. autoclass:: DatasetWithSites
-    :exclude-members: __new__, __init__
 ```
 
 ## Containers

--- a/pixi.lock
+++ b/pixi.lock
@@ -246,7 +246,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c8/14/299f99ce0fde4985cc5ba6f2258c624a5b9bbc547c3d243d99919ca53761/cyclopts-3.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/a8/90a1246c1de9037f83810c24f02464483674f60b770678e6fdece33e597d/genoray-0.10.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/a9/e9fb0424afb091da2212cb45711449167198091893b5b1b41a25875528b1/genoray-0.11.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/8e/0eccb528701273640dd4f13678a0c1352176166aecd1ee7f4fa29355132b/hirola-0.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
@@ -516,7 +516,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c8/14/299f99ce0fde4985cc5ba6f2258c624a5b9bbc547c3d243d99919ca53761/cyclopts-3.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/a8/90a1246c1de9037f83810c24f02464483674f60b770678e6fdece33e597d/genoray-0.10.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/a9/e9fb0424afb091da2212cb45711449167198091893b5b1b41a25875528b1/genoray-0.11.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/8e/0eccb528701273640dd4f13678a0c1352176166aecd1ee7f4fa29355132b/hirola-0.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1a/c1/31b3184cba7b257a4a3b5ca5b88b9204ccb7aa02fe3c992280899293ed54/lightning_utilities-0.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -863,7 +863,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/28/53/21f7b97e82772caa61541348427f42435120b32961c92d16f9c8ce9757d6/cslug-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/14/299f99ce0fde4985cc5ba6f2258c624a5b9bbc547c3d243d99919ca53761/cyclopts-3.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/a8/90a1246c1de9037f83810c24f02464483674f60b770678e6fdece33e597d/genoray-0.10.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/a9/e9fb0424afb091da2212cb45711449167198091893b5b1b41a25875528b1/genoray-0.11.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/8e/0eccb528701273640dd4f13678a0c1352176166aecd1ee7f4fa29355132b/hirola-0.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1a/c1/31b3184cba7b257a4a3b5ca5b88b9204ccb7aa02fe3c992280899293ed54/lightning_utilities-0.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -1125,7 +1125,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/97/526594453e2cdd66076292cb50424907411867532710743057f94afddb4d/cyclopts-3.16.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/a8/90a1246c1de9037f83810c24f02464483674f60b770678e6fdece33e597d/genoray-0.10.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/a9/e9fb0424afb091da2212cb45711449167198091893b5b1b41a25875528b1/genoray-0.11.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/8e/0eccb528701273640dd4f13678a0c1352176166aecd1ee7f4fa29355132b/hirola-0.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
@@ -1394,7 +1394,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c8/14/299f99ce0fde4985cc5ba6f2258c624a5b9bbc547c3d243d99919ca53761/cyclopts-3.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/a8/90a1246c1de9037f83810c24f02464483674f60b770678e6fdece33e597d/genoray-0.10.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/a9/e9fb0424afb091da2212cb45711449167198091893b5b1b41a25875528b1/genoray-0.11.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/8e/0eccb528701273640dd4f13678a0c1352176166aecd1ee7f4fa29355132b/hirola-0.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
@@ -1663,7 +1663,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c8/14/299f99ce0fde4985cc5ba6f2258c624a5b9bbc547c3d243d99919ca53761/cyclopts-3.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/a8/90a1246c1de9037f83810c24f02464483674f60b770678e6fdece33e597d/genoray-0.10.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/a9/e9fb0424afb091da2212cb45711449167198091893b5b1b41a25875528b1/genoray-0.11.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/8e/0eccb528701273640dd4f13678a0c1352176166aecd1ee7f4fa29355132b/hirola-0.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
@@ -1932,7 +1932,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c8/14/299f99ce0fde4985cc5ba6f2258c624a5b9bbc547c3d243d99919ca53761/cyclopts-3.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/a8/90a1246c1de9037f83810c24f02464483674f60b770678e6fdece33e597d/genoray-0.10.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/a9/e9fb0424afb091da2212cb45711449167198091893b5b1b41a25875528b1/genoray-0.11.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/8e/0eccb528701273640dd4f13678a0c1352176166aecd1ee7f4fa29355132b/hirola-0.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
@@ -3623,10 +3623,10 @@ packages:
   - pkg:pypi/fsspec?source=compressed-mapping
   size: 142117
   timestamp: 1743437355974
-- pypi: https://files.pythonhosted.org/packages/d2/a8/90a1246c1de9037f83810c24f02464483674f60b770678e6fdece33e597d/genoray-0.10.8-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b3/a9/e9fb0424afb091da2212cb45711449167198091893b5b1b41a25875528b1/genoray-0.11.2-py3-none-any.whl
   name: genoray
-  version: 0.10.8
-  sha256: caf905bcbb102565565a5fd6ef158a91320364fe979527c282516d99ae65b692
+  version: 0.11.2
+  sha256: d90ac35b50eae1ad4e20ff5fd41e90bcc1e44226024124ccb6160a5aa311aee5
   requires_dist:
   - attrs
   - awkward
@@ -3650,7 +3650,7 @@ packages:
 - pypi: ./
   name: genvarloader
   version: 0.14.4
-  sha256: 362bf50057570ecd4c4a7b9cc93a4ac2ff6f7cff2c88fe3283e9b4141f9c6221
+  sha256: 9c333b04a79746f172f4d28822dcc03c23bc08314e58ec0b50b0dd6faaa0f568
   requires_dist:
   - numba>=0.58.1
   - loguru
@@ -3672,7 +3672,7 @@ packages:
   - awkward
   - hirola>=0.3,<0.4
   - seqpro>=0.3.2
-  - genoray>=0.10.8
+  - genoray>=0.11.2
   requires_python: '>=3.10,<3.13'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda

--- a/pixi.lock
+++ b/pixi.lock
@@ -877,6 +877,264 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/72/25/973bd6128381951b23cdcd8a9870c6dcfc5606cb864df8eabd82e529f9c1/torchinfo-1.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/ee/4d0a7213a6f412afb3483031009a3b970dd7bed3be24de95ab04fba1c05a/torchmetrics-1.7.1-py3-none-any.whl
       - pypi: ./
+  no-torch:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-2_x86_64.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/awkward-2.8.3-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/awkward-cpp-46-py310h0900883_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-h59ae206_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.0-h5e3027f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.1-hafb2847_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.4-h2dcaabb_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.1-hb50fa74_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.19.0-h7962f60_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.13.0-h35de22e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.17-h50d7d24_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.3-hafb2847_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.7-hafb2847_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.32.5-h2811929_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.510-hffe9a0f_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/bcftools-1.21-h3a4d415_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hf71b8c6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py310h8deb56e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/commitizen-4.7.1-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.8.0-py310h89163eb_0.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/cyvcf2-0.31.1-py310h0195497_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decli-0.6.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decopatch-1.4.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/einops-0.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.192-h7f4e02f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.8.9-h5746830_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/htslib-1.21-h566b1c6_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.131.18-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/icecream-2.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.6.1-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250127.1-cxx17_hbbce691_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-h75ea233_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-20.0.0-hebdba27_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-20.0.0-hcb10f89_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-20.0.0-hcb10f89_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-20.0.0-h1bed206_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.24.1-h8e693c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-31_he106b2a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.13.0-h332b0f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.36.0-hc4361e1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.36.0-h0121fbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.71.0-h8e591d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-ha4ef2c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-31_h7ac8fdf_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-1.0.1-hbc5bc17_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.29-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.20.0-hd1b1c89_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.20.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-20.0.0-h081d1f1_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h501fc15_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hba17884_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.49.2-hee588c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.20.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.6.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.10.0-h4c51ac1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h4bc477f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py310h1a6248f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/makefun-1.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py310h89163eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.8.6-py310hdb7682f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/memray-1.17.2-py310hfc232cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/ncls-0.0.68-py310h1fe012e_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h3f2d84a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.2-py310h699fe88_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.5-py310hefbff90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.1.2-h17f744e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py310h5eaa309_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.24.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.18.0-h3f2d84a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/pgenlib-0.91.0-py310h275bdba_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/plink2-2.0.0a.6.9-h9948957_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-1.26.0-py310hc556931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.36-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-spy-0.4.0-h4c5a871_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-20.0.0-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-20.0.0-py310hac404ae_0_cpu.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/pybigwig-0.3.24-py310h95e9690_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.33.2-py310hbcd0ec0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/pyranges-0.1.4-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/linux-64/pysam-0.23.0-py310h64e62c9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.8.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.17-hd6af730_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-7_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py310h89163eb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/questionary-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.0.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.10-py310h31ffbac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.18-h763c568_1.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/samtools-1.21-h96c455f_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.1.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/sorted_nearest-0.0.39-py310h1fe012e_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.1.0-h4ce085d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/textual-3.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.13.2-h0e9735f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.13.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py310h3788b33_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.7.4-h2f11bb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.31.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py310ha75aee5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - pypi: https://files.pythonhosted.org/packages/78/05/536d025b3e17cf938f836665dde32e86f65ee76acd0ae14e22bda6aee274/beartype-0.20.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/53/21f7b97e82772caa61541348427f42435120b32961c92d16f9c8ce9757d6/cslug-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/07/97/526594453e2cdd66076292cb50424907411867532710743057f94afddb4d/cyclopts-3.16.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/a8/90a1246c1de9037f83810c24f02464483674f60b770678e6fdece33e597d/genoray-0.10.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/8e/0eccb528701273640dd4f13678a0c1352176166aecd1ee7f4fa29355132b/hirola-0.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/45/38ae786fb646e5032a982029ad1c0964433e74b67e328d2c9d2fc6691639/pysam-0.23.0-cp310-cp310-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/bc/cc4e3dbc5e7992398dcb7a8eda0cbcf4fb792a0cdb93f857b478bf3cf884/rich_rst-1.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/a1/6de4f7bf0a7704a200de5d0fbaf4d333fd5ca56b9a3e6f3a3ad05e99ba98/seqpro-0.3.2-cp39-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c6/64/3d24181aaea3fb892d4a46f8171845782ee364d60e9494426daf31d12f47/tbb-2022.1.0-py2.py3-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/06/bb/09a6dc2f1110b409d6d2f96429969d7466bde9bf4ad8b2e682d851ef104b/tcmlib-1.3.0-py2.py3-none-manylinux_2_28_x86_64.whl
+      - pypi: ./
   py310:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1860,6 +2118,24 @@ packages:
   - pkg:pypi/awkward?source=hash-mapping
   size: 433940
   timestamp: 1746300742499
+- conda: https://conda.anaconda.org/conda-forge/noarch/awkward-2.8.3-pyhe01879c_1.conda
+  sha256: 579723fcc52ed8db4f051fd3ffc0e684ce2cf572850a0b36a914359524d7be14
+  md5: 3923c3b9f7372958adabea74542c47ae
+  depends:
+  - python >=3.9
+  - awkward-cpp ==46
+  - importlib-metadata >=4.13.0
+  - numpy >=1.18.0
+  - packaging
+  - typing_extensions >=4.1.0
+  - fsspec >=2022.11.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/awkward?source=hash-mapping
+  size: 455501
+  timestamp: 1747414060060
 - conda: https://conda.anaconda.org/conda-forge/linux-64/awkward-cpp-45-py310h0900883_100.conda
   sha256: b288d7c78eba0cfd380360c253eb59e0dee5e4a98d1aa9daaf8c4bb9ae5f8b0e
   md5: 1bf3e0220393d5941b2c1acdc9c95718
@@ -1911,6 +2187,23 @@ packages:
   - pkg:pypi/awkward-cpp?source=hash-mapping
   size: 531289
   timestamp: 1742473663256
+- conda: https://conda.anaconda.org/conda-forge/linux-64/awkward-cpp-46-py310h0900883_100.conda
+  sha256: 2cb6e5a046f367be4f298f65f339a7acdac50201e1d8ce8c85cbb467629ac7ca
+  md5: c6099a5811c875748c66f57a61b07333
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _x86_64-microarch-level >=1
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.18.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/awkward-cpp?source=hash-mapping
+  size: 524047
+  timestamp: 1747358472069
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-h094d708_2.conda
   sha256: 52ac77926deb7e9672ab60e330dfad31392ebe9f0f78cdf0bc597d7d7c12a2cb
   md5: 9b1e62c9d7b158cf1a234ee49ef6232f
@@ -1927,6 +2220,22 @@ packages:
   purls: []
   size: 111498
   timestamp: 1743819638135
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-h59ae206_7.conda
+  sha256: 796f0fd63c4f05e5784dca0edc838ab6288bdb8c4c12ebd45bde93fdbd683495
+  md5: ca157ee18f02c33646d975995631b39e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.9.0,<0.9.1.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-http >=0.10.1,<0.10.2.0a0
+  - aws-c-io >=0.19.0,<0.19.1.0a0
+  - aws-c-sdkutils >=0.2.3,<0.2.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 111152
+  timestamp: 1747190463145
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-h9a6e2ae_4.conda
   sha256: 7444691a43a19510f5b667599034c8fceaca389d52388c6d9d52a4d239594fcd
   md5: a948110dbbde6491c62815643a96d589
@@ -1956,6 +2265,19 @@ packages:
   purls: []
   size: 50997
   timestamp: 1743664886404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.0-h5e3027f_1.conda
+  sha256: da8e6d0fa83a80e6f0f9c59ae0ac157915fb0b684020cc16c9915d4d7171fe20
+  md5: 220588a5c6c9341a39d9e399848e5554
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - libgcc >=13
+  - openssl >=3.5.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 50521
+  timestamp: 1747127810932
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.0-hada3f3f_0.conda
   sha256: e635934e54c2145afa06bd69f5d92d14cb2e27a59625f7236493dd9b11717e9b
   md5: 05a965f6def53dbcb5217945eb0b3689
@@ -1980,6 +2302,29 @@ packages:
   purls: []
   size: 236536
   timestamp: 1743046458804
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.3-hb9d3cd8_0.conda
+  sha256: 251883d45fbc3bc88a8290da073f54eb9d17e8b9edfa464d80cff1b948c571ec
+  md5: 8448031a22c697fac3ed98d69e8a9160
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 236494
+  timestamp: 1747101172537
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.1-hafb2847_5.conda
+  sha256: 68e7ec0ab4f5973343de089ac71c7b9b9387c35640c61e0236ad45fc3dbfaaaa
+  md5: e96cc668c0f9478f5771b37d57f90386
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 21817
+  timestamp: 1747144982788
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.1-hc2d532b_4.conda
   sha256: cf6caf5207c95a36c8089c54307e192befa92b773a65e0369b72fabfdc408fee
   md5: 4cc4dcd582b2f087d62c70b2d6daa59f
@@ -1992,6 +2337,22 @@ packages:
   purls: []
   size: 21753
   timestamp: 1743446917660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.4-h2dcaabb_9.conda
+  sha256: 5df00b73c5b6fa27769a18f6d3172f45f2fbe2b1e440e320199702a2231306f4
+  md5: 2f2ffcdfeabac698297fce1259e51a2a
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-io >=0.19.0,<0.19.1.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 57205
+  timestamp: 1747185871709
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.4-h8170a11_5.conda
   sha256: 4c718a19cf3411ab54b5ff6a7b6dfd10bb46689880e683ae97e1e0de3c7a13dc
   md5: 68614c9a3b3fb09cb1b4e8c4ed9333fb
@@ -2037,6 +2398,21 @@ packages:
   purls: []
   size: 222970
   timestamp: 1745976470685
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.1-hb50fa74_1.conda
+  sha256: d811159f8ec3f3578dbf27a4b3d2756cd4cbc70e42f5e6e71972b6b50ddc8161
+  md5: 2bb746bfe603e4949d99404b25c639ea
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-io >=0.19.0,<0.19.1.0a0
+  - aws-c-compression >=0.3.1,<0.3.2.0a0
+  - aws-c-cal >=0.9.0,<0.9.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 223036
+  timestamp: 1747186878815
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.5-hca9d837_2.conda
   sha256: 9b5a7323dbe50245790dc9c7527ae9b2f8341eeb491ccead060e2a159bd113fd
   md5: 2c3fdcb5a1bf40fd7b6b5598718e5929
@@ -2079,6 +2455,20 @@ packages:
   purls: []
   size: 180304
   timestamp: 1745155363667
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.19.0-h7962f60_2.conda
+  sha256: a2c6d887fb682d7128703a1b6069aaad02dcfc455f03fcb9d8269da6fa9cfed7
+  md5: 7a4be9867bab106d87febec673094a9e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - s2n >=1.5.18,<1.5.19.0a0
+  - aws-c-cal >=0.9.0,<0.9.1.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 179077
+  timestamp: 1747159979745
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.12.3-h773eac8_2.conda
   sha256: b097a71a86cd49e1fd18b6a8f2bedd0b0ea88e75c3423b561e48ef2a494ba389
   md5: 53e040407719cf505b7753a6450e4d03
@@ -2106,6 +2496,20 @@ packages:
   purls: []
   size: 213876
   timestamp: 1746015332689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.13.0-h35de22e_3.conda
+  sha256: 7275a7ca192306ff3b43cedc63bb854ce6279617f8d4799af4837ef05383c35c
+  md5: df3ea458761b3fdf9e6eb7d8a38c121a
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-http >=0.10.1,<0.10.2.0a0
+  - aws-c-io >=0.19.0,<0.19.1.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 215707
+  timestamp: 1747215213079
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.15-h46af1f8_1.conda
   sha256: 601dc338a99ebb146c89a0dcc4e6e3051427fe068aa05557bd35628cab2c6120
   md5: 4b91da7a394cb7c0a5bd9bb8dd8dcc76
@@ -2141,6 +2545,36 @@ packages:
   purls: []
   size: 129704
   timestamp: 1746041983017
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.17-h50d7d24_2.conda
+  sha256: 9d952875d665b55a1a92d1b534a72eeffed6618d5e8131aca6be4a895705fa56
+  md5: 701bf42db0ec5de1e56b66ae0638d20b
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - openssl >=3.5.0,<4.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - aws-c-cal >=0.9.0,<0.9.1.0a0
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-http >=0.10.1,<0.10.2.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-io >=0.19.0,<0.19.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 129742
+  timestamp: 1747215633728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.3-hafb2847_5.conda
+  sha256: 49bcc575df6f31de392fcfbeb8f5cae80c45b77021818bb4b6d41e138d7f3205
+  md5: 51ffa5a303e8256dcb176f14d78887b4
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 58967
+  timestamp: 1747138537291
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.3-hc2d532b_4.conda
   sha256: 09d276413249df36ecc533d9aff97945cc3a2d4ae818bf50d3968fde7e68bc61
   md5: 15a1f6fb713b4cd3fee74588b996a846
@@ -2165,6 +2599,18 @@ packages:
   purls: []
   size: 76007
   timestamp: 1743447027086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.7-hafb2847_1.conda
+  sha256: 03a5e4b3dcda35696133632273043d0b81e55129ff0f9e6d75483aa8eb96371b
+  md5: 6d28d50637fac4f081a0903b4b33d56d
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 76627
+  timestamp: 1747141741534
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.7-hc2d532b_0.conda
   sha256: 69141040515c0e52401d5e2e49afcd29b39dc0f6fecac41afda21f99086ac38f
   md5: 398521f53e58db246658e7cff56d669f
@@ -2220,6 +2666,27 @@ packages:
   purls: []
   size: 390492
   timestamp: 1744838713428
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.32.5-h2811929_3.conda
+  sha256: 0da65b4e3afecf205323f8fdfd2fa5d2a26d295d393d3548360d2de68d266c49
+  md5: c38733af13b256b8893a6af0d2a1d346
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-mqtt >=0.13.0,<0.13.1.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
+  - aws-c-sdkutils >=0.2.3,<0.2.4.0a0
+  - aws-c-io >=0.19.0,<0.19.1.0a0
+  - aws-c-http >=0.10.1,<0.10.2.0a0
+  - aws-c-s3 >=0.7.17,<0.7.18.0a0
+  - aws-c-cal >=0.9.0,<0.9.1.0a0
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 394536
+  timestamp: 1747232223388
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.510-h5b777a2_5.conda
   sha256: e2e18bda4be87b778bc15949c3121cb1c4d2e702a8d8acb3a9f4cb6312397462
   md5: 860ec2d406d3956b1a8f8cc8ac18faa4
@@ -2256,6 +2723,24 @@ packages:
   purls: []
   size: 3401396
   timestamp: 1745604795071
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.510-hffe9a0f_8.conda
+  sha256: 2f5d05c90ac9c3dd7acecb2c4215545d75a05e79d8a55be6570a5a301a8fba33
+  md5: 4cd13ac60fb622ab49dfe949f2cd3051
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
+  - libcurl >=8.13.0,<9.0a0
+  - aws-crt-cpp >=0.32.5,<0.32.6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 3401491
+  timestamp: 1747246390329
 - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
   sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
   md5: 0a8838771cc2e985cd295e01ae83baf1
@@ -2573,6 +3058,16 @@ packages:
   - pkg:pypi/certifi?source=compressed-mapping
   size: 162721
   timestamp: 1739515973129
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
+  sha256: 52aa837642fd851b3f7ad3b1f66afc5366d133c1d452323f786b0378a391915c
+  md5: c33eeaaa33f45031be34cda513df39b6
+  depends:
+  - python >=3.9
+  license: ISC
+  purls:
+  - pkg:pypi/certifi?source=hash-mapping
+  size: 157200
+  timestamp: 1746569627830
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py310h8deb56e_0.conda
   sha256: 1b389293670268ab80c3b8735bc61bc71366862953e000efbb82204d00e41b6c
   md5: 1fc24a3196ad5ede2a68148be61894f4
@@ -2700,6 +3195,30 @@ packages:
   - pkg:pypi/comm?source=hash-mapping
   size: 12103
   timestamp: 1733503053903
+- conda: https://conda.anaconda.org/conda-forge/linux-64/commitizen-4.7.1-py310hff52083_0.conda
+  sha256: f3a42832944712a8d26b2980204ed0abc849eeb10f338d87049c3dbb21c01d52
+  md5: cadce8661472b3dbc4f2cd9cfdaaf12f
+  depends:
+  - argcomplete <3.7,>=1.12.1
+  - charset-normalizer <4,>=2.1.0
+  - colorama <1.0,>=0.4.1
+  - decli <1.0,>=0.6.0
+  - importlib_metadata <9,>=8.0.0
+  - jinja2 >=2.10.3
+  - packaging >=19
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - pyyaml >=3.08
+  - questionary <3.0,>=2.0
+  - termcolor <3,>=1.1
+  - tomlkit <1.0.0,>=0.5.3
+  - typing_extensions <5.0.0,>=4.0.1
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/commitizen?source=hash-mapping
+  size: 117746
+  timestamp: 1747376488923
 - conda: https://conda.anaconda.org/conda-forge/noarch/commitizen-4.6.0-pyhd8ed1ab_0.conda
   sha256: 2aaf1623bcd0160b4e6fcbd573453a2e07a72edf648f92bd7d298fc3a105fe4a
   md5: 1dae27aba235cb09d85435ae5934e77b
@@ -2841,6 +3360,21 @@ packages:
   - rich>=13.6.0
   - rich-rst>=1.3.1,<2.0.0
   - tomli>=2.0.0 ; python_full_version < '3.11' and extra == 'toml'
+  - typing-extensions>=4.8.0 ; python_full_version < '3.11'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/07/97/526594453e2cdd66076292cb50424907411867532710743057f94afddb4d/cyclopts-3.16.1-py3-none-any.whl
+  name: cyclopts
+  version: 3.16.1
+  sha256: ce8abc2393f36b16d9c5186f08f4a77ddd44d011faf6915e5097e0ba9db10e1b
+  requires_dist:
+  - attrs>=23.1.0
+  - docstring-parser>=0.15 ; python_full_version < '4.0'
+  - importlib-metadata>=4.4 ; python_full_version < '3.10'
+  - pyyaml>=6.0.1 ; extra == 'yaml'
+  - rich>=13.6.0
+  - rich-rst>=1.3.1,<2.0.0
+  - tomli>=2.0.0 ; python_full_version < '3.11' and extra == 'toml'
+  - trio>=0.10.0 ; extra == 'trio'
   - typing-extensions>=4.8.0 ; python_full_version < '3.11'
   requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/bioconda/linux-64/cyvcf2-0.31.1-py310h0195497_1.tar.bz2
@@ -3035,6 +3569,17 @@ packages:
   - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 20486
   timestamp: 1733208916977
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ce61f4f99401a4bd455b89909153b40b9c823276aefcbb06f2044618696009ca
+  md5: 72e42d28960d875c7654614f8b50939a
+  depends:
+  - python >=3.9
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=compressed-mapping
+  size: 21284
+  timestamp: 1746947398083
 - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
   sha256: 28d25ea375ebab4bf7479228f8430db20986187b04999136ff5c722ebd32eb60
   md5: ef8b5fca76806159fc25b4f48d8737eb
@@ -3347,6 +3892,21 @@ packages:
   - pkg:pypi/hyperframe?source=hash-mapping
   size: 17397
   timestamp: 1737618427549
+- conda: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.131.18-pyha770c72_0.conda
+  sha256: 2a436bd6c329dd2e5451e05a0945ad48d84595471eabdd536ae22922d8cd7869
+  md5: e36e354d2d375eef069e60aa0c323793
+  depends:
+  - attrs >=22.2.0
+  - click >=7.0
+  - exceptiongroup >=1.0.0
+  - python >=3.9
+  - setuptools
+  - sortedcontainers >=2.1.0,<3.0.0
+  license: MPL-2.0
+  purls:
+  - pkg:pypi/hypothesis?source=hash-mapping
+  size: 357799
+  timestamp: 1747462621786
 - conda: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.131.3-pyha770c72_0.conda
   sha256: 7c4449b93afbc10ce810d6ed9faeb28dbda47f21299b8f70879b74d27a2130ca
   md5: 5c66e43d4aee5bac7af495f806dbbef1
@@ -3393,6 +3953,18 @@ packages:
   - pkg:pypi/icecream?source=hash-mapping
   size: 18697
   timestamp: 1736498252208
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12129203
+  timestamp: 1720853576813
 - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.10-pyhd8ed1ab_0.conda
   sha256: 02f47df6c6982b796aecb086b434627207e87c0a90a50226f11f2cc99c089770
   md5: 8d5b9b702810fb3054d52ba146023bc3
@@ -3451,6 +4023,16 @@ packages:
   - pkg:pypi/importlib-metadata?source=hash-mapping
   size: 29141
   timestamp: 1737420302391
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.6.1-hd8ed1ab_0.conda
+  sha256: 1e3eb9d65c4d7b87c7347553ef9eef6f994996f90a2299e19b35f5997d3a3e79
+  md5: 7f46575a91b1307441abc235d01cab66
+  depends:
+  - importlib-metadata >=8.6.1,<8.6.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 9502
+  timestamp: 1737420303228
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
   sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
   md5: c85c76dc67d75619a92f51dfbce06992
@@ -3842,6 +4424,47 @@ packages:
   purls: []
   size: 9186076
   timestamp: 1745978106549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-20.0.0-hebdba27_3_cpu.conda
+  build_number: 3
+  sha256: dff51b5c2164ad21b7dbf796f7c79c2abba84a88d6932ce7bd09418a672a5e83
+  md5: 5be86a1b5f496f82c7dfeb0dbe19ef03
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.32.5,<0.32.6.0a0
+  - aws-sdk-cpp >=1.11.510,<1.11.511.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250127.1,<20250128.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc >=13
+  - libgoogle-cloud >=2.36.0,<2.37.0a0
+  - libgoogle-cloud-storage >=2.36.0,<2.37.0a0
+  - libopentelemetry-cpp >=1.20.0,<1.21.0a0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libutf8proc >=2.10.0,<2.11.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - orc >=2.1.2,<2.1.3.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 9189847
+  timestamp: 1746920464544
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-20.0.0-hf00d7f4_1_cpu.conda
   build_number: 1
   sha256: be201777b89357d12f576f35ac9c568a540eafaf9fa0f21e592eb98bfb96ec37
@@ -3921,6 +4544,20 @@ packages:
   purls: []
   size: 641239
   timestamp: 1746631689388
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-20.0.0-hcb10f89_3_cpu.conda
+  build_number: 3
+  sha256: 28f186a7806085e13cb8ee939931dc2020b59413b762f68b872cc6620f777f69
+  md5: 679cd6bb558cd6565d98ad66af6ff6ed
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 20.0.0 hebdba27_3_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 642069
+  timestamp: 1746920544904
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-19.0.1-hcb10f89_8_cpu.conda
   build_number: 8
   sha256: d1162e03c292e23c5893385ab012c73e13e49f57ece4fdeb3c6297f550bc0c44
@@ -3966,6 +4603,22 @@ packages:
   purls: []
   size: 608531
   timestamp: 1746631886431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-20.0.0-hcb10f89_3_cpu.conda
+  build_number: 3
+  sha256: ae0cc1eade563a14eaf59a921021cec5c526f6c1af93b81d3136caf41075c6ef
+  md5: 0e84685fdecbd83666dd73292cc7d05a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 20.0.0 hebdba27_3_cpu
+  - libarrow-acero 20.0.0 hcb10f89_3_cpu
+  - libgcc >=13
+  - libparquet 20.0.0 h081d1f1_3_cpu
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 607683
+  timestamp: 1746920679379
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-19.0.1-h1bed206_8_cpu.conda
   build_number: 8
   sha256: 4385e78e7bb9e397ce04eddcdbc0e43ef826b7b3cfdb456645d3dd47357699d9
@@ -4020,6 +4673,25 @@ packages:
   purls: []
   size: 522892
   timestamp: 1746631971341
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-20.0.0-h1bed206_3_cpu.conda
+  build_number: 3
+  sha256: 828806da67cb821c74d43920cc15782d5c8b08318807799b30d9cbcf9fe94733
+  md5: c4d2a874f1ca439fb3c2a17060d6b911
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20250127.1,<20250128.0a0
+  - libarrow 20.0.0 hebdba27_3_cpu
+  - libarrow-acero 20.0.0 hcb10f89_3_cpu
+  - libarrow-dataset 20.0.0 hcb10f89_3_cpu
+  - libgcc >=13
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 525332
+  timestamp: 1746920767029
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.23.1-h8e693c7_0.conda
   sha256: 13b863584fccbb9089de73a2442e540703ce4873e4719c9d98c98e4a8e12f9d1
   md5: 988f4937281a66ca19d1adb3b5e3f859
@@ -4256,6 +4928,20 @@ packages:
   purls: []
   size: 847885
   timestamp: 1740240653082
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
+  sha256: 0024f9ab34c09629621aefd8603ef77bf9d708129b0dd79029e502c39ffc2195
+  md5: ea8ac52380885ed41c1baa8f1d6d2b93
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.1.0=*_2
+  - libgomp 15.1.0 h767d61c_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 829108
+  timestamp: 1746642191935
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_2.conda
   sha256: fb7558c328b38b2f9d2e412c48da7890e7721ba018d733ebdfea57280df01904
   md5: a2222a6ada71fb478682efe483ce0f92
@@ -4266,6 +4952,16 @@ packages:
   purls: []
   size: 53758
   timestamp: 1740240660904
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
+  sha256: 0ab5421a89f090f3aa33841036bb3af4ed85e1f91315b528a9d75fab9aad51ae
+  md5: ddca86c7040dd0e73b2b69bd7833d225
+  depends:
+  - libgcc 15.1.0 h767d61c_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 34586
+  timestamp: 1746642200749
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.23.1-h5888daf_0.conda
   sha256: 190097140d9c16637aa516757d8087f17e8c22cc844c87288da64404b81ef43c
   md5: a09ce5decdef385bcce78c32809fa794
@@ -4299,6 +4995,18 @@ packages:
   purls: []
   size: 53733
   timestamp: 1740240690977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_2.conda
+  sha256: 914daa4f632b786827ea71b5e07cd00d25fc6e67789db2f830dc481eec660342
+  md5: f92e6e0a3c0c0c85561ef61aa59d555d
+  depends:
+  - libgfortran5 15.1.0 hcea5267_2
+  constrains:
+  - libgfortran-ng ==15.1.0=*_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 34541
+  timestamp: 1746642233221
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hf1ad2bd_2.conda
   sha256: c17b7cf3073a1f4e1f34d50872934fa326346e104d3c445abc1e62481ad6085c
   md5: 556a4fdfac7287d349b8f09aba899693
@@ -4312,6 +5020,19 @@ packages:
   purls: []
   size: 1461978
   timestamp: 1740240671964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_2.conda
+  sha256: be23750f3ca1a5cb3ada858c4f633effe777487d1ea35fddca04c0965c073350
+  md5: 01de444988ed960031dbe84cf4f9b1fc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.1.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 1569986
+  timestamp: 1746642212331
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
   sha256: 1a3130e0b9267e781b89399580f3163632d59fe5b0142900d63052ab1a53490e
   md5: 06d02030237f4d5b3d9a7e7d348fe3c6
@@ -4322,6 +5043,16 @@ packages:
   purls: []
   size: 459862
   timestamp: 1740240588123
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
+  sha256: 05fff3dc7e80579bc28de13b511baec281c4343d703c406aefd54389959154fb
+  md5: fbe7d535ff9d3a168c148e07358cd5b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 452635
+  timestamp: 1746642113092
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.36.0-hc4361e1_1.conda
   sha256: 3a56c653231d6233de5853dc01f07afad6a332799a39c3772c0948d2e68547e4
   md5: ae36e6296a8dd8e8a9a8375965bf6398
@@ -4483,6 +5214,19 @@ packages:
   purls: []
   size: 112709
   timestamp: 1743771086123
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
+  sha256: eeff241bddc8f1b87567dd6507c9f441f7f472c27f0860a07628260c000ef27c
+  md5: a76fd702c93cd2dfd89eff30a5fd45a8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
+  license: 0BSD
+  purls: []
+  size: 112845
+  timestamp: 1746531470399
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-1.0.1-hbc5bc17_1.conda
   sha256: 0aa6287ec8698090d09def3416c38e5975fd2b76cd24ff5dac97edcdd6e1fbd4
   md5: c384e4dcd3c345b54bfb79d9ff712349
@@ -4610,6 +5354,22 @@ packages:
   purls: []
   size: 1241803
   timestamp: 1746631842790
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-20.0.0-h081d1f1_3_cpu.conda
+  build_number: 3
+  sha256: 113148922c560f8d2dd2a1684782dc4f93f44637dacd97fce1ad5e5af9dd10e9
+  md5: f15cc1214c08019be884e3defd93e000
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 20.0.0 hebdba27_3_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1243008
+  timestamp: 1746920646524
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h501fc15_0.conda
   sha256: 9965b1ada1f997202ad8c5a960e69057280b7b926c718df9b07c62924d9c1d73
   md5: 452518a9744fbac05fb45531979bdf29
@@ -4676,6 +5436,17 @@ packages:
   purls: []
   size: 918664
   timestamp: 1742083674731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.49.2-hee588c1_0.conda
+  sha256: 525d4a0e24843f90b3ff1ed733f0a2e408aa6dd18b9d4f15465595e078e104a2
+  md5: 93048463501053a00739215ea3f36324
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  purls: []
+  size: 916313
+  timestamp: 1746637007836
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -4713,6 +5484,17 @@ packages:
   purls: []
   size: 3884556
   timestamp: 1740240685253
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
+  sha256: 6ae3d153e78f6069d503d9309f2cac6de5b93d067fc6433160a4c05226a5dad4
+  md5: 1cb1c67961f6dd257eae9e9691b341aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.1.0 h767d61c_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 3902355
+  timestamp: 1746642227493
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_2.conda
   sha256: e86f38b007cf97cc2c67cd519f2de12a313c4ee3f5ef11652ad08932a5e34189
   md5: c75da67f045c2627f59e6fcb5f4e3a9b
@@ -4723,6 +5505,16 @@ packages:
   purls: []
   size: 53830
   timestamp: 1740240722530
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_2.conda
+  sha256: 11bea86e11de7d6bce87589197a383344df3fa0a3552dab7e931785ff1159a5b
+  md5: 9d2072af184b5caa29492bf2344597bb
+  depends:
+  - libstdcxx 15.1.0 h8f9b012_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 34647
+  timestamp: 1746642266826
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.20.0-hb9d3cd8_0.conda
   sha256: 5fd3b8a4a9719e3d1c08826c3dfe42eecc816a2aaf5c3849a85f11ff3c4b1b19
   md5: 942cd32b349ec84fb3879955fa68f994
@@ -4882,6 +5674,21 @@ packages:
   purls: []
   size: 691042
   timestamp: 1743794600936
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h4bc477f_0.conda
+  sha256: b0b3a96791fa8bb4ec030295e8c8bf2d3278f33c0f9ad540e73b5e538e6268e7
+  md5: 14dbe05b929e329dbaa6f2d0aa19466d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 690864
+  timestamp: 1746634244154
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -5072,6 +5879,17 @@ packages:
   - pkg:pypi/makefun?source=hash-mapping
   size: 26784
   timestamp: 1742578652235
+- conda: https://conda.anaconda.org/conda-forge/noarch/makefun-1.16.0-pyhd8ed1ab_0.conda
+  sha256: 0e03e67393eb596430f27bccaf75f5c317cfd0d245e2740a29c61978a82dc9b1
+  md5: 220b98de4da252648b825e21ba351d5d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/makefun?source=hash-mapping
+  size: 26779
+  timestamp: 1747205193363
 - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
   sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
   md5: fee3164ac23dfca50cfcc8b85ddefb81
@@ -5192,6 +6010,22 @@ packages:
   - pkg:pypi/maturin?source=hash-mapping
   size: 6472955
   timestamp: 1741886678732
+- conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.8.6-py310hdb7682f_0.conda
+  sha256: 806cb629935372e69295bd0902018c55af197df16e934f214211bd21a0b8b1f9
+  md5: 278e944776613d1644015d624b76af58
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - openssl >=3.5.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tomli >=1.1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
+  size: 6467984
+  timestamp: 1747195695674
 - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
   sha256: c63ed79d9745109c0a70397713b0c07f06e7d3561abcb122cfc80a141ab3b449
   md5: af2060041d4f3250a7eb6ab3ec0e549b
@@ -5275,6 +6109,26 @@ packages:
   - pkg:pypi/memray?source=hash-mapping
   size: 717972
   timestamp: 1744410040790
+- conda: https://conda.anaconda.org/conda-forge/linux-64/memray-1.17.2-py310hfc232cf_0.conda
+  sha256: 7147ad074843e31f5e0f8f20f898d5b8038b054ca27cec02f82249eba84d25dd
+  md5: b7815a024475cf6f76d0c93fef6b9c4a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - elfutils >=0.192,<0.193.0a0
+  - jinja2
+  - libgcc >=13
+  - libstdcxx >=13
+  - libunwind >=1.6.2,<1.7.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - rich >=11.2.0
+  - textual >=0.34.0
+  license: Apache-2.0 AND BSD-3-Clause
+  purls:
+  - pkg:pypi/memray?source=hash-mapping
+  size: 686727
+  timestamp: 1746769489931
 - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.3-pyh29332c3_0.conda
   sha256: a67484d7dd11e815a81786580f18b6e4aa2392f292f29183631a6eccc8dc37b3
   md5: 7ec6576e328bc128f4982cd646eeba85
@@ -6118,6 +6972,16 @@ packages:
   purls: []
   size: 6988
   timestamp: 1741441142386
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.24.0-hd8ed1ab_0.conda
+  sha256: cdd4c6adb4bb08531f18c489946cd0e290dbad4ec44cf4bf5afebb0231c7bfd4
+  md5: eb0641b84b2a059eab4ed77dcea42f16
+  depends:
+  - pandera-base >=0.24.0,<0.24.1.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 7414
+  timestamp: 1747514074017
 - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.23.1-pyhd8ed1ab_0.conda
   sha256: 346522cbc5a88000c818626028881b89beb509b5f1872093e452352c9b9e5c7f
   md5: cc301a114c9d6d6fea6fc32d49aa250d
@@ -6135,6 +6999,23 @@ packages:
   - pkg:pypi/pandera?source=hash-mapping
   size: 153748
   timestamp: 1741441141466
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.24.0-pyhd8ed1ab_0.conda
+  sha256: 78a254cf8c319eaff2ed423842799ecd7d99b8870274f8a39e4c8d1ae13250a5
+  md5: a8f2f0820ee1b5ca04b657d4cb7770a5
+  depends:
+  - numpy >=1.24.4
+  - packaging >=20.0
+  - pandas >=2.1.1
+  - pydantic
+  - python >=3.9
+  - typeguard
+  - typing_inspect >=0.6.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pandera?source=hash-mapping
+  size: 155311
+  timestamp: 1747514072843
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.6.4-ha770c72_0.conda
   sha256: 16cbcab8a6d9a0cef47b9d3ebeced8a1a75ee54d379649e6260a333d1b2f743c
   md5: 53f2cd4128fa7053bb029bbeafbe3f2e
@@ -6324,6 +7205,18 @@ packages:
   - pkg:pypi/platformdirs?source=compressed-mapping
   size: 23291
   timestamp: 1742485085457
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
+  sha256: 0f48999a28019c329cd3f6fd2f01f09fc32cc832f7d6bbe38087ddac858feaa3
+  md5: 424844562f5d337077b445ec6b1398a7
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/platformdirs?source=compressed-mapping
+  size: 23531
+  timestamp: 1746710438805
 - conda: https://conda.anaconda.org/bioconda/linux-64/plink2-2.0.0a.6.9-h9948957_0.tar.bz2
   sha256: 8f9b2415a5035b5019ef83d2db6f6af2b9739796186a3e558a7baf69c14b0b6b
   md5: b9e94cb7fa3bb4353c68e4c553690245
@@ -6345,6 +7238,17 @@ packages:
   - pkg:pypi/pluggy?source=hash-mapping
   size: 23595
   timestamp: 1733222855563
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+  sha256: a8eb555eef5063bbb7ba06a379fa7ea714f57d9741fe0efdb9442dbbc2cccbcc
+  md5: 7da7ccd349dbf6487a7778579d2bb971
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pluggy?source=compressed-mapping
+  size: 24246
+  timestamp: 1747339794916
 - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-1.26.0-py310hc556931_0.conda
   sha256: 4a8b1069f14bfd9f8efe761cc0715c77d5dfbefeb7d8651073e0455a5efb91be
   md5: cc98853d8d0f75ee4676c008b4148468
@@ -6836,6 +7740,22 @@ packages:
   - pkg:pypi/pydantic?source=compressed-mapping
   size: 306616
   timestamp: 1744192311966
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.4-pyh3cfb1c2_0.conda
+  sha256: a522473505ac6a9c10bb304d7338459a406ba22a6d3bb1a355c1b5283553a372
+  md5: 8ad3ad8db5ce2ba470c9facc37af00a9
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.33.2
+  - python >=3.9
+  - typing-extensions >=4.6.1
+  - typing-inspection >=0.4.0
+  - typing_extensions >=4.12.2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic?source=compressed-mapping
+  size: 306304
+  timestamp: 1746632069456
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.33.1-py310hc1293b2_0.conda
   sha256: 76992a2b50b98a43b66be401998b0b71f4bbb3cc0db456309263a604dddff086
   md5: 24460b8a58d6d491be4088ffb5343f4b
@@ -6887,6 +7807,23 @@ packages:
   - pkg:pypi/pydantic-core?source=hash-mapping
   size: 1900701
   timestamp: 1743607634677
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.33.2-py310hbcd0ec0_0.conda
+  sha256: 8da9aed7f21d775a7c91db6c9f95a0e00cae2d132709d5dc608c2e6828f9344b
+  md5: 6b210a72e9e1b1cb6d30b266b84ca993
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1892885
+  timestamp: 1746625312783
 - conda: https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.15.4-pyhd8ed1ab_0.conda
   sha256: 5ec877142ded763061e114e787a4e201c2fb3f0b1db2f04ace610a1187bb34ae
   md5: c7c50dd5192caa58a05e6a4248a27acb
@@ -7743,6 +8680,23 @@ packages:
   - pkg:pypi/rpds-py?source=hash-mapping
   size: 394023
   timestamp: 1743037659894
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.10-py310h31ffbac_1.conda
+  sha256: a32c9a322d267f37a44f9a24d257426ec612bafa45a1e9280b130cb213d69e23
+  md5: 4468e953df21731a19f5c8ba94bc0225
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruff?source=hash-mapping
+  size: 8224192
+  timestamp: 1747401348073
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.6-py310h01b0e6a_0.conda
   sha256: 1c2f7a2aa27bd5dd2b6d83d87d26d2d9ba28505202540accd23c20beafb786b0
   md5: 7d7e9696e7e236aa48ab0990b70dbbc6
@@ -7852,6 +8806,18 @@ packages:
   purls: []
   size: 348633
   timestamp: 1744972730362
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.18-h763c568_1.conda
+  sha256: 6d0399775ef7841914e99aed5b7330ce3d9d29a4219d40b1b94fd9a50d902a73
+  md5: 0bf75253494a85260575e23c3b29db90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - openssl >=3.5.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 353577
+  timestamp: 1746350509891
 - conda: https://conda.anaconda.org/bioconda/linux-64/samtools-1.21-h96c455f_1.tar.bz2
   sha256: 2a22cd528c5f8448398a6ca77154bed39081cee521f95ac704af4df64114304f
   md5: 0ff9d5d48561198378ad3cb34ce830bf
@@ -7901,6 +8867,17 @@ packages:
   - pkg:pypi/setuptools?source=compressed-mapping
   size: 786557
   timestamp: 1743775941985
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.1.0-pyhff2d567_0.conda
+  sha256: 777d34ed359cedd5a5004c930077c101bb3b70e5fbb04d29da5058d75b0ba487
+  md5: f6f72d0837c79eaec77661be43e8a691
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/setuptools?source=compressed-mapping
+  size: 778484
+  timestamp: 1746085063737
 - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
   sha256: 0557c090913aa63cdbe821dbdfa038a321b488e22bc80196c4b3b1aace4914ef
   md5: 7c3c2a0f3ebdea2bbc35538d162b43bf
@@ -8614,6 +9591,19 @@ packages:
   - pkg:pypi/typer?source=compressed-mapping
   size: 77044
   timestamp: 1745886712803
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
+  sha256: b70f0d7892d81e1e2fd0c581c6d85e6e3c3683752e1fb2cef8f75a994c0a379b
+  md5: 962bae3826ede4349263e6e027280724
+  depends:
+  - typer-slim-standard ==0.15.4 haa4fddc_0
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typer?source=hash-mapping
+  size: 77100
+  timestamp: 1747243737598
 - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.2-pyh29332c3_0.conda
   sha256: c094713560bfacab0539c863010a5223171d9980cbd419cc799e474ae15aca08
   md5: 7c8d9609e2cfe08dd7672e10fe7e7de9
@@ -8650,6 +9640,24 @@ packages:
   - pkg:pypi/typer-slim?source=compressed-mapping
   size: 46152
   timestamp: 1745886712803
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
+  sha256: ccd7fe2719899bc766a9a7215f307ef48dc67c227e2006a6a9b5a2c882fadba0
+  md5: 845a20742ceeec7c193a2ed448b3c3b2
+  depends:
+  - python >=3.9
+  - click >=8.0.0,<8.2
+  - typing_extensions >=3.7.4.3
+  - python
+  constrains:
+  - typer 0.15.4.*
+  - rich >=10.11.0
+  - shellingham >=1.3.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typer-slim?source=hash-mapping
+  size: 46236
+  timestamp: 1747243737598
 - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.2-h801b22e_0.conda
   sha256: 79b6b34e90e50e041908939d53053f69285714b0082a0370fba6ab3b38315c8d
   md5: ea164fc4e03f61f7ff3c1166001969af
@@ -8674,6 +9682,18 @@ packages:
   purls: []
   size: 5411
   timestamp: 1745886712803
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
+  sha256: 1d1c779d381667e367345469a5fdb97cc3c175453cb1dcd5ed7cd5e7810c5d38
+  md5: 235d77753dc869548f22292b872bb0ab
+  depends:
+  - typer-slim ==0.15.4 pyhe01879c_0
+  - rich
+  - shellingham
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 5471
+  timestamp: 1747243737598
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.13.2-h0e9735f_0.conda
   sha256: 4865fce0897d3cb0ffc8998219157a8325f6011c136e6fd740a9a6b169419296
   md5: 568ed1300869dca0ba09fb750cda5dbb
@@ -8815,6 +9835,20 @@ packages:
   purls: []
   size: 13646786
   timestamp: 1746049812291
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.7.4-h2f11bb8_0.conda
+  sha256: 2d1f1db85276f370fddf1181c7fd57d7830b8e2aa246883f3b151b044a514e74
+  md5: 76487142e327c1c077f71a6ea252c0d6
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR MIT
+  purls: []
+  size: 13813160
+  timestamp: 1747348722503
 - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.34.1-pyh31011fe_0.conda
   sha256: 12fff3fc66d0214db3b68388f9b543c0f32a74ab69bbc48f926287b76f84b4ba
   md5: b16572c04a572377c4010aae0b16b1b7
@@ -8844,6 +9878,20 @@ packages:
   - pkg:pypi/virtualenv?source=hash-mapping
   size: 3635535
   timestamp: 1743474070226
+- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.31.2-pyhd8ed1ab_0.conda
+  sha256: 763dc774200b2eebdf5437b112834c5455a1dd1c9b605340696950277ff36729
+  md5: c0600c1b374efa7a1ff444befee108ca
+  depends:
+  - distlib >=0.3.7,<1
+  - filelock >=3.12.2,<4
+  - platformdirs >=3.9.1,<5
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/virtualenv?source=hash-mapping
+  size: 4133755
+  timestamp: 1746781585998
 - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.0.5-py312h12e396e_0.conda
   sha256: b97b961190e2f0d4bc4e26d6a58cce847aa353a292f1fec194e9ecca25793101
   md5: 731f9ed51e7198ec91c4b9d7899e881c

--- a/pixi.toml
+++ b/pixi.toml
@@ -87,6 +87,7 @@ docs = { features = ["docs", "pytorch-cpu", "basenji2", "py312"] }
 py310 = { features = ["pytorch-cpu", "py310"] }
 py311 = { features = ["pytorch-cpu", "py311"] }
 py312 = { features = ["pytorch-cpu", "py312"] }
+no-torch = { features = ["py310"] }
 # docs-gpu = { features = ["docs", "pytorch-gpu", "basenji2", "py310"] }
 
 [tasks]

--- a/python/genvarloader/__init__.py
+++ b/python/genvarloader/__init__.py
@@ -5,7 +5,7 @@ from seqpro.bed import read_bedlike, with_length
 
 from ._bigwig import BigWigs
 from ._dataset._impl import ArrayDataset, Dataset, RaggedDataset
-from ._dataset._reconstruct import Reference
+from ._dataset._reference import RefDataset, Reference
 from ._dataset._write import write
 from ._dummy import get_dummy_dataset
 from ._torch import to_nested_tensor
@@ -28,4 +28,5 @@ __all__ = [
     "sites_vcf_to_table",
     "SitesSchema",
     "DatasetWithSites",
+    "RefDataset",
 ]

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -33,35 +33,26 @@ from .._ragged import (
     Ragged,
     RaggedAnnotatedHaps,
     RaggedIntervals,
+    RaggedSeqs,
     _jitter,
     _reverse,
     _reverse_complement,
     is_rag_dtype,
     to_padded,
 )
-from .._torch import TorchDataset, get_dataloader
+from .._torch import TORCH_AVAILABLE, TorchDataset, get_dataloader
 from .._types import DTYPE, AnnotatedHaps, Idx
 from .._utils import _lengths_to_offsets, _normalize_contig_name, idx_like_to_array
 from ._indexing import DatasetIndexer
 from ._rag_variants import RaggedVariants
-from ._reconstruct import (
-    Haps,
-    HapsTracks,
-    RaggedSeqs,
-    Ref,
-    Reference,
-    RefTracks,
-    Tracks,
-)
+from ._reconstruct import Haps, HapsTracks, Ref, RefTracks, Tracks
+from ._reference import Reference
 from ._utils import bed_to_regions, regions_to_bed
 
-try:
+if TORCH_AVAILABLE:
     import torch
     import torch.utils.data as td
 
-    TORCH_AVAILABLE = True
-except ImportError:
-    TORCH_AVAILABLE = False
 
 _py_open = open
 
@@ -1086,7 +1077,7 @@ class Dataset:
 
         return evolve(self, _tracks=ds_tracks, _recon=recon)
 
-    def to_torch_dataset(self) -> "td.Dataset":
+    def to_torch_dataset(self) -> td.Dataset:
         """Convert the dataset to a PyTorch :class:`Dataset <torch.utils.data.Dataset>`. Requires PyTorch to be installed."""
         if self.output_length == "ragged":
             raise ValueError(
@@ -1099,7 +1090,7 @@ class Dataset:
         self,
         batch_size: int = 1,
         shuffle: bool = False,
-        sampler: "td.Sampler" | Iterable | None = None,  # type: ignore
+        sampler: td.Sampler | Iterable | None = None,
         num_workers: int = 0,
         collate_fn: Callable | None = None,
         pin_memory: bool = False,
@@ -1107,12 +1098,12 @@ class Dataset:
         timeout: float = 0,
         worker_init_fn: Callable | None = None,
         multiprocessing_context: Callable | None = None,
-        generator: "torch.Generator" | None = None,  # type: ignore
+        generator: torch.Generator | None = None,
         *,
         prefetch_factor: int | None = None,
         persistent_workers: bool = False,
         pin_memory_device: str = "",
-    ) -> "td.DataLoader":
+    ) -> td.DataLoader:
         """Convert the dataset to a PyTorch :class:`DataLoader <torch.utils.data.DataLoader>`. The parameters are the same as a
         :class:`DataLoader <torch.utils.data.DataLoader>` with a few omissions e.g. :code:`batch_sampler`.
         Requires PyTorch to be installed.

--- a/python/genvarloader/_dataset/_reference.py
+++ b/python/genvarloader/_dataset/_reference.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import (
+    Callable,
+    Generic,
+    Iterable,
+    List,
+    Literal,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
+
+import numba as nb
+import numpy as np
+import polars as pl
+from attrs import define, evolve
+from loguru import logger
+from numpy.typing import NDArray
+from seqpro._ragged import Ragged
+
+from .._fasta import Fasta
+from .._ragged import RaggedSeqs, to_padded
+from .._torch import (
+    TORCH_AVAILABLE,
+    get_dataloader,
+    no_torch_error,
+    tensor_from_maybe_bytes,
+)
+from .._types import Idx
+from .._utils import _lengths_to_offsets, _normalize_contig_name
+from ._utils import bed_to_regions, padded_slice
+
+
+@define
+class Reference:
+    """A reference genome kept in-memory. Typically this is only instantiated to be
+    passed to :meth:`Dataset.open <genvarloader.Dataset.open>` and avoid data duplication.
+
+    .. note::
+        Do not instantiate this class directly. Use :meth:`Reference.from_path` instead.
+    """
+
+    reference: NDArray[np.uint8]
+    contigs: List[str]
+    offsets: NDArray[np.uint64]
+    pad_char: int
+
+    @classmethod
+    def from_path(
+        cls,
+        fasta: Union[str, Path],
+        contigs: List[str] | None = None,
+        in_memory: bool = True,
+    ):
+        """Load a reference genome from a FASTA file.
+
+        Parameters
+        ----------
+        fasta
+            Path to the FASTA file.
+        contigs
+            List of contig names to load. If None, all contigs in the FASTA file are loaded.
+            Can be either UCSC or Ensembl style (i.e. with or without the "chr" prefix) and
+            will be handled appropriately to match the underlying FASTA.
+        in_memory
+            Whether to load the reference genome into memory. If True, the reference genome
+            is loaded into memory. If False, the reference genome is read on-demand from a
+            memory mapped array. This will still be much faster than reading from FASTA but
+            slower than keeping it in memory. This is useful if you need to work with many
+            reference genomes or have very limited RAM.
+        """
+        _fasta = Fasta("ref", fasta, "N")
+
+        if not _fasta._valid_cache():
+            logger.info("Memory-mapping FASTA file for faster access.")
+            _fasta._write_to_cache()
+
+        ref_mmap = np.memmap(_fasta.cache_path, np.uint8, "r")
+        offsets = _lengths_to_offsets(
+            np.array(list(_fasta.contigs.values())), np.uint64
+        )
+        pad_char = ord("N")
+
+        if contigs is None or not in_memory:
+            contigs = list(_fasta.contigs)
+
+        if in_memory:
+            _contigs = [_normalize_contig_name(c, _fasta.contigs) for c in contigs]
+            if unmapped := [
+                source for source, mapped in zip(contigs, _contigs) if mapped is None
+            ]:
+                raise ValueError(
+                    f"Some of the given contig names are not present in reference file: {unmapped}"
+                )
+            contigs = cast(list[str], _contigs)
+
+            reference = np.empty(sum(_fasta.contigs[c] for c in contigs), np.uint8)
+            offset = 0
+            for c in contigs:
+                c_idx = list(_fasta.contigs).index(c)
+                o_s, o_e = offsets[c_idx], offsets[c_idx + 1]
+                reference[offset : offset + o_e - o_s] = ref_mmap[o_s:o_e]
+                offset += o_e - o_s
+            offsets = _lengths_to_offsets(
+                np.array([_fasta.contigs[c] for c in contigs]), np.uint64
+            )
+        else:
+            reference = ref_mmap
+
+        return cls(reference, contigs, offsets, pad_char)
+
+    def fetch(
+        self, contig: str, start: int = 0, end: int | None = None
+    ) -> NDArray[np.bytes_]:
+        c = _normalize_contig_name(contig, self.contigs)
+        if c is None:
+            raise ValueError(f"Contig {contig} not found in reference.")
+        c_idx = self.contigs.index(c)
+        o_s, o_e = self.offsets[c_idx], self.offsets[c_idx + 1]
+
+        if end is None:
+            end = cast(int, self.offsets[c_idx + 1] - self.offsets[c_idx])
+
+        _contig = self.reference[o_s:o_e]
+        if start < 0 or end > len(_contig):
+            seq = padded_slice(_contig, start, end, self.pad_char)
+        else:
+            seq = _contig[start:end]
+
+        return seq.view("S1")
+
+
+T = TypeVar("T", NDArray[np.bytes_], RaggedSeqs)
+
+
+@define
+class RefDataset(Generic[T]):
+    """A reference dataset for pulling out sequences from a reference genome. Also a memory saver
+    when the total length of the regions of interest are greater than the reference genome."""
+
+    reference: Reference
+    regions: pl.DataFrame
+    max_jitter: int
+    jitter: int
+    output_length: Literal["ragged", "variable"] | int
+    deterministic: bool
+    _full_regions: NDArray[np.int32]
+    _rng: np.random.Generator
+
+    def __init__(
+        self: RefDataset[RaggedSeqs],
+        reference: Reference,
+        regions: pl.DataFrame,
+        jitter: int = 0,
+        deterministic: bool = True,
+        output_length: Literal["ragged", "variable"] | int = "ragged",
+        seed: int | np.random.Generator | None = None,
+    ):
+        if regions.height == 0:
+            raise ValueError("Table of regions has a height of zero.")
+
+        if jitter < 0:
+            raise ValueError(f"jitter ({jitter}) must be a non-negative integer.")
+        elif jitter > (
+            min_len := regions.select(
+                (pl.col("chromEnd") - pl.col("chromStart")).min()
+            ).item()
+        ):
+            raise ValueError(
+                f"jitter ({jitter}) must be less than the minimum region length ({min_len})."
+            )
+
+        self.jitter = jitter
+        self.deterministic = deterministic
+        self.reference = reference
+        self.regions = regions
+        self.output_length = output_length
+        self._full_regions = bed_to_regions(regions, reference.contigs)
+        self._rng = np.random.default_rng(seed)
+
+    @property
+    def shape(self) -> tuple[int]:
+        """Shape of the dataset."""
+        return (self.regions.height,)
+
+    def __len__(self) -> int:
+        """Length of the dataset."""
+        return self.regions.height
+
+    @overload
+    def with_len(self, output_length: Literal["ragged"]) -> RefDataset[RaggedSeqs]: ...
+    @overload
+    def with_len(
+        self, output_length: Literal["variable"] | int
+    ) -> RefDataset[NDArray[np.bytes_]]: ...
+    def with_len(
+        self, output_length: Literal["ragged", "variable"] | int
+    ) -> RefDataset:
+        if isinstance(output_length, int):
+            if output_length < 1:
+                raise ValueError(
+                    f"Output length ({output_length}) must be a positive integer."
+                )
+            min_r_len: int = (self._full_regions[:, 2] - self._full_regions[:, 1]).min()
+            max_output_length = min_r_len + 2 * self.max_jitter
+            eff_length = output_length + 2 * self.jitter
+
+            if eff_length > max_output_length:
+                raise ValueError(
+                    f"Jitter-expanded output length (out_len={self.output_length}) + 2 * ({self.jitter=}) = {eff_length} must be less"
+                    f" than or equal to the maximum output length of the dataset ({max_output_length})."
+                    f" The maximum output length is the minimum region length ({min_r_len}) + 2 * (max_jitter={self.max_jitter})."
+                )
+
+        return evolve(self, output_length=output_length)
+
+    def __getitem__(self, idx: Idx) -> T:
+        # (... 4)
+        regions = self._full_regions[idx].copy()
+
+        out_reshape = None
+        squeeze = False
+        if regions.ndim > 2:
+            out_reshape = regions.shape[:-1]
+        elif regions.ndim == 1:
+            squeeze = True
+
+        regions = regions.reshape(-1, 4)
+
+        batch_size = len(regions)
+
+        lengths = regions[:, 2] - regions[:, 1]
+
+        if isinstance(self.output_length, int):
+            # (b)
+            out_lengths = np.full(batch_size, self.output_length, dtype=np.int32)
+        else:
+            out_lengths = lengths
+
+        # (b)
+        if self.deterministic:
+            missing_len_shift = np.full(batch_size, 0)
+        else:
+            missing_len_shift = (lengths - out_lengths).clip(min=0)
+
+        max_shift = missing_len_shift + 2 * self.jitter
+        shifts = self._rng.integers(0, max_shift + 1, dtype=np.int32)
+        regions[:, 1] += shifts - self.jitter
+        regions[:, 2] = regions[:, 1] + out_lengths
+
+        # (b+1)
+        out_offsets = _lengths_to_offsets(out_lengths)
+
+        # ragged (b ~l)
+        ref = get_reference(
+            regions=regions,
+            out_offsets=out_offsets,
+            reference=self.reference.reference,
+            ref_offsets=self.reference.offsets,
+            pad_char=self.reference.pad_char,
+        ).view("S1")
+
+        ref = cast(Ragged[np.bytes_], Ragged.from_offsets(ref, batch_size, out_offsets))
+
+        if squeeze:
+            ref = ref.squeeze()
+        if out_reshape is not None:
+            ref = ref.reshape(out_reshape)
+
+        if self.output_length == "ragged":
+            out = ref
+        elif self.output_length == "variable":
+            out = to_padded(ref, pad_value=self.reference.pad_char)
+        else:
+            out = ref.to_numpy()
+
+        return cast(T, out)
+
+    def to_torch_dataset(self) -> TorchDataset:
+        """Convert the dataset to a PyTorch dataset.
+
+        Returns
+        -------
+        TorchDataset
+            A PyTorch dataset.
+        """
+        if self.output_length == "ragged":
+            raise ValueError(
+                "Cannot convert to PyTorch dataset with ragged output length."
+            )
+        self = cast(RefDataset[NDArray[np.bytes_]], self)
+        return TorchDataset(self)
+
+    def to_dataloader(
+        self,
+        batch_size: int = 1,
+        shuffle: bool = False,
+        sampler: td.Sampler | Iterable | None = None,
+        num_workers: int = 0,
+        collate_fn: Callable | None = None,
+        pin_memory: bool = False,
+        drop_last: bool = False,
+        timeout: float = 0,
+        worker_init_fn: Callable | None = None,
+        multiprocessing_context: Callable | None = None,
+        generator: torch.Generator | None = None,
+        *,
+        prefetch_factor: int | None = None,
+        persistent_workers: bool = False,
+        pin_memory_device: str = "",
+    ) -> "td.DataLoader":
+        """Convert the dataset to a PyTorch :class:`DataLoader <torch.utils.data.DataLoader>`. The parameters are the same as a
+        :class:`DataLoader <torch.utils.data.DataLoader>` with a few omissions e.g. :code:`batch_sampler`.
+        Requires PyTorch to be installed.
+
+        Parameters
+        ----------
+        batch_size
+            How many samples per batch to load.
+        shuffle
+            Set to True to have the data reshuffled at every epoch.
+        sampler
+            Defines the strategy to draw samples from the dataset. Can be any :py:class:`Iterable <typing.Iterable>` with :code:`__len__` implemented. If specified, shuffle must not be specified.
+
+            .. important::
+                Do not provide a :class:`BatchSampler <torch.utils.data.BatchSampler>` here. GVL Datasets use multithreading when indexed with batches of indices to avoid the overhead of multi-processing.
+                To leverage this, GVL will automatically wrap the :code:`sampler` with a :class:`BatchSampler <torch.utils.data.BatchSampler>`
+                so that lists of indices are given to the GVL Dataset instead of one index at a time. See `this post <https://discuss.pytorch.org/t/dataloader-sample-by-slices-from-dataset/113005>`_
+                for more information.
+        num_workers
+            How many subprocesses to use for dataloading. :code:`0` means that the data will be loaded in the main process.
+
+            .. tip::
+                For GenVarLoader, it is generally best to set this to 0 or 1 since almost everything in
+                GVL is multithreaded. However, if you are using a transform that is compute intensive and single threaded, there may
+                be a benefit to setting this > 1.
+        collate_fn
+            Merges a list of samples to form a mini-batch of Tensor(s).
+        pin_memory
+            If :code:`True`, the data loader will copy Tensors into device/CUDA pinned memory before returning them. If your data elements are a custom type, or your :code:`collate_fn` returns a batch that is a custom type, see the example below.
+        drop_last
+            Set to :code:`True` to drop the last incomplete batch, if the dataset size is not divisible by the batch size. If :code:`False` and the size of dataset is not divisible by the batch size, then the last batch will be smaller.
+        timeout
+            If positive, the timeout value for collecting a batch from workers. Should always be non-negative.
+        worker_init_fn
+            If not :code:`None`, this will be called on each worker subprocess with the worker id (an int in :code:`[0, num_workers - 1]`) as input, after seeding and before data loading.
+        multiprocessing_context
+            If :code:`None`, the default multiprocessing context of your operating system will be used.
+        generator
+            If not :code:`None`, this RNG will be used by RandomSampler to generate random indexes and multiprocessing to generate :code:`base_seed` for workers.
+        prefetch_factor
+            Number of batches loaded in advance by each worker. 2 means there will be a total of 2 * num_workers batches prefetched across all workers. (default value depends on the set value for num_workers. If value of num_workers=0 default is None. Otherwise, if value of num_workers > 0 default is 2).
+        persistent_workers
+            If :code:`True`, the data loader will not shut down the worker processes after a dataset has been consumed once. This allows to maintain the workers Dataset instances alive.
+        pin_memory_device
+            The device to :code:`pin_memory` to if :code:`pin_memory` is :code:`True`.
+        """
+        return get_dataloader(
+            dataset=self.to_torch_dataset(),
+            batch_size=batch_size,
+            shuffle=shuffle,
+            sampler=sampler,
+            num_workers=num_workers,
+            collate_fn=collate_fn,
+            pin_memory=pin_memory,
+            drop_last=drop_last,
+            timeout=timeout,
+            worker_init_fn=worker_init_fn,
+            multiprocessing_context=multiprocessing_context,
+            generator=generator,
+            prefetch_factor=prefetch_factor,
+            persistent_workers=persistent_workers,
+            pin_memory_device=pin_memory_device,
+        )
+
+
+@nb.njit(parallel=True, nogil=True, cache=True)
+def get_reference(
+    regions: NDArray[np.int32],
+    out_offsets: NDArray[np.int64],
+    reference: NDArray[np.uint8],
+    ref_offsets: NDArray[np.uint64],
+    pad_char: int,
+) -> NDArray[np.uint8]:
+    out = np.empty(out_offsets[-1], np.uint8)
+    for i in nb.prange(len(regions)):
+        o_s, o_e = out_offsets[i], out_offsets[i + 1]
+        c_idx, start, end = regions[i, :3]
+        c_s = ref_offsets[c_idx]
+        c_e = ref_offsets[c_idx + 1]
+        out[o_s:o_e] = padded_slice(reference[c_s:c_e], start, end, pad_char)
+    return out
+
+
+if TORCH_AVAILABLE:
+    import torch
+    import torch.utils.data as td
+
+    class TorchDataset(td.Dataset):
+        def __init__(self, dataset: RefDataset[NDArray[np.bytes_]]):
+            self.dataset = dataset
+
+        def __len__(self) -> int:
+            return len(self.dataset)
+
+        def __getitem__(self, idx: int | list[int]) -> torch.Tensor:
+            batch = self.dataset[idx]
+            batch = tensor_from_maybe_bytes(batch)
+            return batch
+else:
+    TorchDataset = no_torch_error  # type: ignore

--- a/python/genvarloader/_dataset/_utils.py
+++ b/python/genvarloader/_dataset/_utils.py
@@ -11,7 +11,9 @@ __all__ = []
 
 
 @nb.njit(nogil=True, cache=True)
-def padded_slice(arr: NDArray, start: int, stop: int, pad_val: int):
+def padded_slice(
+    arr: NDArray[DTYPE], start: int, stop: int, pad_val: int
+) -> NDArray[DTYPE]:
     pad_left = -min(0, start)
     pad_right = max(0, stop - len(arr))
 
@@ -73,7 +75,12 @@ def regions_to_bed(regions: NDArray[np.int32], contigs: Sequence[str]) -> pl.Dat
 
 
 def bed_to_regions(bed: pl.DataFrame, contigs: Sequence[str]) -> NDArray[np.int32]:
-    """Convert a BED3+ DataFrame to GVL's internal representation of regions.
+    """Convert a BED3+ DataFrame to GVL's internal representation of regions, a
+    2D array of shape (n_regions, 4) with the following columns:
+    - chrom: Contig index
+    - chromStart: 0-based start position
+    - chromEnd: 0-based exclusive end position
+    - strand: Strand index (1 for +, -1 for -)
 
     Parameters
     ----------

--- a/python/genvarloader/_dummy.py
+++ b/python/genvarloader/_dummy.py
@@ -153,7 +153,7 @@ def get_dummy_dataset():
 
     dummy_recon = HapsTracks(dummy_haps, dummy_tracks)
 
-    dummy_dataset: RaggedDataset[RaggedSeqs, Ragged[np.float32], None, None] = (
+    dummy_dataset: RaggedDataset[RaggedSeqs, Ragged[np.float32]] = (
         RaggedDataset(
             path=Path("dummy"),
             output_length="ragged",

--- a/python/genvarloader/_torch.py
+++ b/python/genvarloader/_torch.py
@@ -1,4 +1,5 @@
-from textwrap import dedent
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -24,9 +25,9 @@ try:
     import torch
     import torch.utils.data as td
 
-    _TORCH_AVAILABLE = True
+    TORCH_AVAILABLE = True
 except ImportError:
-    _TORCH_AVAILABLE = False
+    TORCH_AVAILABLE = False
 
 
 if TYPE_CHECKING:
@@ -36,17 +37,25 @@ if TYPE_CHECKING:
     from ._dataset._impl import Dataset
 
 
-def no_torch_error():
+def no_torch_error(*args, **kwargs):
     raise ImportError(
-        "PyTorch is not available. Please install PyTorch to use this function."
+        "PyTorch is not available. Please install PyTorch to use this function/class."
     )
 
 
+def requires_torch(func_or_class):
+    if TORCH_AVAILABLE:
+        return func_or_class
+    else:
+        return no_torch_error
+
+
+@requires_torch
 def get_dataloader(
-    dataset: "td.Dataset",
+    dataset: td.Dataset,
     batch_size: int = 1,
     shuffle: bool = False,
-    sampler: Optional[Union["td.Sampler", Iterable]] = None,
+    sampler: Optional[Union[td.Sampler, Iterable]] = None,
     num_workers: int = 0,
     collate_fn: Optional[Callable] = None,
     pin_memory: bool = False,
@@ -54,29 +63,30 @@ def get_dataloader(
     timeout: float = 0,
     worker_init_fn: Optional[Callable] = None,
     multiprocessing_context: Optional[Callable] = None,
-    generator: Optional["torch.Generator"] = None,
+    generator: Optional[torch.Generator] = None,
     *,
     prefetch_factor: Optional[int] = None,
     persistent_workers: bool = False,
     pin_memory_device: str = "",
 ):
-    if not _TORCH_AVAILABLE:
+    if not TORCH_AVAILABLE:
         raise ImportError(
             "PyTorch is not available. Please install PyTorch to use this function."
         )
 
     if num_workers > 1:
         logger.warning(
-            dedent(
-                """
-                It is recommended to use num_workers <= 1 with GenVarLoader since it leverages
-                multithreading which has lower overhead than multiprocessing.
-                """
-            )
+            "It is recommended to use num_workers <= 1 with GenVarLoader since it leverages"
+            " multithreading which has lower overhead than multiprocessing."
         )
 
     if sampler is None:
-        sampler = get_sampler(len(dataset), batch_size, shuffle, drop_last)  # type: ignore
+        sampler = get_sampler(
+            len(dataset),  # type: ignore
+            batch_size,
+            shuffle,
+            drop_last,
+        )
 
     return td.DataLoader(
         dataset,
@@ -96,10 +106,11 @@ def get_dataloader(
     )
 
 
+@requires_torch
 def get_sampler(
     ds_len: int, batch_size: int, shuffle: bool = False, drop_last: bool = False
 ):
-    if not _TORCH_AVAILABLE:
+    if not TORCH_AVAILABLE:
         raise ImportError(
             "PyTorch is not available. Please install PyTorch to use this function."
         )
@@ -113,21 +124,22 @@ def get_sampler(
 
 
 @overload
-def _tensor_from_maybe_bytes(array: NDArray) -> "torch.Tensor": ...
+def tensor_from_maybe_bytes(array: NDArray) -> "torch.Tensor": ...
 @overload
-def _tensor_from_maybe_bytes(array: AnnotatedHaps) -> dict[str, "torch.Tensor"]: ...
-def _tensor_from_maybe_bytes(
+def tensor_from_maybe_bytes(array: AnnotatedHaps) -> dict[str, "torch.Tensor"]: ...
+@requires_torch
+def tensor_from_maybe_bytes(
     array: NDArray | AnnotatedHaps,
 ) -> "torch.Tensor" | Dict[str, "torch.Tensor"]:
-    if not _TORCH_AVAILABLE:
+    if not TORCH_AVAILABLE:
         raise ImportError(
             "Could not import PyTorch. Please install PyTorch to use torch features."
         )
     if isinstance(array, AnnotatedHaps):
         return {
-            "haps": _tensor_from_maybe_bytes(array.haps),
-            "var_idxs": _tensor_from_maybe_bytes(array.var_idxs),
-            "ref_coords": _tensor_from_maybe_bytes(array.ref_coords),
+            "haps": tensor_from_maybe_bytes(array.haps),
+            "var_idxs": tensor_from_maybe_bytes(array.var_idxs),
+            "ref_coords": tensor_from_maybe_bytes(array.ref_coords),
         }
     else:
         if array.dtype.type == np.bytes_:
@@ -135,6 +147,7 @@ def _tensor_from_maybe_bytes(
         return torch.from_numpy(array)
 
 
+@requires_torch
 def to_nested_tensor(rag: Ragged | ak.Array) -> "torch.Tensor":
     """Convert a Ragged array to a PyTorch `nested tensor <https://pytorch.org/docs/stable/nested.html>`_. Will cast byte arrays
     (dtype "S1") to uint8.
@@ -144,7 +157,7 @@ def to_nested_tensor(rag: Ragged | ak.Array) -> "torch.Tensor":
     rag
         Ragged array to convert.
     """
-    if not _TORCH_AVAILABLE:
+    if not TORCH_AVAILABLE:
         raise ImportError(
             "Could not import PyTorch. Please install PyTorch to use torch features."
         )
@@ -163,11 +176,11 @@ def to_nested_tensor(rag: Ragged | ak.Array) -> "torch.Tensor":
     return nt
 
 
-if _TORCH_AVAILABLE:
+if TORCH_AVAILABLE:
 
     class TorchDataset(td.Dataset):
-        def __init__(self, dataset: "Dataset"):
-            if not _TORCH_AVAILABLE:
+        def __init__(self, dataset: Dataset):
+            if not TORCH_AVAILABLE:
                 raise ImportError(
                     "Could not import PyTorch. Please install PyTorch to use torch features."
                 )
@@ -178,13 +191,13 @@ if _TORCH_AVAILABLE:
 
         def __getitem__(
             self, idx: int | list[int]
-        ) -> Union["torch.Tensor", Tuple["torch.Tensor", ...], Any]:
+        ) -> torch.Tensor | Tuple[torch.Tensor, ...] | Any:
             r_idx, s_idx = np.unravel_index(idx, self.dataset.shape)
             batch = self.dataset[r_idx, s_idx]
             if isinstance(batch, np.ndarray):
-                batch = _tensor_from_maybe_bytes(batch)
+                batch = tensor_from_maybe_bytes(batch)
             elif isinstance(batch, tuple):
-                batch = tuple(_tensor_from_maybe_bytes(b) for b in batch)
+                batch = tuple(tensor_from_maybe_bytes(b) for b in batch)
             return batch
 
     class StratifiedSampler(td.Sampler):

--- a/python/genvarloader/_variants/_sitesonly.py
+++ b/python/genvarloader/_variants/_sitesonly.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Generic, Sequence, Tuple, overload
+from typing import Generic, Sequence, Tuple, overload
 
 import numba as nb
 import numpy as np
@@ -12,7 +12,7 @@ from genoray import VCF
 from genoray._utils import ContigNormalizer
 from numpy.typing import NDArray
 
-from .._dataset._impl import ArrayDataset, MaybeTRK
+from .._dataset._impl import SEQ, ArrayDataset, MaybeTRK
 from .._dataset._indexing import DatasetIndexer
 from .._types import AnnotatedHaps, Idx
 from ._records import RaggedAlleles
@@ -73,7 +73,7 @@ def _sites_table_to_bedlike(sites: pl.DataFrame) -> pl.DataFrame:
 
 
 class DatasetWithSites(Generic[MaybeTRK]):
-    dataset: ArrayDataset[AnnotatedHaps, MaybeTRK, None, None]
+    dataset: ArrayDataset[AnnotatedHaps, MaybeTRK]
     """Dataset of haplotypes and potentially tracks."""
     sites: pl.DataFrame
     """Table of variant site information."""
@@ -100,7 +100,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
 
     def __init__(
         self,
-        dataset: ArrayDataset[Any, MaybeTRK, Any, Any],
+        dataset: ArrayDataset[SEQ, MaybeTRK],
         sites: pl.DataFrame,
         max_variants_per_region: int = 1,
     ):
@@ -185,11 +185,8 @@ class DatasetWithSites(Generic[MaybeTRK]):
             strict=False,
         ).drop("End_site")
 
-        _dataset = (
-            dataset.with_seqs("annotated")
-            .with_indices(False)
-            .with_transform(None)
-            .with_settings(deterministic=True, jitter=0)
+        _dataset = dataset.with_seqs("annotated").with_settings(
+            deterministic=True, jitter=0
         )
 
         self.sites = sites

--- a/python/genvarloader/_variants/_sitesonly.py
+++ b/python/genvarloader/_variants/_sitesonly.py
@@ -105,7 +105,8 @@ class DatasetWithSites(Generic[MaybeTRK]):
         max_variants_per_region: int = 1,
     ):
         """Dataset with variant sites, used to apply site-only variants e.g. from ClinVar to a Dataset of haplotypes.
-        Currently only supports bi-allelic SNPs.
+        Currently only supports bi-allelic SNPs. Takes the intersection of the dataset regions and the sites, and
+        applies the site-only variants to the Dataset's haplotypes.
 
         Accessed just like a Dataset, but where the rows are combinations of dataset regions and sites. Will return
         :class:`AnnotatedHaps` with variants applied and flags indicating whether the variant was applied, deleted, or existed.
@@ -124,6 +125,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
         Examples
         --------
         .. code-block:: python
+
             import genvarloader as gvl
             sites = gvl.sites_vcf_to_table("path/to/variants.vcf")
 

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Literal
 
 import genvarloader as gvl
 import numpy as np
@@ -6,6 +7,7 @@ from pytest_cases import fixture, parametrize_with_cases
 
 data_dir = Path(__file__).resolve().parents[1] / "data"
 ref = data_dir / "fasta" / "hg38.fa.bgz"
+
 
 def ds_phased():
     return gvl.Dataset.open(data_dir / "phased_dataset.vcf.gvl", ref)
@@ -27,20 +29,11 @@ def seqs_annot():
     return "annotated"
 
 
-def bool_false():
-    return False
-
-
-def bool_true():
-    return True
-
-
 @fixture(scope="session")
 @parametrize_with_cases("ds", prefix="ds_", cases=".")
 @parametrize_with_cases("seq_type", prefix="seqs_", cases=".")
-@parametrize_with_cases("return_indices", prefix="bool_", cases=".")
-def dataset(ds: gvl.Dataset, seq_type, return_indices: bool):
-    return ds.with_seqs(seq_type).with_indices(return_indices)
+def dataset(ds: gvl.Dataset, seq_type: Literal["reference", "haplotypes", "annotated"]):
+    return ds.with_seqs(seq_type)
 
 
 def idx_scalar():

--- a/tests/dataset/test_ds_haps.py
+++ b/tests/dataset/test_ds_haps.py
@@ -32,7 +32,7 @@ def dataset_svar():
 
 
 @parametrize_with_cases("dataset", cases=".", prefix="dataset_")
-def test_ds_haps(dataset: gvl.RaggedDataset[RaggedSeqs, None, None, None]):
+def test_ds_haps(dataset: gvl.RaggedDataset[RaggedSeqs, None]):
     for region, sample in product(range(dataset.n_regions), dataset.samples):
         c, s, e, rc = dataset.regions.select(
             "chrom", "chromStart", "chromEnd", "strand"

--- a/tests/dataset/test_ds_haps.py
+++ b/tests/dataset/test_ds_haps.py
@@ -5,7 +5,7 @@ import genvarloader as gvl
 import numpy as np
 import pysam
 import seqpro as sp
-from genvarloader._dataset._reconstruct import RaggedSeqs
+from genvarloader._ragged import RaggedSeqs
 from pytest_cases import parametrize_with_cases
 
 data_dir = Path(__file__).resolve().parents[1] / "data"

--- a/tests/test_ref_ds.py
+++ b/tests/test_ref_ds.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import genvarloader as gvl
+import numpy as np
+import polars as pl
+import pytest
+import seqpro as sp
+from pytest_cases import fixture, parametrize_with_cases
+
+DDIR = Path(__file__).parent / "data"
+REF = DDIR / "fasta" / "hg38.fa.bgz"
+
+
+@fixture
+def reference():
+    return gvl.Reference.from_path(REF, in_memory=False)
+
+
+@pytest.mark.xfail(strict=True, raises=ValueError)
+def case_no_regions():
+    regions = pl.DataFrame(
+        schema={"chrom": pl.Utf8, "chromStart": pl.Int32, "chromEnd": pl.Int32}
+    )
+    desired = gvl.Ragged.empty(0, np.bytes_)
+    return regions, desired
+
+
+def case_ragged_regions():
+    """Three regions with different lengths."""
+    regions = pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1"],
+            "chromStart": [0, 100],
+            "chromEnd": [100, 150],
+        }
+    )
+    data = sp.cast_seqs(b"N" * 150)
+    lengths = (regions["chromEnd"] - regions["chromStart"]).to_numpy().astype(np.uint32)
+    desired = gvl.Ragged.from_lengths(data, lengths)
+    return regions, desired
+
+
+@parametrize_with_cases("regions, desired", cases=".")
+def test_getitem(
+    reference: gvl.Reference, regions: pl.DataFrame, desired: gvl.Ragged[np.bytes_]
+):
+    ds = gvl.RefDataset(reference, regions, seed=0)
+    actual = ds[:]
+
+    np.testing.assert_equal(actual.data, desired.data)
+    np.testing.assert_equal(actual.lengths, desired.lengths)

--- a/tests/tracks/test_annot_tracks.py
+++ b/tests/tracks/test_annot_tracks.py
@@ -16,7 +16,7 @@ def dataset():
 
 
 def test_annot_tracks(
-    dataset: gvl.RaggedDataset[RaggedAnnotatedHaps, None, None, None],
+    dataset: gvl.RaggedDataset[RaggedAnnotatedHaps, None],
 ):
     annots = dataset.regions.with_columns(
         chromEnd=pl.col("chromStart") + 1, score=pl.lit(1.0)


### PR DESCRIPTION
- **fix: contig offset mapping for in-memory reference and incrementing offset when writing cache**
- **feat!: add RefDataset to work with one or more reference genomes. Also change internal indexing to never materialize a full dataset index, dramatically reducing memory usage to support datasets with 1M+ regions. BREAKING CHANGE: move returning indices and transforms to torch API, since these features are generally unnecessary for non-dataloading contexts.**
