### PR TITLE
fix: Let GVL recognize bgz-compressed VCFs

### DIFF
--- a/python/genvarloader/_variants/_utils.py
+++ b/python/genvarloader/_variants/_utils.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-VCF_SUFFIX = re.compile(r"\.[vb]cf(\.gz)?$")
+VCF_SUFFIX = re.compile(r"\.[vb]cf(\.(gz|bgz))?$")
 
 
 def path_is_vcf(path: str | Path) -> bool:

--- a/tests/variants/test_variant_utils.py
+++ b/tests/variants/test_variant_utils.py
@@ -18,4 +18,3 @@ def test_path_is_vcf():
     assert path_is_vcf(Path("test.bcf.gz"))
     assert path_is_vcf(Path("test.vcf.bgz"))
     assert path_is_vcf(Path("test.bcf.bgz"))
-

--- a/tests/variants/test_variant_utils.py
+++ b/tests/variants/test_variant_utils.py
@@ -16,3 +16,6 @@ def test_path_is_vcf():
     assert path_is_vcf(Path("test.vcf.gz"))
     assert path_is_vcf(Path("test.bcf"))
     assert path_is_vcf(Path("test.bcf.gz"))
+    assert path_is_vcf(Path("test.vcf.bgz"))
+    assert path_is_vcf(Path("test.bcf.bgz"))
+


### PR DESCRIPTION
Follow up to discussion #103 