### PR TITLE
Support multiple site-only variants

### DIFF
--- a/tests/variants/test_sites.py
+++ b/tests/variants/test_sites.py
@@ -1,4 +1,5 @@
 from typing import cast
+import pytest
 
 import genvarloader as gvl
 import numpy as np
@@ -16,7 +17,7 @@ def test_sites():
         .rename({"chrom": "CHROM"})
         .drop("chromStart", "chromEnd")
     )
-    dss = gvl.DatasetWithSites(ds, sites)
+    dss = gvl.DatasetWithSites(ds, sites, max_variants_per_region=2)
     alt = cast(str, sites.item(0, "ALT")).encode("ascii")
     for s in range(dss.n_samples):
         ann_haps = dss.dataset[0, s].squeeze()
@@ -27,26 +28,40 @@ def test_sites():
         # SNP or insertion
         if coords[0] == coords[1] - 1 or coords[0] == coords[1]:
             # (1 l), (1)
-            site_haps, flags = dss[0, s]  # first site
+            site_haps, flags = dss[0, s]
             # (l)
             site_haps = site_haps.haps.squeeze()
             # ()
             flags = flags.squeeze()
             if haps[0] == alt:
                 np.testing.assert_array_equal(site_haps, haps)
-                assert flags == EXISTED
-            elif haps[0] != alt:
+                assert flags[0] == EXISTED
+            else:
                 desired = haps.copy()
                 desired[0] = alt
                 np.testing.assert_array_equal(site_haps, desired)
-                assert flags == APPLIED
+                assert flags[0] == APPLIED
         # deletion
         elif coords[0] < coords[1] - 1:
             # (1 l), (1)
-            site_haps, flags = dss[1, s]  # second site
+            site_haps, flags = dss[0, s]
             # (l)
             site_haps = site_haps.haps.squeeze()
             # ()
             flags = flags.squeeze()
             np.testing.assert_array_equal(site_haps, haps)
-            assert flags == DELETED
+            assert flags[1] == DELETED
+
+
+def test_sites_max_variants_error():
+    ds = gvl.get_dummy_dataset().with_len(4).subset_to(regions=0).with_tracks(None)
+    sites = (
+        pl.concat([ds.regions, ds.regions])
+        .with_columns(
+            POS=pl.col("chromStart") + pl.arange(1, 3), REF=pl.lit("A"), ALT=pl.lit("T")
+        )
+        .rename({"chrom": "CHROM"})
+        .drop("chromStart", "chromEnd")
+    )
+    with pytest.raises(ValueError):
+        gvl.DatasetWithSites(ds, sites, max_variants_per_region=1)


### PR DESCRIPTION
## Summary
- allow DatasetWithSites to handle multiple variants per region
- update reconstruction logic for grouped sites
- extend tests for multi-variant regions

## Testing
- `cargo test` *(fails: failed to download crates)*
- `pytest -q` *(fails: command not found)*