### PR TITLE
DatasetWithSites wasn't accepting 'variable' length datasets

### DIFF
--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -1231,6 +1231,8 @@ class Dataset:
         if unlist:
             out = out[0]
 
+        if isinstance(out, list):
+            out = tuple(out)
         return out
 
     @overload

--- a/python/genvarloader/_variants/_sitesonly.py
+++ b/python/genvarloader/_variants/_sitesonly.py
@@ -224,7 +224,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
 
         ds_rows = self._row_map[r_idx, 0]
         out = self.dataset[ds_rows, s_idx]
-        if isinstance(out, tuple):
+        if isinstance(out, tuple) or isinstance(out, list):
             haps, tracks = out
         else:
             haps = out
@@ -262,7 +262,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
             haps = haps.reshape((*out_reshape, ploidy, length))
             flags = flags.reshape(*out_reshape, ploidy)
 
-        if isinstance(out, tuple):
+        if isinstance(out, tuple) or isinstance(out, list):
             return (
                 haps,
                 flags,

--- a/python/genvarloader/_variants/_sitesonly.py
+++ b/python/genvarloader/_variants/_sitesonly.py
@@ -224,7 +224,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
 
         ds_rows = self._row_map[r_idx, 0]
         out = self.dataset[ds_rows, s_idx]
-        if isinstance(out, tuple) or isinstance(out, list):
+        if isinstance(out, tuple):
             haps, tracks = out
         else:
             haps = out
@@ -262,7 +262,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
             haps = haps.reshape((*out_reshape, ploidy, length))
             flags = flags.reshape(*out_reshape, ploidy)
 
-        if isinstance(out, tuple) or isinstance(out, list):
+        if isinstance(out, tuple):
             return (
                 haps,
                 flags,

--- a/python/genvarloader/_variants/_sitesonly.py
+++ b/python/genvarloader/_variants/_sitesonly.py
@@ -143,7 +143,7 @@ class DatasetWithSites(Generic[MaybeTRK]):
         if max_variants_per_region > 1:
             raise NotImplementedError("max_variants_per_region > 1 not yet supported")
 
-        if not isinstance(dataset, ArrayDataset):
+        if not isinstance(dataset, ArrayDataset) and dataset.output_length != "variable":
             raise ValueError(
                 'Dataset output_length must either be "variable" or a fixed length integer.'
             )


### PR DESCRIPTION
DatasetWithSites was saying it 'Dataset output_length must either be "variable" or a fixed length integer.' but was only checking if output_length was a fixed length integer. It threw an error when output length was variable. This updates the check so that variable length datasets are also accepted.