### PR TITLE
Fixing a type issue when a dataset with annotation tracks is used as a DatasetWithSites

### DIFF
--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -1231,6 +1231,8 @@ class Dataset:
         if unlist:
             out = out[0]
 
+        if isinstance(out, list):
+            out = tuple(out)
         return out
 
     @overload

--- a/python/genvarloader/_variants/_sitesonly.py
+++ b/python/genvarloader/_variants/_sitesonly.py
@@ -224,7 +224,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
 
         ds_rows = self._row_map[r_idx, 0]
         out = self.dataset[ds_rows, s_idx]
-        if isinstance(out, tuple):
+        if isinstance(out, tuple) or isinstance(out, list):
             haps, tracks = out
         else:
             haps = out
@@ -262,7 +262,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
             haps = haps.reshape((*out_reshape, ploidy, length))
             flags = flags.reshape(*out_reshape, ploidy)
 
-        if isinstance(out, tuple):
+        if isinstance(out, tuple) or isinstance(out, list):
             return (
                 haps,
                 flags,

--- a/python/genvarloader/_variants/_sitesonly.py
+++ b/python/genvarloader/_variants/_sitesonly.py
@@ -224,7 +224,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
 
         ds_rows = self._row_map[r_idx, 0]
         out = self.dataset[ds_rows, s_idx]
-        if isinstance(out, tuple) or isinstance(out, list):
+        if isinstance(out, tuple):
             haps, tracks = out
         else:
             haps = out
@@ -262,7 +262,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
             haps = haps.reshape((*out_reshape, ploidy, length))
             flags = flags.reshape(*out_reshape, ploidy)
 
-        if isinstance(out, tuple) or isinstance(out, list):
+        if isinstance(out, tuple):
             return (
                 haps,
                 flags,


### PR DESCRIPTION
A dataset with annotation tracks created using ds.write_annot_tracks() returns a list not a tuple but DatasetWithSites assumes that datasets returning tracks will return a tuple and throws an error if the ds returns a list. This means that using a DatasetWithSites on a dataset with annotations from a bed doesn't work.

This pull request addresses the issue by adjusting DatasetWithSites to handle tuples and lists the same way. Example usage that this allows previously would have thrown an error when example = site_ds[0] was run, now runs fine.

```python
ds_path = "./demo.gvl"
ds = gvl.Dataset.open(ds_path, reference).with_len(10001)

track_path = './annotation.bed'
# Read the bed file
track_bed = pd.read_csv(track_path, sep='\t', 
                     names=['chrom', 'Start', 'End', 'Name', 'score', 'Strand'])
track_bed = track_bed.sort_values(by='Start').reset_index().drop(columns='index')
track_pos_bed = track_bed[track_bed['Strand'] == '+']
track_neg_bed = track_bed[track_bed['Strand'] == '-']
track_pos_bed = pl.from_pandas(track_pos_bed)
track_neg_bed = pl.from_pandas(track_neg_bed)

annot_ds = ds.write_annot_tracks({'TrackPos':track_pos_bed,
                       'TrackNeg':track_neg_bed,}).with_tracks(['TrackPos','TrackNeg'])
sites = gvl.sites_vcf_to_table(
    "./snps.vcf"
)
site_ds = gvl.DatasetWithSites(annot_ds, sites)
example = site_ds[0]
```
