### PR TITLE
Fix bigwig docstring shape description

### DIFF
--- a/python/genvarloader/_bigwig.py
+++ b/python/genvarloader/_bigwig.py
@@ -107,7 +107,7 @@ class BigWigs(Reader):
 
         Returns
         -------
-            Shape: (samples length). Data corresponding to the given genomic coordinates and samples.
+            Shape = (samples, length). Data corresponding to the given genomic coordinates and samples.
         """
         _contig = _normalize_contig_name(contig, self.contigs)
         if _contig is None:


### PR DESCRIPTION
## Summary
- fix the `read` method's output shape description in `_bigwig.py`

## Testing
- `pytest -q` *(fails: command not found)*