### PR TITLE
WT and reference alleles were always the same.

### DIFF
--- a/python/genvarloader/_variants/_sitesonly.py
+++ b/python/genvarloader/_variants/_sitesonly.py
@@ -248,10 +248,10 @@ class DatasetWithSites(Generic[MaybeTRK]):
         mut_haps, v_idxs, ref_coords, flags = apply_site_only_variants(
             haps=wt_haps.haps.view(np.uint8).copy(),  # (b p l)
             v_idxs=wt_haps.var_idxs.copy(),  # (b p l)
-            ref_coords=wt_haps.ref_coords.copy(),  # (b p l)
-            site_starts=starts.copy(),
-            alt_alleles=alts.data.view(np.uint8).copy(),
-            alt_offsets=alts.offsets.copy(),
+            ref_coords=wt_haps.ref_coords,  # (b p l)
+            site_starts=starts,
+            alt_alleles=alts.data.view(np.uint8),
+            alt_offsets=alts.offsets,
         )
 
         mut_haps = AnnotatedHaps(

--- a/python/genvarloader/_variants/_sitesonly.py
+++ b/python/genvarloader/_variants/_sitesonly.py
@@ -246,12 +246,12 @@ class DatasetWithSites(Generic[MaybeTRK]):
         wt_haps = wt_haps.reshape((-1, ploidy, length))
         # flags: (b p)
         mut_haps, v_idxs, ref_coords, flags = apply_site_only_variants(
-            haps=wt_haps.haps.view(np.uint8),  # (b p l)
-            v_idxs=wt_haps.var_idxs,  # (b p l)
-            ref_coords=wt_haps.ref_coords,  # (b p l)
-            site_starts=starts,
-            alt_alleles=alts.data.view(np.uint8),
-            alt_offsets=alts.offsets,
+            haps=wt_haps.haps.view(np.uint8).copy(),  # (b p l)
+            v_idxs=wt_haps.var_idxs.copy(),  # (b p l)
+            ref_coords=wt_haps.ref_coords.copy(),  # (b p l)
+            site_starts=starts.copy(),
+            alt_alleles=alts.data.view(np.uint8).copy(),
+            alt_offsets=alts.offsets.copy(),
         )
 
         mut_haps = AnnotatedHaps(


### PR DESCRIPTION
At least when I tested this on top of my changes to allow variable datasets to be DatasetsWithSites I found that regardless of the flag value Ref and Var Haps were always the same. This was because the apply_site_only_variants was getting passed a pointer to the WT haps so changes were being applied to Ref haps. The returned Var haps were just a new pointer to the same object that had been mutated under the hood. Copying everything before passing it in resolves the issues