### PR TITLE
Handle reference fetch bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.14.5 (Unreleased)
+
+### Fix
+
+- handle out-of-bounds reference fetches
+- validate coordinates in `get_reference`
+- check slice lengths in `padded_slice`
+
 ## 0.14.4 (2025-05-12)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genvarloader"
-version = "0.14.4"
+version = "0.14.5"
 description = "Pipeline for efficient genomic data processing."
 authors = [
     { name = "David Laub", email = "dlaub@ucsd.edu" },

--- a/python/genvarloader/_dataset/_reference.py
+++ b/python/genvarloader/_dataset/_reference.py
@@ -126,7 +126,11 @@ class Reference:
             end = cast(int, self.offsets[c_idx + 1] - self.offsets[c_idx])
 
         _contig = self.reference[o_s:o_e]
-        if start < 0 or end > len(_contig):
+        contig_len = len(_contig)
+
+        if start >= contig_len or end <= 0:
+            seq = np.full(end - start, self.pad_char, np.uint8)
+        elif start < 0 or end > contig_len:
             seq = padded_slice(_contig, start, end, self.pad_char)
         else:
             seq = _contig[start:end]
@@ -464,6 +468,9 @@ def get_reference(
         c_idx, start, end = regions[i, :3]
         c_s = ref_offsets[c_idx]
         c_e = ref_offsets[c_idx + 1]
+
+        assert end > start
+
         out[o_s:o_e] = padded_slice(reference[c_s:c_e], start, end, pad_char)
     return out
 

--- a/python/genvarloader/_dataset/_utils.py
+++ b/python/genvarloader/_dataset/_utils.py
@@ -14,17 +14,32 @@ __all__ = []
 def padded_slice(
     arr: NDArray[DTYPE], start: int, stop: int, pad_val: int
 ) -> NDArray[DTYPE]:
+    """Return ``arr[start:stop]`` padded to ``stop - start``.
+
+    This function handles queries that lie completely outside ``arr`` and
+    validates that ``stop`` is greater than ``start``.
+    """
+
+    assert stop > start
+
+    length = stop - start
+
+    if start >= len(arr) or stop <= 0:
+        out = np.empty(length, arr.dtype)
+        out[:] = pad_val
+        return out
+
     pad_left = -min(0, start)
     pad_right = max(0, stop - len(arr))
 
-    out = np.empty(stop - start, arr.dtype)
+    out = np.empty(length, arr.dtype)
 
     if pad_left == 0 and pad_right == 0:
         out[:] = arr[start:stop]
         return out
 
     if pad_left > 0 and pad_right > 0:
-        out_stop = len(out) - pad_right
+        out_stop = length - pad_right
         out[:pad_left] = pad_val
         out[pad_left:out_stop] = arr[:]
         out[out_stop:] = pad_val
@@ -32,7 +47,7 @@ def padded_slice(
         out[:pad_left] = pad_val
         out[pad_left:] = arr[:stop]
     elif pad_right > 0:
-        out_stop = len(out) - pad_right
+        out_stop = length - pad_right
         out[:out_stop] = arr[start:]
         out[out_stop:] = pad_val
 

--- a/tests/test_reference_oob.py
+++ b/tests/test_reference_oob.py
@@ -1,0 +1,29 @@
+import numpy as np
+from genvarloader._dataset._reference import Reference, get_reference
+
+
+def make_ref():
+    seq = np.frombuffer(b"ACGT", np.uint8)
+    offsets = np.array([0, len(seq)], np.uint64)
+    return Reference(seq, ["chr1"], offsets, ord("N"))
+
+
+def test_fetch_out_of_bounds_right():
+    ref = make_ref()
+    seq = ref.fetch("chr1", 6, 10)
+    np.testing.assert_equal(seq, np.frombuffer(b"NNNN", "S1"))
+
+
+def test_fetch_entirely_left():
+    ref = make_ref()
+    seq = ref.fetch("chr1", -5, -1)
+    np.testing.assert_equal(seq, np.frombuffer(b"NNNN", "S1"))
+
+
+def test_get_reference_out_of_bounds():
+    ref = make_ref()
+    regions = np.array([[0, 6, 10, 1]], np.int32)
+    out_offsets = np.array([0, 4], np.int64)
+    out = get_reference(regions, out_offsets, ref.reference, ref.offsets, ref.pad_char)
+    np.testing.assert_equal(out.view("S1"), np.frombuffer(b"NNNN", "S1"))
+


### PR DESCRIPTION
## Summary
- validate slice bounds in `padded_slice`
- pad sequences when `Reference.fetch` is queried outside the contig
- assert valid coordinates in `get_reference`
- add regression tests for out-of-bound fetches
- document bug fix in changelog and bump version

## Testing
- `ruff check tests/test_reference_oob.py python/genvarloader/_dataset/_utils.py python/genvarloader/_dataset/_reference.py`
- `pytest -q` *(fails: command not found)*
- `cargo test --no-run` *(fails: network access required)*