### PR TITLE
test(1kg): add bcftools-consensus parity tests across BCF/PGEN/SVAR backends

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.68.0
+          pixi-version: v0.68.1
           cache: true
           environments: ${{ matrix.environment }}
           locked: false

--- a/docs/superpowers/plans/2026-05-12-1kg-bcftools-parity.md
+++ b/docs/superpowers/plans/2026-05-12-1kg-bcftools-parity.md
@@ -1,0 +1,798 @@
+# 1KG bcftools-consensus Parity Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a slow-marked pytest that validates `Dataset[region, sample]` haplotypes against `bcftools consensus` on the real 1000 Genomes chr21/chr22 subset (5 samples) hosted at Zenodo record 20132907, exercising the BCF, PGEN, and SVAR backends.
+
+**Architecture:** A new data-prep script (`tests/data/generate_1kg_ground_truth.py`) pooches the BCF/CSI from Zenodo, derives PGEN (via plink2) and SVAR (via genoray), writes three `.gvl` datasets, picks 100 variant-centered 10 kb regions across chr21/chr22, and emits one bcftools-consensus FASTA per (region, sample, haplotype). A new test (`tests/dataset/test_ds_haps_1kg.py`) mirrors the existing `test_ds_haps.py` and asserts byte-equality across all backends.
+
+**Tech Stack:** Python, pixi, pooch, bcftools, samtools, plink2, genoray (VCF/PGEN/SparseVar), genvarloader, pytest, pytest_cases, pysam, polars, seqpro.
+
+**Reference materials:**
+- Spec: `docs/superpowers/specs/2026-05-12-1kg-bcftools-parity-design.md`
+- Existing analog data-prep: `tests/data/generate_ground_truth.py`
+- Existing analog test: `tests/dataset/test_ds_haps.py`
+
+**TDD note:** This feature is a data-pipeline + integration test. Pure unit TDD does not fit the data-prep script (each step calls an external tool whose output we want to keep). The plan uses incremental smoke checks (run the script with `--stage` flags or partial commands) and the final parity test as the integration-level "failing test → passing test" cycle. The test file is written before the data exists, and we verify it fails for the right reason (missing files) before generating data and watching it pass.
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+| --- | --- | --- |
+| `tests/data/generate_1kg_ground_truth.py` | Create | One-shot data-prep CLI: pooch fetch → normalize → PGEN → SVAR → region BED → 3× gvl.write → bcftools consensus loop |
+| `tests/dataset/test_ds_haps_1kg.py` | Create | Parity test (3 backends × 100 regions × 5 samples × 2 haps) |
+| `pixi.toml` | Modify | Add `gen-1kg` task |
+| `docs/superpowers/specs/2026-05-12-1kg-bcftools-parity-design.md` | Already exists | Spec |
+
+---
+
+### Task 1: Scaffold the data-prep script and pixi task
+
+**Files:**
+- Create: `tests/data/generate_1kg_ground_truth.py`
+- Modify: `pixi.toml`
+
+- [ ] **Step 1: Create the script skeleton**
+
+Create `tests/data/generate_1kg_ground_truth.py`:
+
+```python
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from time import perf_counter
+
+import typer
+from loguru import logger
+
+WDIR = Path(__file__).resolve().parent
+ONE_KG_DIR = WDIR / "1kg"
+CONS_DIR = WDIR / "1kg_consensus"
+REF = WDIR / "fasta" / "hg38.fa.bgz"
+
+N_REGIONS = 100
+REGION_LEN = 10_000
+SEED = 0
+
+ZENODO_BCF_URL = "https://zenodo.org/records/20132907/files/1kg.chr21_chr22.5samples.bcf"
+ZENODO_CSI_URL = "https://zenodo.org/records/20132907/files/1kg.chr21_chr22.5samples.bcf.csi"
+# Fill these in on first successful run; the script prints observed hashes
+# and exits when they are None.
+ZENODO_BCF_HASH: str | None = None
+ZENODO_CSI_HASH: str | None = None
+
+
+def run_shell(cmd: list[str], input: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
+    try:
+        return subprocess.run(cmd, check=True, capture_output=True, input=input)
+    except subprocess.CalledProcessError as e:
+        print("Command:", " ".join(e.cmd))
+        print("Stdout:", e.stdout.decode(errors="replace"))
+        print("Stderr:", e.stderr.decode(errors="replace"))
+        raise
+
+
+def main() -> None:
+    """Generate 1000 Genomes ground-truth haplotypes via bcftools consensus."""
+    log_file = WDIR / "generate_1kg_ground_truth.log"
+    if log_file.exists():
+        log_file.unlink()
+    _ = logger.add(log_file, level="DEBUG")
+
+    t0 = perf_counter()
+
+    if not REF.exists():
+        raise SystemExit(
+            f"Reference {REF} not found. Run `pixi run -e dev gen` first to "
+            "fetch hg38."
+        )
+
+    ONE_KG_DIR.mkdir(0o777, parents=True, exist_ok=True)
+    if CONS_DIR.exists():
+        shutil.rmtree(CONS_DIR)
+    CONS_DIR.mkdir(0o777, parents=True, exist_ok=True)
+
+    logger.info("Pipeline scaffold OK")
+    logger.info(f"Finished in {perf_counter() - t0:.1f}s")
+
+
+if __name__ == "__main__":
+    typer.run(main)
+```
+
+- [ ] **Step 2: Add the pixi task**
+
+Edit `pixi.toml`. Find the `[tasks]` section (the same one that defines `gen` and `test`) and add a single new line after the `test` task line:
+
+```toml
+gen-1kg = { cmd = "python tests/data/generate_1kg_ground_truth.py", depends-on = ["gen"] }
+```
+
+Do not modify `gen` or `test`.
+
+- [ ] **Step 3: Smoke-run the scaffold**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: exits 0; logs "Pipeline scaffold OK"; creates `tests/data/1kg/` and `tests/data/1kg_consensus/`. (Assumes `gen` has already been run at least once so `hg38.fa.bgz` exists; if not the script exits with the explicit message above — that's also acceptable for this step.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add tests/data/generate_1kg_ground_truth.py pixi.toml
+rtk git commit -m "test(1kg): scaffold ground-truth generation script"
+```
+
+---
+
+### Task 2: Pooch the BCF + CSI from Zenodo
+
+**Files:**
+- Modify: `tests/data/generate_1kg_ground_truth.py`
+
+- [ ] **Step 1: Add a `fetch_zenodo` helper that prints the observed hash on first run**
+
+Insert below `run_shell`:
+
+```python
+def fetch_zenodo(url: str, known_hash: str | None, fname: str) -> Path:
+    import pooch
+
+    if known_hash is None:
+        # First run: download once without verification, log the observed hash,
+        # then fail loudly so the developer can paste it into the script.
+        path = Path(
+            pooch.retrieve(url, known_hash=None, fname=fname, path=ONE_KG_DIR)
+        )
+        import hashlib
+
+        h = hashlib.sha256(path.read_bytes()).hexdigest()
+        logger.error(
+            f"known_hash for {fname} is None. Observed sha256: {h}. "
+            "Paste this into ZENODO_BCF_HASH / ZENODO_CSI_HASH and re-run."
+        )
+        raise SystemExit(2)
+
+    return Path(
+        pooch.retrieve(url, known_hash=known_hash, fname=fname, path=ONE_KG_DIR)
+    )
+```
+
+- [ ] **Step 2: Call it from `main`**
+
+Inside `main`, after the `CONS_DIR.mkdir(...)` line, before the final `logger.info("Pipeline scaffold OK")`, add:
+
+```python
+    bcf = fetch_zenodo(ZENODO_BCF_URL, ZENODO_BCF_HASH, "source.bcf")
+    csi = fetch_zenodo(ZENODO_CSI_URL, ZENODO_CSI_HASH, "source.bcf.csi")
+    logger.info(f"Fetched: {bcf} ({bcf.stat().st_size} bytes)")
+    logger.info(f"Fetched: {csi} ({csi.stat().st_size} bytes)")
+```
+
+Remove the `logger.info("Pipeline scaffold OK")` line.
+
+- [ ] **Step 3: First run to capture the hash**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: exits with code 2 and an error log line containing the observed sha256 for `source.bcf`. Copy that hash and paste it as the value of `ZENODO_BCF_HASH` in the script (replacing `None`).
+
+- [ ] **Step 4: Second run to capture the CSI hash**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: same as above but for `source.bcf.csi`. Paste into `ZENODO_CSI_HASH`.
+
+- [ ] **Step 5: Verify both hashes are accepted**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: exits 0, logs both file sizes. No re-download (pooch sees the file and verifies).
+
+- [ ] **Step 6: Verify the URL exists if the script reports a 404**
+
+If pooch raises an HTTP error in Step 3, the URL pattern is wrong. The Zenodo record page is `https://zenodo.org/records/20132907`; open it in a browser (or `curl -sI`) and copy the exact filenames into `ZENODO_BCF_URL` and `ZENODO_CSI_URL`. Re-run Step 3.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add tests/data/generate_1kg_ground_truth.py
+rtk git commit -m "test(1kg): pooch BCF + CSI from Zenodo"
+```
+
+---
+
+### Task 3: Normalize the BCF (left-align, atomize, split multiallelics)
+
+**Files:**
+- Modify: `tests/data/generate_1kg_ground_truth.py`
+
+- [ ] **Step 1: Add a `normalize_bcf` helper**
+
+Insert below `fetch_zenodo`:
+
+```python
+def normalize_bcf(source_bcf: Path) -> Path:
+    """Left-align, atomize, and split multiallelics. Returns indexed filtered.bcf."""
+    filtered = ONE_KG_DIR / "filtered.bcf"
+
+    # Step A: left-align
+    result = run_shell(
+        [
+            "bcftools",
+            "norm",
+            "-f",
+            str(REF),
+            "-O",
+            "u",
+            str(source_bcf),
+        ]
+    )
+    logger.info("bcftools norm (left-align) done")
+
+    # Step B: atomize + split multiallelics; emit as bgzipped BCF
+    result = run_shell(
+        [
+            "bcftools",
+            "norm",
+            "-a",
+            "--atom-overlaps",
+            ".",
+            "-f",
+            str(REF),
+            "-m",
+            "-",
+            "-O",
+            "b",
+            "-o",
+            str(filtered),
+        ],
+        input=result.stdout,
+    )
+    logger.info("bcftools norm (atomize + split) done")
+
+    # Index
+    _ = run_shell(["bcftools", "index", "-f", str(filtered)])
+    return filtered
+```
+
+- [ ] **Step 2: Wire it into `main`**
+
+Inside `main`, after the `logger.info(f"Fetched: {csi} ...")` line, add:
+
+```python
+    filtered = normalize_bcf(bcf)
+    logger.info(f"Normalized BCF at {filtered}")
+```
+
+- [ ] **Step 3: Run and verify**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: exits 0; `tests/data/1kg/filtered.bcf` and `filtered.bcf.csi` exist; log shows variant counts in the bcftools stderr.
+
+Sanity check the output:
+```bash
+bcftools view -h tests/data/1kg/filtered.bcf | tail -3
+bcftools view tests/data/1kg/filtered.bcf | head -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add tests/data/generate_1kg_ground_truth.py
+rtk git commit -m "test(1kg): normalize BCF with bcftools norm"
+```
+
+---
+
+### Task 4: Generate PGEN via plink2
+
+**Files:**
+- Modify: `tests/data/generate_1kg_ground_truth.py`
+
+- [ ] **Step 1: Add a `make_pgen` helper**
+
+Insert below `normalize_bcf`:
+
+```python
+def make_pgen(filtered_bcf: Path) -> Path:
+    out_prefix = ONE_KG_DIR / "filtered"
+    _ = run_shell(
+        [
+            "plink2",
+            "--bcf",
+            str(filtered_bcf),
+            "--make-pgen",
+            "--vcf-half-call",
+            "r",
+            "--out",
+            str(out_prefix),
+        ]
+    )
+    return out_prefix.with_suffix(".pgen")
+```
+
+- [ ] **Step 2: Wire it into `main`**
+
+After the `logger.info(f"Normalized BCF ...")` line, add:
+
+```python
+    pgen = make_pgen(filtered)
+    logger.info(f"PGEN at {pgen}")
+```
+
+- [ ] **Step 3: Run and verify**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: exits 0; `tests/data/1kg/filtered.pgen`, `.pvar`, `.psam` exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add tests/data/generate_1kg_ground_truth.py
+rtk git commit -m "test(1kg): generate PGEN via plink2"
+```
+
+---
+
+### Task 5: Generate SparseVar via genoray
+
+**Files:**
+- Modify: `tests/data/generate_1kg_ground_truth.py`
+
+- [ ] **Step 1: Add a `make_svar` helper**
+
+Insert below `make_pgen`:
+
+```python
+def make_svar(filtered_bcf: Path) -> Path:
+    from genoray import VCF, SparseVar
+
+    out = ONE_KG_DIR / "filtered.svar"
+    if out.exists():
+        shutil.rmtree(out)
+    SparseVar.from_vcf(out, VCF(filtered_bcf), "50mb")
+    SparseVar(out).cache_afs()
+    return out
+```
+
+- [ ] **Step 2: Wire it into `main`**
+
+After the `logger.info(f"PGEN at ...")` line, add:
+
+```python
+    svar = make_svar(filtered)
+    logger.info(f"SVAR at {svar}")
+```
+
+- [ ] **Step 3: Run and verify**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: exits 0; `tests/data/1kg/filtered.svar/` exists and contains genoray's standard sparse-variant directory layout.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add tests/data/generate_1kg_ground_truth.py
+rtk git commit -m "test(1kg): generate SparseVar via genoray"
+```
+
+---
+
+### Task 6: Pick 100 variant-centered 10 kb regions across chr21/chr22
+
+**Files:**
+- Modify: `tests/data/generate_1kg_ground_truth.py`
+
+- [ ] **Step 1: Add a `pick_regions` helper**
+
+Insert below `make_svar`:
+
+```python
+def pick_regions(filtered_bcf: Path) -> Path:
+    import numpy as np
+    import polars as pl
+
+    bed_path = ONE_KG_DIR / "regions.bed"
+
+    # Pull (chrom, pos) for chr21/chr22 only via bcftools query.
+    proc = run_shell(
+        [
+            "bcftools",
+            "query",
+            "-f",
+            "%CHROM\t%POS\n",
+            "-r",
+            "chr21,chr22",
+            str(filtered_bcf),
+        ]
+    )
+    raw = proc.stdout.decode().strip()
+    if not raw:
+        # The Zenodo dataset uses GRCh38 contig names without the "chr" prefix
+        # on some 1KG releases. Fall back to bare contig names.
+        proc = run_shell(
+            [
+                "bcftools",
+                "query",
+                "-f",
+                "%CHROM\t%POS\n",
+                "-r",
+                "21,22",
+                str(filtered_bcf),
+            ]
+        )
+        raw = proc.stdout.decode().strip()
+
+    if not raw:
+        raise SystemExit(
+            "No variants found on chr21/chr22 (tried 'chr21,chr22' and '21,22'). "
+            "Inspect filtered.bcf with `bcftools view -h` to find the contig "
+            "naming convention used."
+        )
+
+    df = pl.read_csv(
+        raw.encode(),
+        separator="\t",
+        has_header=False,
+        new_columns=["chrom", "pos"],
+        schema_overrides={"chrom": pl.Utf8, "pos": pl.Int64},
+    )
+
+    # Keep variants with at least REGION_LEN/2 of flanking space on each side.
+    half = REGION_LEN // 2
+    df = df.filter(pl.col("pos") > half)
+
+    rng = np.random.default_rng(SEED)
+    idx = rng.choice(df.height, size=N_REGIONS, replace=False)
+    chosen = df[idx.tolist()]
+
+    starts = chosen["pos"].to_numpy() - half
+    ends = starts + REGION_LEN
+    strand = rng.choice(["+", "-"], size=N_REGIONS, replace=True)
+
+    out = pl.DataFrame(
+        {
+            "chrom": chosen["chrom"].to_numpy(),
+            "start": starts,
+            "end": ends,
+            "name": ["."] * N_REGIONS,
+            "score": ["."] * N_REGIONS,
+            "strand": strand,
+        }
+    )
+    out.write_csv(bed_path, include_header=False, separator="\t")
+    logger.info(f"Wrote {N_REGIONS} regions to {bed_path}")
+    return bed_path
+```
+
+- [ ] **Step 2: Wire it into `main`**
+
+After `logger.info(f"SVAR at ...")`, add:
+
+```python
+    bed_path = pick_regions(filtered)
+```
+
+- [ ] **Step 3: Run and verify**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: exits 0; `tests/data/1kg/regions.bed` has 100 lines; each line has 6 tab-separated fields; `end - start == 10000` for every row. Sanity check:
+
+```bash
+wc -l tests/data/1kg/regions.bed
+awk '$3-$2 != 10000' tests/data/1kg/regions.bed | head
+```
+
+The second command should produce no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add tests/data/generate_1kg_ground_truth.py
+rtk git commit -m "test(1kg): pick 100 variant-centered 10kb regions"
+```
+
+---
+
+### Task 7: Write the three .gvl datasets (BCF, PGEN, SVAR)
+
+**Files:**
+- Modify: `tests/data/generate_1kg_ground_truth.py`
+
+- [ ] **Step 1: Add a `write_datasets` helper**
+
+Insert below `pick_regions`:
+
+```python
+def write_datasets(filtered_bcf: Path, pgen: Path, svar: Path, bed_path: Path) -> None:
+    import genvarloader as gvl
+    from genoray import PGEN, VCF, SparseVar
+
+    bcf_ds = ONE_KG_DIR / "phased_1kg.bcf.gvl"
+    pgen_ds = ONE_KG_DIR / "phased_1kg.pgen.gvl"
+    svar_ds = ONE_KG_DIR / "phased_1kg.svar.gvl"
+
+    for d in (bcf_ds, pgen_ds, svar_ds):
+        if d.exists():
+            shutil.rmtree(d)
+
+    vcf_reader = VCF(filtered_bcf)
+    if not vcf_reader._valid_index():
+        vcf_reader._write_gvi_index()
+    _ = vcf_reader._load_index()
+    gvl.write(path=bcf_ds, bed=bed_path, variants=vcf_reader)
+    logger.info(f"Wrote {bcf_ds}")
+
+    gvl.write(path=pgen_ds, bed=bed_path, variants=PGEN(pgen))
+    logger.info(f"Wrote {pgen_ds}")
+
+    gvl.write(path=svar_ds, bed=bed_path, variants=SparseVar(svar))
+    logger.info(f"Wrote {svar_ds}")
+```
+
+- [ ] **Step 2: Wire it into `main`**
+
+After the `bed_path = pick_regions(filtered)` line, add:
+
+```python
+    write_datasets(filtered, pgen, svar, bed_path)
+```
+
+- [ ] **Step 3: Run and verify**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: exits 0; three directories exist under `tests/data/1kg/`:
+- `phased_1kg.bcf.gvl/`
+- `phased_1kg.pgen.gvl/`
+- `phased_1kg.svar.gvl/`
+
+Each should have `metadata.json`, `input_regions.arrow`, and a `genotypes/` subdirectory.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add tests/data/generate_1kg_ground_truth.py
+rtk git commit -m "test(1kg): write BCF/PGEN/SVAR-backed gvl datasets"
+```
+
+---
+
+### Task 8: Generate per-(region, sample, hap) bcftools-consensus FASTAs
+
+**Files:**
+- Modify: `tests/data/generate_1kg_ground_truth.py`
+
+- [ ] **Step 1: Add a `generate_consensus_fastas` helper**
+
+Insert below `write_datasets`:
+
+```python
+def generate_consensus_fastas(filtered_bcf: Path, bed_path: Path) -> None:
+    import polars as pl
+    from tqdm.auto import tqdm
+
+    # Read samples from the BCF header.
+    proc = run_shell(["bcftools", "query", "-l", str(filtered_bcf)])
+    samples = proc.stdout.decode().strip().splitlines()
+    logger.info(f"Samples: {samples}")
+
+    bed = pl.read_csv(
+        bed_path,
+        separator="\t",
+        has_header=False,
+        new_columns=["chrom", "start", "end", "name", "score", "strand"],
+        schema_overrides={"chrom": pl.Utf8},
+    ).with_row_index()
+
+    total = bed.height * len(samples) * 2
+    pbar = tqdm(total=total, desc="bcftools consensus")
+    for row_nr, chrom, start, end in bed.select(
+        "index", "chrom", "start", "end"
+    ).iter_rows():
+        subseq = run_shell(
+            ["samtools", "faidx", str(REF), f"{chrom}:{start + 1}-{end}"]
+        )
+        for sample in samples:
+            for hap in (0, 1):
+                out_fa = CONS_DIR / f"1kg_{sample}_nr{row_nr}_h{hap}.fa"
+                _ = run_shell(
+                    [
+                        "bcftools",
+                        "consensus",
+                        "-H",
+                        str(hap + 1),
+                        "-s",
+                        sample,
+                        "-o",
+                        str(out_fa),
+                        str(filtered_bcf),
+                    ],
+                    input=subseq.stdout,
+                )
+                _ = run_shell(["samtools", "faidx", str(out_fa)])
+                _ = pbar.update()
+    pbar.close()
+```
+
+- [ ] **Step 2: Wire it into `main`**
+
+After `write_datasets(filtered, pgen, svar, bed_path)`, add:
+
+```python
+    generate_consensus_fastas(filtered, bed_path)
+```
+
+- [ ] **Step 3: Run end-to-end and verify**
+
+Run: `pixi run -e dev gen-1kg`
+
+Expected: exits 0; `tests/data/1kg_consensus/` contains exactly `100 × 5 × 2 = 1000` `.fa` files (plus `.fai` indexes, so 2000 entries):
+
+```bash
+ls tests/data/1kg_consensus/*.fa | wc -l
+```
+
+Expected: `1000`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add tests/data/generate_1kg_ground_truth.py
+rtk git commit -m "test(1kg): emit bcftools consensus FASTAs for all (region, sample, hap)"
+```
+
+---
+
+### Task 9: Write the parametrized parity test
+
+**Files:**
+- Create: `tests/dataset/test_ds_haps_1kg.py`
+
+- [ ] **Step 1: Write the test file**
+
+Create `tests/dataset/test_ds_haps_1kg.py`:
+
+```python
+from itertools import product
+from pathlib import Path
+
+import genvarloader as gvl
+import numpy as np
+import pysam
+import pytest
+import seqpro as sp
+from genvarloader._ragged import RaggedSeqs
+from pytest_cases import parametrize_with_cases
+
+data_dir = Path(__file__).resolve().parents[1] / "data"
+ref = data_dir / "fasta" / "hg38.fa.bgz"
+cons_dir = data_dir / "1kg_consensus"
+
+pytestmark = pytest.mark.slow
+
+
+def dataset_bcf():
+    return (
+        gvl.Dataset.open(data_dir / "1kg" / "phased_1kg.bcf.gvl", ref, rc_neg=False)
+        .with_len("ragged")
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+
+
+def dataset_pgen():
+    return (
+        gvl.Dataset.open(data_dir / "1kg" / "phased_1kg.pgen.gvl", ref, rc_neg=False)
+        .with_len("ragged")
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+
+
+def dataset_svar():
+    return (
+        gvl.Dataset.open(data_dir / "1kg" / "phased_1kg.svar.gvl", ref, rc_neg=False)
+        .with_len("ragged")
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+
+
+@parametrize_with_cases("dataset", cases=".", prefix="dataset_")
+def test_ds_haps_1kg(dataset: gvl.RaggedDataset[RaggedSeqs, None]):
+    for region, sample in product(range(dataset.n_regions), dataset.samples):
+        c, s, e, _ = dataset.regions.select(
+            "chrom", "chromStart", "chromEnd", "strand"
+        ).row(region)
+        haps = dataset[region, sample]
+        for h in range(2):
+            actual = sp.cast_seqs(haps[h])
+            fpath = f"1kg_{sample}_nr{region}_h{h}.fa"
+            with pysam.FastaFile(str(cons_dir / fpath)) as f:
+                desired = sp.cast_seqs(f.fetch(f.references[0]).upper())
+            np.testing.assert_equal(
+                actual,
+                desired,
+                f"region: {region}, sample: {sample}, hap: {h}, "
+                f"coords: {c}:{s + 1}-{e}",
+            )
+```
+
+- [ ] **Step 2: Verify the test is discovered and fails on a missing-data sentinel before generation**
+
+Skip this step if Tasks 1–8 already produced the data (the test will pass instead). Otherwise:
+
+Run: `pixi run -e dev pytest tests/dataset/test_ds_haps_1kg.py -m slow -v --collect-only`
+
+Expected: pytest lists three test parametrizations (`test_ds_haps_1kg[dataset_bcf]`, `[dataset_pgen]`, `[dataset_svar]`).
+
+- [ ] **Step 3: Run the test**
+
+Run: `pixi run -e dev pytest tests/dataset/test_ds_haps_1kg.py -m slow -v`
+
+Expected: all three parametrizations PASS.
+
+If any fail with mismatches, that's the bug the test is designed to surface — diagnose using the per-assertion failure message (`region: N, sample: S, hap: H, coords: ...`).
+
+- [ ] **Step 4: Verify the default test run is unaffected**
+
+Run: `pixi run -e dev pytest tests/dataset/test_ds_haps_1kg.py -v`
+
+Expected: tests are skipped/deselected (without `-m slow`, the slow marker excludes them per project convention).
+
+If they are *not* skipped, check `pyproject.toml` / `pytest.ini` for the marker config — the project's existing convention is that `slow` tests are excluded by default but this is worth confirming.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add tests/dataset/test_ds_haps_1kg.py
+rtk git commit -m "test(1kg): add bcftools-consensus parity test across BCF/PGEN/SVAR backends"
+```
+
+---
+
+### Task 10: Final verification
+
+**Files:** None.
+
+- [ ] **Step 1: Full default test suite still passes**
+
+Run: `pixi run -e dev pytest tests -q`
+
+Expected: same pass count as before this branch; the new test does not run because it is slow-marked.
+
+- [ ] **Step 2: Slow suite passes**
+
+Run: `pixi run -e dev pytest tests -m slow -v`
+
+Expected: the three new parametrizations PASS along with any other slow tests in the project. (If other slow tests fail and are unrelated to this work, note them and continue — this task is not responsible for pre-existing slow-test failures.)
+
+- [ ] **Step 3: Lint**
+
+Run: `pixi run -e dev ruff check python/ tests/`
+
+Expected: clean (or only pre-existing warnings).
+
+- [ ] **Step 4: Confirm spec coverage**
+
+Open the spec at `docs/superpowers/specs/2026-05-12-1kg-bcftools-parity-design.md` and skim each section. Confirm:
+- Data layout matches what was generated (Task 1–8).
+- Test structure matches Task 9.
+- Pixi task added per spec (Task 1).
+
+No commit unless changes were needed; if so:
+
+```bash
+rtk git add -A
+rtk git commit -m "test(1kg): final tidy after verification"
+```

--- a/docs/superpowers/specs/2026-05-12-1kg-bcftools-parity-design.md
+++ b/docs/superpowers/specs/2026-05-12-1kg-bcftools-parity-design.md
@@ -1,0 +1,221 @@
+# 1KG bcftools-consensus Parity Tests — Design
+
+**Date:** 2026-05-12
+**Status:** Draft
+
+## Motivation
+
+The existing haplotype reconstruction tests (`tests/dataset/test_ds_haps.py`)
+verify parity with `bcftools consensus` using a small, hand-authored synthetic
+VCF (`tests/data/source.vcf`, 20 bp regions). This catches gross bugs but does
+not exercise:
+
+- Dense, realistic variant distributions
+- Long-range haplotypes (>20 bp) where many indels compound
+- Real allele frequencies / heterozygosity patterns from 1000 Genomes
+
+This spec adds a complementary real-data parity test using the chr21/chr22
+subset of 1000 Genomes data for 5 individuals, hosted at
+[Zenodo record 20132907](https://zenodo.org/records/20132907). The test
+re-uses the exact same parity model as the synthetic test: for each
+(region, sample, haplotype), `Dataset[region, sample][h]` must byte-equal
+the output of `bcftools consensus -H {h+1} -s {sample}` on the same
+normalized BCF.
+
+## Scope
+
+In scope:
+- New data-preparation script that downloads the BCF, derives PGEN and SVAR,
+  picks regions, writes three `.gvl` datasets, and emits per-call FASTAs.
+- New test that asserts byte parity for all three backends.
+- A pixi task to run the data prep on demand.
+
+Out of scope:
+- Track / interval parity (this is a haplotype-only test).
+- Jitter, RC packing, splice — covered by other tests; this test uses
+  `rc_neg=False` and no jitter so the comparison is a strict byte equality.
+- Adding the generated `.gvl` directories or FASTAs to the repo. Data prep is
+  invoked manually (or via the new pixi task) and writes under
+  `tests/data/1kg/`.
+
+## Files
+
+- `tests/data/generate_1kg_ground_truth.py` — new data-prep script.
+- `tests/dataset/test_ds_haps_1kg.py` — new parity test.
+- `pixi.toml` — add a `gen-1kg` task. `test` is **not** modified; the new
+  test is `@pytest.mark.slow` so it is excluded by the default
+  pytest invocation.
+
+## Data Layout
+
+```
+tests/data/
+├── fasta/hg38.fa.bgz          # reused from existing generate_ground_truth.py
+├── 1kg/
+│   ├── source.bcf             # pooch-downloaded from Zenodo
+│   ├── source.bcf.csi         # pooch-downloaded from Zenodo
+│   ├── filtered.bcf           # normalized (left-align + atomize + split)
+│   ├── filtered.bcf.csi
+│   ├── filtered.pgen/.pvar/.psam
+│   ├── filtered.svar/         # genoray SparseVar dir
+│   ├── regions.bed            # 100 random regions
+│   ├── phased_1kg.bcf.gvl/    # gvl.write output from BCF reader
+│   ├── phased_1kg.pgen.gvl/
+│   └── phased_1kg.svar.gvl/
+└── 1kg_consensus/
+    └── 1kg_{sample}_nr{row}_h{hap}.fa
+```
+
+## Data-Prep Pipeline
+
+`tests/data/generate_1kg_ground_truth.py`. Implementation closely mirrors
+`generate_ground_truth.py`; only the steps that differ are spelled out in
+detail.
+
+1. **Fetch BCF and CSI** via `pooch.retrieve` with a `known_hash`. The
+   Zenodo record exposes both files as separate downloads; each is fetched
+   independently to `tests/data/1kg/`. Hashes are filled in on first run
+   (script logs the observed hash and exits if `known_hash` is the
+   placeholder `None`, instructing the developer to update the file).
+2. **Reference.** Assert `tests/data/fasta/hg38.fa.bgz` and its `.fai` /
+   `.csi` exist. If not, instruct the user to run `pixi run -e dev gen`
+   first. This avoids duplicating the 3 GB fetch.
+3. **Normalize** with `bcftools norm -f <ref>` then
+   `bcftools norm -a --atom-overlaps . -f <ref> -m -` (left-align, atomize,
+   split multiallelics). Output bgzipped + indexed as `filtered.bcf`.
+4. **PGEN**: `plink2 --bcf filtered.bcf --make-pgen --vcf-half-call r --out filtered`.
+5. **SVAR**: `SparseVar.from_vcf(out, VCF(filtered.bcf), "50mb")` then
+   `cache_afs()`.
+6. **Pick regions** (seed = 0, N = 100, length = 10_000):
+   - Read variant positions from the normalized BCF (chrom + pos only;
+     polars from `bcftools view`).
+   - Restrict to chr21 and chr22.
+   - Uniformly sample 100 variants without replacement; for each, the
+     region is `[pos - 5000, pos + 5000)` clipped to a reasonable margin
+     (skip variants within 5 kb of contig start). With 10 kb windows on
+     these chroms, each region will span many variants across the 5
+     samples, exercising compound indel reconstruction.
+   - Assign a random strand `+/-` (carried but unused — `rc_neg=False`).
+   - Write `regions.bed` with columns
+     `chrom, start, end, name=".", score=".", strand`.
+7. **Write three datasets** via `gvl.write`:
+   - `VCF(filtered.bcf)` → `phased_1kg.bcf.gvl`
+   - `PGEN(filtered.pgen)` → `phased_1kg.pgen.gvl`
+   - `SparseVar(filtered.svar)` → `phased_1kg.svar.gvl`
+
+   All three with `max_jitter=0` (default) to keep the comparison strict.
+8. **Generate ground-truth FASTAs.** For each `(row_nr, chrom, start, end)`
+   in the BED, for each of the 5 samples, for `hap in (0, 1)`:
+
+   ```
+   samtools faidx <ref> {chrom}:{start+1}-{end} \
+     | bcftools consensus -H {hap+1} -s {sample} -o <out.fa> filtered.bcf
+   samtools faidx <out.fa>
+   ```
+
+   Output written to `tests/data/1kg_consensus/1kg_{sample}_nr{row}_h{hap}.fa`.
+   Progress bar with total `n_regions * n_samples * 2` (= 1000).
+
+The script is idempotent: re-running cleans the `1kg_consensus/`,
+`phased_1kg.*.gvl/`, and `filtered.*` outputs before regenerating. The
+pooched BCF/CSI are cached by pooch and not re-downloaded.
+
+## Test
+
+`tests/dataset/test_ds_haps_1kg.py`. Structure mirrors `test_ds_haps.py`
+exactly:
+
+```python
+import pytest
+from itertools import product
+from pathlib import Path
+
+import genvarloader as gvl
+import numpy as np
+import pysam
+import seqpro as sp
+from genvarloader._ragged import RaggedSeqs
+from pytest_cases import parametrize_with_cases
+
+data_dir = Path(__file__).resolve().parents[1] / "data"
+ref = data_dir / "fasta" / "hg38.fa.bgz"
+cons_dir = data_dir / "1kg_consensus"
+
+pytestmark = pytest.mark.slow
+
+
+def dataset_bcf():
+    return (
+        gvl.Dataset.open(data_dir / "1kg" / "phased_1kg.bcf.gvl", ref, rc_neg=False)
+        .with_len("ragged")
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+
+# ... pgen, svar identical pattern ...
+
+
+@parametrize_with_cases("dataset", cases=".", prefix="dataset_")
+def test_ds_haps_1kg(dataset: gvl.RaggedDataset[RaggedSeqs, None]):
+    for region, sample in product(range(dataset.n_regions), dataset.samples):
+        c, s, e, rc = dataset.regions.select(
+            "chrom", "chromStart", "chromEnd", "strand"
+        ).row(region)
+        haps = dataset[region, sample]
+        for h in range(2):
+            actual = sp.cast_seqs(haps[h])
+            fpath = f"1kg_{sample}_nr{region}_h{h}.fa"
+            with pysam.FastaFile(str(cons_dir / fpath)) as f:
+                desired = sp.cast_seqs(f.fetch(f.references[0]).upper())
+            np.testing.assert_equal(
+                actual,
+                desired,
+                f"region: {region}, sample: {sample}, hap: {h}, "
+                f"coords: {c}:{s + 1}-{e}",
+            )
+```
+
+Each parametrize case is one backend. Total assertions: 3 backends × 100
+regions × 5 samples × 2 haps = 3000.
+
+## Pixi Tasks
+
+Add a single new task; do not touch `test` or `gen`.
+
+```toml
+[tasks]
+gen-1kg = { cmd = "python tests/data/generate_1kg_ground_truth.py", depends-on = ["gen"] }
+```
+
+`depends-on = ["gen"]` ensures the reference FASTA exists. The new test is
+discovered by `pytest tests` but skipped unless `-m slow` is passed, which
+is the project's existing convention.
+
+## Failure Modes and Edge Cases
+
+- **`known_hash` not yet populated.** First run prints the observed sha256
+  of each downloaded file and exits with a clear message. Subsequent runs
+  validate.
+- **Reference missing.** Script exits early with the message "run
+  `pixi run -e dev gen` first".
+- **Variant near contig boundary.** Filter candidate variants to those
+  with at least 5 kb of flanking sequence on the chromosome before
+  sampling.
+- **N/2 allele in haplotype.** `bcftools consensus -H {hap+1}` emits the
+  observed allele; the gvl readers handle this via the normal variant
+  application path. If parity fails on these, that is the bug the test
+  is designed to catch.
+- **Reference allele case.** `bcftools consensus` may emit lowercase
+  reference bases (soft-masked regions in hg38). The test uses
+  `.upper()` on the consensus FASTA before comparison, matching
+  `test_ds_haps.py`.
+
+## Non-Goals / YAGNI Notes
+
+- No CI integration. The downloaded data is large and the test is slow;
+  it is intended to be run manually or in a dedicated nightly job that
+  the maintainer can wire up later.
+- No support for re-running with different seeds or region counts as
+  CLI flags initially. Constants at the top of the script suffice; we
+  can promote them to `typer` options if a second use case appears.
+- No parity test for tracks. This test is haplotype-only.

--- a/pixi.lock
+++ b/pixi.lock
@@ -182,7 +182,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/44/28/b6672962639e85dc0ac36f71ab3a8f5f38e01b51343d7aa372a6b56fa3f3/pyarrow-21.0.0-cp310-cp310-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/2f/ed68a7ee0f76b20b3d8ea3c3dcb06f9c2a2725a95c83cbe0eee65939e750/awkward_cpp-52-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
@@ -221,6 +220,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e5/6d36f92a197c3c17729a2125e29c169f460538a7d939a27eaaa6dcfcba8e/zstandard-0.25.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       osx-arm64:
@@ -346,7 +346,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/57/f6/a92704f33af317ce33c2bbda4a63f902f088d24b92a89fb5cdc52148e7cb/arro3_core-0.8.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl
@@ -395,6 +394,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/26/2c4e3e57055d5c3460b353caa899a6af5b6e44b81425433b765529d72990/pgenlib-0.94.0-cp310-cp310-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   dev:
     channels:
@@ -568,7 +568,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/ac/b605473de2bb404e742f2cc3583d12aedb2352a70e49ae8fce455b50c5aa/multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/12/95a1d33f04a79c402664070d43b8b9f72dc18914e135b345b611b0b1f8cc/yarl-1.23.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ed/c7895fd2fde7f3ee70d248175f9b6cdf792fb741ab92dc59cd9ef3bd241b/frozenlist-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
@@ -624,6 +623,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -753,7 +753,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/2d/6ea7cad2c2f0625c4120bef5353ab7cf749141bf1d070011cebb72f68189/pandera-0.31.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/57/f6/a92704f33af317ce33c2bbda4a63f902f088d24b92a89fb5cdc52148e7cb/arro3_core-0.8.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
@@ -799,6 +798,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/26/2c4e3e57055d5c3460b353caa899a6af5b6e44b81425433b765529d72990/pgenlib-0.94.0-cp310-cp310-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   docs:
     channels:
@@ -1003,7 +1003,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/55/0f/e7f1ff3a1cabc6c4486a7ee1b0506aedf2f5f8329760ac1f4e8032feef2b/pysam-0.24.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
@@ -1093,6 +1092,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       osx-arm64:
@@ -1238,7 +1238,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl
@@ -1336,6 +1335,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   docs-gpu:
@@ -1526,7 +1526,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/55/0f/e7f1ff3a1cabc6c4486a7ee1b0506aedf2f5f8329760ac1f4e8032feef2b/pysam-0.24.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/56/9a/fff8376f8e3d084cd1530e1ef7b879bb7d6d265620c95c1b322725c694f4/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -1638,6 +1637,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
@@ -1783,7 +1783,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl
@@ -1878,6 +1877,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   no-torch:
@@ -1948,7 +1948,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/44/28/b6672962639e85dc0ac36f71ab3a8f5f38e01b51343d7aa372a6b56fa3f3/pyarrow-21.0.0-cp310-cp310-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/1c/ed568eca3a963dc3e447b01961ae653e0d6f107c2cfd77b3f2b1a5cfc520/hypothesis-6.152.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/2f/ed68a7ee0f76b20b3d8ea3c3dcb06f9c2a2725a95c83cbe0eee65939e750/awkward_cpp-52-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -2000,6 +1999,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e5/6d36f92a197c3c17729a2125e29c169f460538a7d939a27eaaa6dcfcba8e/zstandard-0.25.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       osx-arm64:
@@ -2051,7 +2051,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/57/f6/a92704f33af317ce33c2bbda4a63f902f088d24b92a89fb5cdc52148e7cb/arro3_core-0.8.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
@@ -2109,6 +2108,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/26/2c4e3e57055d5c3460b353caa899a6af5b6e44b81425433b765529d72990/pgenlib-0.94.0-cp310-cp310-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   notebook:
     channels:
@@ -2395,7 +2395,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/44/28/b6672962639e85dc0ac36f71ab3a8f5f38e01b51343d7aa372a6b56fa3f3/pyarrow-21.0.0-cp310-cp310-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/3e/f0dba6333dbe5c5a338d1466939c8733256a5f6d7e10615b8f96a90277e5/fast_histogram-0.14-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/2f/ed68a7ee0f76b20b3d8ea3c3dcb06f9c2a2725a95c83cbe0eee65939e750/awkward_cpp-52-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
@@ -2431,6 +2430,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e5/6d36f92a197c3c17729a2125e29c169f460538a7d939a27eaaa6dcfcba8e/zstandard-0.25.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       osx-arm64:
@@ -2623,7 +2623,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/2d/6ea7cad2c2f0625c4120bef5353ab7cf749141bf1d070011cebb72f68189/pandera-0.31.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/57/f6/a92704f33af317ce33c2bbda4a63f902f088d24b92a89fb5cdc52148e7cb/arro3_core-0.8.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
@@ -2665,6 +2664,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/26/2c4e3e57055d5c3460b353caa899a6af5b6e44b81425433b765529d72990/pgenlib-0.94.0-cp310-cp310-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   py310:
     channels:
@@ -2845,7 +2845,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/44/28/b6672962639e85dc0ac36f71ab3a8f5f38e01b51343d7aa372a6b56fa3f3/pyarrow-21.0.0-cp310-cp310-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/2f/ed68a7ee0f76b20b3d8ea3c3dcb06f9c2a2725a95c83cbe0eee65939e750/awkward_cpp-52-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
@@ -2884,6 +2883,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e5/6d36f92a197c3c17729a2125e29c169f460538a7d939a27eaaa6dcfcba8e/zstandard-0.25.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       osx-arm64:
@@ -3009,7 +3009,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/57/f6/a92704f33af317ce33c2bbda4a63f902f088d24b92a89fb5cdc52148e7cb/arro3_core-0.8.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl
@@ -3058,6 +3057,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/26/2c4e3e57055d5c3460b353caa899a6af5b6e44b81425433b765529d72990/pgenlib-0.94.0-cp310-cp310-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   py311:
     channels:
@@ -3236,7 +3236,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/44/0b/0615dbedb98f5b32a35a53290fbdc6e22306968109278d7e58df82d7a9f6/numba-0.65.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/46/27/5799b020e4cdfb25a7c951c06a96397c135efcdc21b78d853bbd9c814c7d/llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/bb/3d3e0a9350a81f3cf38e0bf69c4ad0c17e2f4bfe142c98202294fe0cfa92/selectolax-0.4.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
@@ -3274,6 +3273,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/ec/b0c23ec7fc9df5af527b2d63f15a92699f7fd0515986763ed8e50489a755/ncls-0.0.70-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       osx-arm64:
@@ -3394,7 +3394,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/b0/a4ffc4ae74d2d822200dcc46898987d8eb6032d1e2b219cae39da6f5cbcc/pandas-3.0.3-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
@@ -3443,6 +3442,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/88/6e569ab74cb87f0e4f3ff05051749131e78c1b8100f90147a7a06555f47c/awkward_cpp-52-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   py312:
@@ -3618,7 +3618,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/55/0f/e7f1ff3a1cabc6c4486a7ee1b0506aedf2f5f8329760ac1f4e8032feef2b/pysam-0.24.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -3659,6 +3658,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/bcftools-1.23.1-h0ba0a6f_0.conda
@@ -3776,7 +3776,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2f/97/9214bd9b860e680a281232e218d10b718a7280b593f4ab56240a558dc975/pgenlib-0.94.0-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
@@ -3825,6 +3824,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   py313:
@@ -3999,7 +3999,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/42/2b2b00b0df934353c8e3ebfb2be68f63d7aa6dfe5eb5d5f6427b092e0814/awkward_cpp-52-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/e6/01ada46425bd120b36e7c2f6fe74a980de6912d416f07c9c85b22fadd515/pybigwig-0.3.25-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5f/dd/0c6a5a36ec132665f85e5e33f0480b58cf5aa8af8fbe1d5971410d789558/ncls-0.0.70.tar.gz
@@ -4041,6 +4040,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/bcftools-1.23.1-h0ba0a6f_0.conda
@@ -4159,7 +4159,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/dd/0c6a5a36ec132665f85e5e33f0480b58cf5aa8af8fbe1d5971410d789558/ncls-0.0.70.tar.gz
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
@@ -4209,6 +4208,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   splice:
     channels:
@@ -4509,7 +4509,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/12/95a1d33f04a79c402664070d43b8b9f72dc18914e135b345b611b0b1f8cc/yarl-1.23.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/50/3e/f0dba6333dbe5c5a338d1466939c8733256a5f6d7e10615b8f96a90277e5/fast_histogram-0.14-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ed/c7895fd2fde7f3ee70d248175f9b6cdf792fb741ab92dc59cd9ef3bd241b/frozenlist-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
@@ -4561,6 +4560,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -4758,7 +4758,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/2d/6ea7cad2c2f0625c4120bef5353ab7cf749141bf1d070011cebb72f68189/pandera-0.31.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/57/f6/a92704f33af317ce33c2bbda4a63f902f088d24b92a89fb5cdc52148e7cb/arro3_core-0.8.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/bc/246f452431c592a2a424050e8bb9ccf494fb47613fd97c912f4d573a5e3b/phantom_types-3.0.2-py3-none-any.whl
@@ -4800,6 +4799,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/26/2c4e3e57055d5c3460b353caa899a6af5b6e44b81425433b765529d72990/pgenlib-0.94.0-cp310-cp310-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/bioconda/linux-64/bcftools-1.23.1-hb2cee57_0.conda
@@ -11196,7 +11196,7 @@ packages:
   - awkward
   - hirola>=0.3,<0.4
   - seqpro>=0.11.0
-  - genoray>=2.3.1,<3
+  - genoray>=2.3.2,<3
   - polars-bio>=0.20,<0.21
   - genvarloader-cli>=0.1.0 ; extra == 'cli'
   - tbb ; extra == 'tbb'
@@ -12781,38 +12781,6 @@ packages:
   version: 0.24.0
   sha256: 4a642f18649e59817de272173e9c27c031dceaca199809e4f8b338ebfc5d6698
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/56/23/4ab9f6c8286495f7d35c1d4b6cef83d29c636d9e3ce80234a3553348269d/genoray-2.3.1-py3-none-any.whl
-  name: genoray
-  version: 2.3.1
-  sha256: 9621bd79ff2c19a7b72ec7d9671075f4ebf77dfa725a90daf5a465d4d2c20429
-  requires_dist:
-  - attrs
-  - awkward
-  - cyclopts
-  - cyvcf2>=0.31.1
-  - filelock>3,<4
-  - hirola>=0.3.0
-  - joblib-progress>=1.0.6,<2
-  - joblib>=1.4.2,<2
-  - loguru>=0.7.0
-  - more-itertools>=10
-  - numba
-  - numpy>=1.26
-  - oxbow>=0.5.1,<0.6
-  - pandas>=2.2.3
-  - pgenlib>=0.91.0
-  - phantom-types>=3
-  - polars-bio>=0.20.1,<0.21
-  - polars>=1.37.1
-  - pyarrow>=21
-  - pydantic
-  - pyranges>=0.1.3
-  - seqpro>=0.11,<0.12
-  - tqdm>=4.65
-  - typing-extensions>=4.14
-  - zstandard
-  - genoray-cli>=0.2.0 ; extra == 'cli'
-  requires_python: '>=3.10,<3.14'
 - pypi: https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl
   name: ipywidgets
   version: 8.1.8
@@ -16099,6 +16067,38 @@ packages:
   requires_dist:
   - colorama>=0.4.6 ; extra == 'windows-terminal'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f5/dc/8c295769c1ef8bfa1a4baf64b2b71642f417bb9c794ae9968734c7f20959/genoray-2.3.2-py3-none-any.whl
+  name: genoray
+  version: 2.3.2
+  sha256: 18e9cef5e0457e695968e573f655bec6be81bdaf20b5a266b9ebc0dd149b4a38
+  requires_dist:
+  - attrs
+  - awkward
+  - cyclopts
+  - cyvcf2>=0.31.1
+  - filelock>3,<4
+  - hirola>=0.3.0
+  - joblib-progress>=1.0.6,<2
+  - joblib>=1.4.2,<2
+  - loguru>=0.7.0
+  - more-itertools>=10
+  - numba
+  - numpy>=1.26
+  - oxbow>=0.5.1,<0.6
+  - pandas>=2.2.3
+  - pgenlib>=0.91.0
+  - phantom-types>=3
+  - polars-bio>=0.20.1,<0.21
+  - polars>=1.37.1
+  - pyarrow>=21
+  - pydantic
+  - pyranges>=0.1.3
+  - seqpro>=0.11,<0.12
+  - tqdm>=4.65
+  - typing-extensions>=4.14
+  - zstandard
+  - genoray-cli>=0.2.0 ; extra == 'cli'
+  requires_python: '>=3.10,<3.14'
 - pypi: https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
   name: nvidia-nvjitlink-cu12
   version: 12.8.93

--- a/pixi.toml
+++ b/pixi.toml
@@ -118,9 +118,12 @@ python = "3.13.*"
 [tasks]
 prek-install = "prek install --hook-type commit-msg --hook-type pre-push"
 gen = { cmd = "python tests/data/generate_ground_truth.py" }
-test = { cmd = "pytest tests && cargo test --release", depends-on = ["gen"] }
 gen-1kg = { cmd = "python tests/data/generate_1kg_ground_truth.py", depends-on = [
     "gen",
+] }
+test = { cmd = "pytest tests && cargo test --release", depends-on = [
+    "gen",
+    "gen-1kg",
 ] }
 
 [feature.docs.tasks]

--- a/pixi.toml
+++ b/pixi.toml
@@ -84,7 +84,7 @@ numba = "==0.59.1"
 pyarrow = ">=21"
 hirola = "==0.3"
 seqpro = "==0.11.0"
-genoray = "==2.3.1"
+genoray = "==2.3.2"
 polars = "==1.37.1"
 loguru = "*"
 attrs = "*"
@@ -119,7 +119,9 @@ python = "3.13.*"
 prek-install = "prek install --hook-type commit-msg --hook-type pre-push"
 gen = { cmd = "python tests/data/generate_ground_truth.py" }
 test = { cmd = "pytest tests && cargo test --release", depends-on = ["gen"] }
-gen-1kg = { cmd = "python tests/data/generate_1kg_ground_truth.py", depends-on = ["gen"] }
+gen-1kg = { cmd = "python tests/data/generate_1kg_ground_truth.py", depends-on = [
+    "gen",
+] }
 
 [feature.docs.tasks]
 install-e = "uv pip install -e /cellar/users/dlaub/projects/ML4GLand/SeqPro -e /cellar/users/dlaub/projects/genoray -e ."

--- a/pixi.toml
+++ b/pixi.toml
@@ -119,6 +119,7 @@ python = "3.13.*"
 prek-install = "prek install --hook-type commit-msg --hook-type pre-push"
 gen = { cmd = "python tests/data/generate_ground_truth.py" }
 test = { cmd = "pytest tests && cargo test --release", depends-on = ["gen"] }
+gen-1kg = { cmd = "python tests/data/generate_1kg_ground_truth.py", depends-on = ["gen"] }
 
 [feature.docs.tasks]
 install-e = "uv pip install -e /cellar/users/dlaub/projects/ML4GLand/SeqPro -e /cellar/users/dlaub/projects/genoray -e ."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "awkward",
     "hirola>=0.3,<0.4",
     "seqpro>=0.11.0",
-    "genoray>=2.3.1,<3",
+    "genoray>=2.3.2,<3",
     "polars-bio>=0.20,<0.21",
 ]
 

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -172,6 +172,32 @@ def pick_regions(filtered_bcf: Path) -> Path:
     return bed_path
 
 
+def write_datasets(filtered_bcf: Path, pgen: Path, svar: Path, bed_path: Path) -> None:
+    import genvarloader as gvl
+    from genoray import PGEN, VCF, SparseVar
+
+    bcf_ds = ONE_KG_DIR / "phased_1kg.bcf.gvl"
+    pgen_ds = ONE_KG_DIR / "phased_1kg.pgen.gvl"
+    svar_ds = ONE_KG_DIR / "phased_1kg.svar.gvl"
+
+    for d in (bcf_ds, pgen_ds, svar_ds):
+        if d.exists():
+            shutil.rmtree(d)
+
+    vcf_reader = VCF(filtered_bcf)
+    if not vcf_reader._valid_index():
+        vcf_reader._write_gvi_index()
+    _ = vcf_reader._load_index()
+    gvl.write(path=bcf_ds, bed=bed_path, variants=vcf_reader)
+    logger.info(f"Wrote {bcf_ds}")
+
+    gvl.write(path=pgen_ds, bed=bed_path, variants=PGEN(pgen))
+    logger.info(f"Wrote {pgen_ds}")
+
+    gvl.write(path=svar_ds, bed=bed_path, variants=SparseVar(svar))
+    logger.info(f"Wrote {svar_ds}")
+
+
 def main() -> None:
     """Generate 1000 Genomes ground-truth haplotypes via bcftools consensus."""
     log_file = WDIR / "generate_1kg_ground_truth.log"
@@ -204,6 +230,7 @@ def main() -> None:
     svar = make_svar(filtered)
     logger.info(f"SVAR at {svar}")
     bed_path = pick_regions(filtered)
+    write_datasets(filtered, pgen, svar, bed_path)
     logger.info(f"Finished in {perf_counter() - t0:.1f}s")
 
 

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -113,6 +113,65 @@ def make_svar(filtered_bcf: Path) -> Path:
     return out
 
 
+def pick_regions(filtered_bcf: Path) -> Path:
+    import io
+    import numpy as np
+    import polars as pl
+
+    bed_path = ONE_KG_DIR / "regions.bed"
+
+    proc = run_shell(
+        [
+            "bcftools",
+            "query",
+            "-f",
+            "%CHROM\t%POS\n",
+            "-r",
+            "chr21,chr22",
+            str(filtered_bcf),
+        ]
+    )
+    raw = proc.stdout.decode().strip()
+    if not raw:
+        raise SystemExit(
+            "No variants found on chr21/chr22. Inspect filtered.bcf with "
+            "`bcftools view -h` to verify contig naming."
+        )
+
+    df = pl.read_csv(
+        io.BytesIO(raw.encode()),
+        separator="\t",
+        has_header=False,
+        new_columns=["chrom", "pos"],
+        schema_overrides={"chrom": pl.Utf8, "pos": pl.Int64},
+    )
+
+    half = REGION_LEN // 2
+    df = df.filter(pl.col("pos") > half)
+
+    rng = np.random.default_rng(SEED)
+    idx = rng.choice(df.height, size=N_REGIONS, replace=False)
+    chosen = df[idx.tolist()]
+
+    starts = chosen["pos"].to_numpy() - half
+    ends = starts + REGION_LEN
+    strand = rng.choice(["+", "-"], size=N_REGIONS, replace=True)
+
+    out = pl.DataFrame(
+        {
+            "chrom": chosen["chrom"].to_numpy(),
+            "start": starts,
+            "end": ends,
+            "name": ["."] * N_REGIONS,
+            "score": ["."] * N_REGIONS,
+            "strand": strand,
+        }
+    )
+    out.write_csv(bed_path, include_header=False, separator="\t")
+    logger.info(f"Wrote {N_REGIONS} regions to {bed_path}")
+    return bed_path
+
+
 def main() -> None:
     """Generate 1000 Genomes ground-truth haplotypes via bcftools consensus."""
     log_file = WDIR / "generate_1kg_ground_truth.log"
@@ -144,6 +203,7 @@ def main() -> None:
     logger.info(f"PGEN at {pgen}")
     svar = make_svar(filtered)
     logger.info(f"SVAR at {svar}")
+    bed_path = pick_regions(filtered)
     logger.info(f"Finished in {perf_counter() - t0:.1f}s")
 
 

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -99,6 +99,20 @@ def make_pgen(filtered_bcf: Path) -> Path:
         ]
     )
     return out_prefix.with_suffix(".pgen")
+
+
+def make_svar(filtered_bcf: Path) -> Path:
+    """Generate SparseVar from normalized BCF via genoray."""
+    from genoray import VCF, SparseVar
+
+    out = ONE_KG_DIR / "filtered.svar"
+    if out.exists():
+        shutil.rmtree(out)
+    SparseVar.from_vcf(out, VCF(filtered_bcf), "50mb")
+    SparseVar(out).cache_afs()
+    return out
+
+
 def main() -> None:
     """Generate 1000 Genomes ground-truth haplotypes via bcftools consensus."""
     log_file = WDIR / "generate_1kg_ground_truth.log"
@@ -128,7 +142,8 @@ def main() -> None:
     logger.info(f"Normalized BCF at {filtered}")
     pgen = make_pgen(filtered)
     logger.info(f"PGEN at {pgen}")
-
+    svar = make_svar(filtered)
+    logger.info(f"SVAR at {svar}")
     logger.info(f"Finished in {perf_counter() - t0:.1f}s")
 
 

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -17,12 +17,10 @@ N_REGIONS = 100
 REGION_LEN = 10_000
 SEED = 0
 
-ZENODO_BCF_URL = "https://zenodo.org/records/20132907/files/1kg.chr21_chr22.5samples.bcf"
-ZENODO_CSI_URL = "https://zenodo.org/records/20132907/files/1kg.chr21_chr22.5samples.bcf.csi"
-# Fill these in on first successful run; the script prints observed hashes
-# and exits when they are None.
-ZENODO_BCF_HASH: str | None = None
-ZENODO_CSI_HASH: str | None = None
+ZENODO_BCF_URL = "https://zenodo.org/records/20132907/files/1kgp.thin.bcf"
+ZENODO_CSI_URL = "https://zenodo.org/records/20132907/files/1kgp.thin.bcf.csi"
+ZENODO_BCF_MD5 = "md5:3bdfed585e4a6b2a51c49d1d7dc7124f"
+ZENODO_CSI_MD5 = "md5:8f190a43294404ca320b45a05851d56a"
 
 
 def run_shell(cmd: list[str], input: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
@@ -35,6 +33,12 @@ def run_shell(cmd: list[str], input: bytes | None = None) -> subprocess.Complete
         raise
 
 
+def fetch_zenodo(url: str, known_hash: str, fname: str) -> Path:
+    import pooch
+
+    return Path(
+        pooch.retrieve(url, known_hash=known_hash, fname=fname, path=ONE_KG_DIR)
+    )
 def main() -> None:
     """Generate 1000 Genomes ground-truth haplotypes via bcftools consensus."""
     log_file = WDIR / "generate_1kg_ground_truth.log"
@@ -55,7 +59,10 @@ def main() -> None:
         shutil.rmtree(CONS_DIR)
     CONS_DIR.mkdir(0o777, parents=True, exist_ok=True)
 
-    logger.info("Pipeline scaffold OK")
+    bcf = fetch_zenodo(ZENODO_BCF_URL, ZENODO_BCF_MD5, "source.bcf")
+    csi = fetch_zenodo(ZENODO_CSI_URL, ZENODO_CSI_MD5, "source.bcf.csi")
+    logger.info(f"Fetched: {bcf} ({bcf.stat().st_size} bytes)")
+    logger.info(f"Fetched: {csi} ({csi.stat().st_size} bytes)")
     logger.info(f"Finished in {perf_counter() - t0:.1f}s")
 
 

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -23,7 +23,9 @@ ZENODO_BCF_MD5 = "md5:3bdfed585e4a6b2a51c49d1d7dc7124f"
 ZENODO_CSI_MD5 = "md5:8f190a43294404ca320b45a05851d56a"
 
 
-def run_shell(cmd: list[str], input: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
+def run_shell(
+    cmd: list[str], input: bytes | None = None
+) -> subprocess.CompletedProcess[bytes]:
     try:
         return subprocess.run(cmd, check=True, capture_output=True, input=input)
     except subprocess.CalledProcessError as e:
@@ -100,6 +102,7 @@ def normalize_bcf(source_bcf: Path) -> Path:
 
     _ = run_shell(["bcftools", "index", "-f", str(filtered)])
     return filtered
+
 
 def make_pgen(filtered_bcf: Path) -> Path:
     """Generate PGEN from normalized BCF via plink2."""
@@ -273,8 +276,7 @@ def main() -> None:
 
     if not REF.exists():
         raise SystemExit(
-            f"Reference {REF} not found. Run `pixi run -e dev gen` first to "
-            "fetch hg38."
+            f"Reference {REF} not found. Run `pixi run -e dev gen` first to fetch hg38."
         )
 
     ONE_KG_DIR.mkdir(0o777, parents=True, exist_ok=True)

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from time import perf_counter
+
+import typer
+from loguru import logger
+
+WDIR = Path(__file__).resolve().parent
+ONE_KG_DIR = WDIR / "1kg"
+CONS_DIR = WDIR / "1kg_consensus"
+REF = WDIR / "fasta" / "hg38.fa.bgz"
+
+N_REGIONS = 100
+REGION_LEN = 10_000
+SEED = 0
+
+ZENODO_BCF_URL = "https://zenodo.org/records/20132907/files/1kg.chr21_chr22.5samples.bcf"
+ZENODO_CSI_URL = "https://zenodo.org/records/20132907/files/1kg.chr21_chr22.5samples.bcf.csi"
+# Fill these in on first successful run; the script prints observed hashes
+# and exits when they are None.
+ZENODO_BCF_HASH: str | None = None
+ZENODO_CSI_HASH: str | None = None
+
+
+def run_shell(cmd: list[str], input: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
+    try:
+        return subprocess.run(cmd, check=True, capture_output=True, input=input)
+    except subprocess.CalledProcessError as e:
+        print("Command:", " ".join(e.cmd))
+        print("Stdout:", e.stdout.decode(errors="replace"))
+        print("Stderr:", e.stderr.decode(errors="replace"))
+        raise
+
+
+def main() -> None:
+    """Generate 1000 Genomes ground-truth haplotypes via bcftools consensus."""
+    log_file = WDIR / "generate_1kg_ground_truth.log"
+    if log_file.exists():
+        log_file.unlink()
+    _ = logger.add(log_file, level="DEBUG")
+
+    t0 = perf_counter()
+
+    if not REF.exists():
+        raise SystemExit(
+            f"Reference {REF} not found. Run `pixi run -e dev gen` first to "
+            "fetch hg38."
+        )
+
+    ONE_KG_DIR.mkdir(0o777, parents=True, exist_ok=True)
+    if CONS_DIR.exists():
+        shutil.rmtree(CONS_DIR)
+    CONS_DIR.mkdir(0o777, parents=True, exist_ok=True)
+
+    logger.info("Pipeline scaffold OK")
+    logger.info(f"Finished in {perf_counter() - t0:.1f}s")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -82,6 +82,23 @@ def normalize_bcf(source_bcf: Path) -> Path:
 
     _ = run_shell(["bcftools", "index", "-f", str(filtered)])
     return filtered
+
+def make_pgen(filtered_bcf: Path) -> Path:
+    """Generate PGEN from normalized BCF via plink2."""
+    out_prefix = ONE_KG_DIR / "filtered"
+    _ = run_shell(
+        [
+            "plink2",
+            "--bcf",
+            str(filtered_bcf),
+            "--make-pgen",
+            "--vcf-half-call",
+            "r",
+            "--out",
+            str(out_prefix),
+        ]
+    )
+    return out_prefix.with_suffix(".pgen")
 def main() -> None:
     """Generate 1000 Genomes ground-truth haplotypes via bcftools consensus."""
     log_file = WDIR / "generate_1kg_ground_truth.log"
@@ -109,6 +126,8 @@ def main() -> None:
 
     filtered = normalize_bcf(bcf)
     logger.info(f"Normalized BCF at {filtered}")
+    pgen = make_pgen(filtered)
+    logger.info(f"PGEN at {pgen}")
 
     logger.info(f"Finished in {perf_counter() - t0:.1f}s")
 

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -39,6 +39,49 @@ def fetch_zenodo(url: str, known_hash: str, fname: str) -> Path:
     return Path(
         pooch.retrieve(url, known_hash=known_hash, fname=fname, path=ONE_KG_DIR)
     )
+
+
+def normalize_bcf(source_bcf: Path) -> Path:
+    """Left-align, atomize, and split multiallelics. Returns indexed filtered.bcf."""
+    filtered = ONE_KG_DIR / "filtered.bcf"
+
+    # Step A: left-align
+    result = run_shell(
+        [
+            "bcftools",
+            "norm",
+            "-f",
+            str(REF),
+            "-O",
+            "u",
+            str(source_bcf),
+        ]
+    )
+    logger.info("bcftools norm (left-align) done")
+
+    # Step B: atomize + split multiallelics; emit as bgzipped BCF
+    _ = run_shell(
+        [
+            "bcftools",
+            "norm",
+            "-a",
+            "--atom-overlaps",
+            ".",
+            "-f",
+            str(REF),
+            "-m",
+            "-",
+            "-O",
+            "b",
+            "-o",
+            str(filtered),
+        ],
+        input=result.stdout,
+    )
+    logger.info("bcftools norm (atomize + split) done")
+
+    _ = run_shell(["bcftools", "index", "-f", str(filtered)])
+    return filtered
 def main() -> None:
     """Generate 1000 Genomes ground-truth haplotypes via bcftools consensus."""
     log_file = WDIR / "generate_1kg_ground_truth.log"
@@ -63,6 +106,10 @@ def main() -> None:
     csi = fetch_zenodo(ZENODO_CSI_URL, ZENODO_CSI_MD5, "source.bcf.csi")
     logger.info(f"Fetched: {bcf} ({bcf.stat().st_size} bytes)")
     logger.info(f"Fetched: {csi} ({csi.stat().st_size} bytes)")
+
+    filtered = normalize_bcf(bcf)
+    logger.info(f"Normalized BCF at {filtered}")
+
     logger.info(f"Finished in {perf_counter() - t0:.1f}s")
 
 

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -80,6 +80,24 @@ def normalize_bcf(source_bcf: Path) -> Path:
     )
     logger.info("bcftools norm (atomize + split) done")
 
+    # Drop symbolic alleles (SVs / OTHER); gvl + bcftools must see the same variants.
+    filtered_tmp = ONE_KG_DIR / "filtered.no_svs.bcf"
+    _ = run_shell(
+        [
+            "bcftools",
+            "view",
+            "-e",
+            'TYPE="OTHER"',
+            "-O",
+            "b",
+            "-o",
+            str(filtered_tmp),
+            str(filtered),
+        ]
+    )
+    filtered_tmp.replace(filtered)
+    logger.info("bcftools view (drop SVs) done")
+
     _ = run_shell(["bcftools", "index", "-f", str(filtered)])
     return filtered
 
@@ -233,8 +251,6 @@ def generate_consensus_fastas(filtered_bcf: Path, bed_path: Path) -> None:
                         str(hap + 1),
                         "-s",
                         sample,
-                        "-e",
-                        'ALT~"<.*>"',
                         "-o",
                         str(out_fa),
                         str(filtered_bcf),

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -198,6 +198,54 @@ def write_datasets(filtered_bcf: Path, pgen: Path, svar: Path, bed_path: Path) -
     logger.info(f"Wrote {svar_ds}")
 
 
+def generate_consensus_fastas(filtered_bcf: Path, bed_path: Path) -> None:
+    import polars as pl
+    from tqdm.auto import tqdm
+
+    proc = run_shell(["bcftools", "query", "-l", str(filtered_bcf)])
+    samples = proc.stdout.decode().strip().splitlines()
+    logger.info(f"Samples: {samples}")
+
+    bed = pl.read_csv(
+        bed_path,
+        separator="\t",
+        has_header=False,
+        new_columns=["chrom", "start", "end", "name", "score", "strand"],
+        schema_overrides={"chrom": pl.Utf8},
+    ).with_row_index()
+
+    total = bed.height * len(samples) * 2
+    pbar = tqdm(total=total, desc="bcftools consensus")
+    for row_nr, chrom, start, end in bed.select(
+        "index", "chrom", "start", "end"
+    ).iter_rows():
+        subseq = run_shell(
+            ["samtools", "faidx", str(REF), f"{chrom}:{start + 1}-{end}"]
+        )
+        for sample in samples:
+            for hap in (0, 1):
+                out_fa = CONS_DIR / f"1kg_{sample}_nr{row_nr}_h{hap}.fa"
+                _ = run_shell(
+                    [
+                        "bcftools",
+                        "consensus",
+                        "-H",
+                        str(hap + 1),
+                        "-s",
+                        sample,
+                        "-e",
+                        'ALT~"<.*>"',
+                        "-o",
+                        str(out_fa),
+                        str(filtered_bcf),
+                    ],
+                    input=subseq.stdout,
+                )
+                _ = run_shell(["samtools", "faidx", str(out_fa)])
+                _ = pbar.update()
+    pbar.close()
+
+
 def main() -> None:
     """Generate 1000 Genomes ground-truth haplotypes via bcftools consensus."""
     log_file = WDIR / "generate_1kg_ground_truth.log"
@@ -231,6 +279,7 @@ def main() -> None:
     logger.info(f"SVAR at {svar}")
     bed_path = pick_regions(filtered)
     write_datasets(filtered, pgen, svar, bed_path)
+    generate_consensus_fastas(filtered, bed_path)
     logger.info(f"Finished in {perf_counter() - t0:.1f}s")
 
 

--- a/tests/dataset/test_ds_haps_1kg.py
+++ b/tests/dataset/test_ds_haps_1kg.py
@@ -1,0 +1,63 @@
+from itertools import product
+from pathlib import Path
+
+import genvarloader as gvl
+import numpy as np
+import pysam
+import pytest
+import seqpro as sp
+from genvarloader._ragged import RaggedSeqs
+from pytest_cases import parametrize_with_cases
+
+data_dir = Path(__file__).resolve().parents[1] / "data"
+ref = data_dir / "fasta" / "hg38.fa.bgz"
+cons_dir = data_dir / "1kg_consensus"
+
+pytestmark = pytest.mark.slow
+
+
+def dataset_bcf():
+    return (
+        gvl.Dataset.open(data_dir / "1kg" / "phased_1kg.bcf.gvl", ref, rc_neg=False)
+        .with_len("ragged")
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+
+
+def dataset_pgen():
+    return (
+        gvl.Dataset.open(data_dir / "1kg" / "phased_1kg.pgen.gvl", ref, rc_neg=False)
+        .with_len("ragged")
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+
+
+def dataset_svar():
+    return (
+        gvl.Dataset.open(data_dir / "1kg" / "phased_1kg.svar.gvl", ref, rc_neg=False)
+        .with_len("ragged")
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+
+
+@parametrize_with_cases("dataset", cases=".", prefix="dataset_")
+def test_ds_haps_1kg(dataset: gvl.RaggedDataset[RaggedSeqs, None]):
+    for region, sample in product(range(dataset.n_regions), dataset.samples):
+        c, s, e, _ = dataset.regions.select(
+            "chrom", "chromStart", "chromEnd", "strand"
+        ).row(region)
+        haps = dataset[region, sample]
+        for h in range(2):
+            actual = sp.cast_seqs(haps[h])
+            fpath = f"1kg_{sample}_nr{region}_h{h}.fa"
+            with pysam.FastaFile(str(cons_dir / fpath)) as f:
+                desired = sp.cast_seqs(f.fetch(f.references[0]).upper())
+            np.testing.assert_equal(
+                actual,
+                desired,
+                f"region: {region}, sample: {sample}, hap: {h}, "
+                f"coords: {c}:{s + 1}-{e}",
+            )


### PR DESCRIPTION
## Summary
- Add 1000 Genomes-based integration tests verifying GVL haplotype reconstruction matches `bcftools consensus` output
- Test all three variant backends (BCF, PGEN, SparseVar) across 100 variant-centered 10kb regions for all samples and haplotypes
- Fix SV handling: drop structural variants in normalization step rather than at consensus time

## Test Plan
- [ ] `pixi run -e dev test` passes (429 passed, 5 skipped, 2 xfailed)
- [ ] Parity tests compare GVL output against `bcftools consensus` ground truth for each backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)