### PR TITLE
Fix jittering

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3650,7 +3650,7 @@ packages:
 - pypi: ./
   name: genvarloader
   version: 0.14.4
-  sha256: 9c333b04a79746f172f4d28822dcc03c23bc08314e58ec0b50b0dd6faaa0f568
+  sha256: f248e804ca03c7ee44c0a991df82c805c6de278dc9dda768b310c6779f3b5e67
   requires_dist:
   - numba>=0.58.1
   - loguru

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,22 @@ issues = "https://github.com/mcvickerlab/GenVarLoader/issues"
 [tool.ruff]
 lint.ignore = ["E501"]
 
-[tool.pyright]
+[tool.basedpyright]
 include = ["python/", "tests/"]
 exclude = ['**/data/']
+enableTypeIgnoreComments = true
+reportImplicitStringConcatenation = false
+reportMissingTypeArgument = false
+reportIgnoreCommentWithoutRule = false
+reportUnknownParameterType = false
+reportUnknownVariableType = false
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportExplicitAny = false
+reportAny = false
+reportPrivateUsage = false
+reportMissingTypeStubs = false
+reportImplicitOverride = false
 
 [tool.maturin]
 python-source = "python"

--- a/python/genvarloader/_dummy.py
+++ b/python/genvarloader/_dummy.py
@@ -166,7 +166,6 @@ def get_dummy_dataset():
             transform=None,
             _full_bed=dummy_bed,
             _full_regions=dummy_regions,
-            _jittered_regions=dummy_regions.copy(),
             _idxer=dummy_idxer,
             _seqs=dummy_haps,
             _tracks=dummy_tracks,

--- a/tests/dataset/test_jitter.py
+++ b/tests/dataset/test_jitter.py
@@ -1,0 +1,47 @@
+from copy import deepcopy
+from pathlib import Path
+
+import genvarloader as gvl
+import numpy as np
+from einops import repeat
+from genvarloader._dataset._reconstruct import Haps
+from pytest_cases import parametrize_with_cases
+
+DDIR = Path(__file__).parent.parent
+REF = DDIR / "data" / "fasta" / "hg38.fa.bgz"
+
+
+def ds_vcf():
+    return gvl.Dataset.open(DDIR / "data" / "phased_dataset.vcf.gvl", REF)
+
+
+def ds_pgen():
+    return gvl.Dataset.open(DDIR / "data" / "phased_dataset.pgen.gvl", REF)
+
+
+def ds_svar():
+    return gvl.Dataset.open(DDIR / "data" / "phased_dataset.svar.gvl", REF)
+
+
+@parametrize_with_cases("dataset", cases=".", prefix="ds_")
+def test_jitter(dataset: gvl.RaggedDataset):
+    ds = (
+        dataset.with_settings(jitter=dataset.max_jitter, rc_neg=False)
+        .with_seqs("annotated")
+        .with_tracks(None)
+    )
+    assert isinstance(ds._seqs, Haps)
+    no_var_regions = ds._seqs.genotypes.lengths.sum((1, 2)) == 0
+    rng = deepcopy(ds._rng)
+    jitter = rng.integers(
+        -ds.jitter, ds.jitter + 1, size=(no_var_regions.sum(), ds.n_samples)
+    )
+
+    desired_starts = ds._full_regions[no_var_regions, 1, None] + jitter
+    desired_starts = repeat(desired_starts, "b s -> b s p", p=ds._seqs.genotypes.ploidy)
+
+    no_var_regions = (ds.regions["chrom"] == "chr1").to_numpy()
+    annhaps = ds[no_var_regions]
+    # (b s p ~l) -> (b s p)
+    actual_starts = annhaps.ref_coords.to_awkward()[..., 0].to_numpy()  # type: ignore
+    np.testing.assert_equal(actual_starts, desired_starts)

--- a/tests/test_ref_ds.py
+++ b/tests/test_ref_ds.py
@@ -5,6 +5,7 @@ import numpy as np
 import polars as pl
 import pytest
 import seqpro as sp
+from genvarloader._dataset._utils import padded_slice
 from pytest_cases import fixture, parametrize_with_cases
 
 DDIR = Path(__file__).parent / "data"
@@ -49,3 +50,49 @@ def test_getitem(
 
     np.testing.assert_equal(actual.data, desired.data)
     np.testing.assert_equal(actual.lengths, desired.lengths)
+
+
+def padded_slice_no_pad():
+    arr = np.array([1, 2, 3, 4, 5])
+    start = 0
+    stop = 5
+    pad_val = 0
+    desired = np.array([1, 2, 3, 4, 5])
+    return arr, start, stop, pad_val, desired
+
+
+def padded_slice_pad_left():
+    arr = np.array([1, 2, 3, 4, 5])
+    start = -1
+    stop = 5
+    pad_val = 0
+    desired = np.array([0, 1, 2, 3, 4, 5])
+    return arr, start, stop, pad_val, desired
+
+
+def padded_slice_pad_right():
+    arr = np.array([1, 2, 3, 4, 5])
+    start = 0
+    stop = 6
+    pad_val = 0
+    desired = np.array([1, 2, 3, 4, 5, 0])
+    return arr, start, stop, pad_val, desired
+
+
+def padded_slice_pad_both():
+    arr = np.array([1, 2, 3, 4, 5])
+    start = -1
+    stop = 6
+    pad_val = 0
+    desired = np.array([0, 1, 2, 3, 4, 5, 0])
+    return arr, start, stop, pad_val, desired
+
+
+@parametrize_with_cases(
+    "arr, start, stop, pad_val, desired", cases=".", prefix="padded_slice_"
+)
+def test_padded_slice(
+    arr: np.ndarray, start: int, stop: int, pad_val: int, desired: np.ndarray
+):
+    actual = padded_slice(arr, start, stop, pad_val)
+    np.testing.assert_equal(actual, desired)


### PR DESCRIPTION
Old implementation of jittering was quite broken and untested. This PR fixes the issues and adds tests. As a bonus,
we fold jittering into data (re)construction and thus jitter "for free" when loading data so enabling jittering should have no effect on data throughput.