### PR TITLE
feat: replace link.svar symlink with metadata-embedded path reference

### DIFF
--- a/docs/source/format.md
+++ b/docs/source/format.md
@@ -1,0 +1,80 @@
+# Dataset format
+
+A GVL dataset is a directory written by [`gvl.write`](api.md#genvarloader.write) and read
+by [`gvl.Dataset.open`](api.md#genvarloader.Dataset.open). This page is the authoritative
+description of its on-disk layout.
+
+## Directory layout
+
+```
+dataset_dir/
+├── metadata.json          # the Metadata schema (below)
+├── input_regions.arrow    # original BED regions + region-index map
+├── genotypes/             # present iff variants were provided to gvl.write
+│   ├── offsets.npy        # per (region, sample, ploidy) offsets into variant_idxs.npy
+│   ├── svar_meta.json     # shape + dtype of offsets.npy — present iff source was .svar
+│   ├── variant_idxs.npy   # variant indices; absent when sourced from .svar
+│   ├── dosages.npy        # optional, absent when sourced from .svar
+│   └── variants.arrow     # variant table; absent when sourced from .svar
+└── intervals/             # or annot_intervals/ when annotated; present iff tracks given
+```
+
+When the dataset was built from an `.svar`, the heavy per-variant arrays (`variant_idxs.npy`,
+`dosages.npy`, `index.arrow`) are **not duplicated** into the dataset. Instead the dataset
+records a back-reference to the source `.svar` in `metadata.json` (see `svar_link` below).
+
+## `metadata.json` schema
+
+`metadata.json` is the serialization of `genvarloader._dataset._write.Metadata`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `samples` | `list[str]` | Sample identifiers, sorted. |
+| `contigs` | `list[str]` | Contig names used to interpret BED coords. |
+| `n_regions` | `int` | Number of regions (after jitter padding). |
+| `ploidy` | `int \| None` | Ploidy when the dataset has genotypes. |
+| `max_jitter` | `int` | Maximum coordinate jitter (defaults to 0). |
+| `version` | `SemanticVersion \| None` | Package version that wrote this dataset. Drives format dispatch. |
+| `svar_link` | `SvarLink \| None` | Back-reference to a source `.svar`, when present. |
+
+`SvarLink`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `relative_path` | `str` | POSIX path from `dataset_dir` to the `.svar`. |
+| `absolute_path` | `str` | Original absolute path; used as a fallback. |
+| `fingerprint` | `SvarFingerprint` | Integrity check (see below). |
+
+`SvarFingerprint`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `n_variants` | `int` | Row count of the svar's `index.arrow`. |
+| `variant_idxs_bytes` | `int` | Byte size of the svar's `variant_idxs.npy`. |
+
+## SVAR resolution at open time
+
+When opening a dataset whose `metadata.svar_link` is non-null,
+[`Dataset.open`](api.md#genvarloader.Dataset.open) resolves the svar in this order:
+
+1. Caller-provided `svar=...` argument.
+2. `svar_link.relative_path` resolved against the dataset directory.
+3. `svar_link.absolute_path`.
+4. A unique `*.svar` directory next to the dataset.
+
+If none match, a `FileNotFoundError` is raised naming the expected `.svar` basename. After
+resolution, the fingerprint is verified; a mismatch raises `ValueError` and lists both
+expected and observed values.
+
+## Format changelog
+
+| Version | Change |
+|---------|--------|
+| `< 0.18.0` | Variant coordinates stored 0-based. |
+| `0.18.0` | Variant coordinates switched to 1-based. |
+| `0.25.0` | `metadata.json` gains `svar_link`; old `genotypes/link.svar` symlink layout deprecated. `Metadata.version` typed as `SemanticVersion` (on-disk JSON unchanged). |
+
+> **Upgrading legacy datasets.** A dataset written before `0.25.0` that was built from an
+> `.svar` will still open (with a `DeprecationWarning`). Run
+> `genvarloader.migrate_svar_link(path)` to convert the symlink layout to the new metadata
+> layout in place.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -3,6 +3,7 @@
 
 dataset
 write
+format
 geuvadis
 basenji2_eval
 faq

--- a/docs/superpowers/plans/2026-05-21-svar-link-replacement.md
+++ b/docs/superpowers/plans/2026-05-21-svar-link-replacement.md
@@ -1,0 +1,1252 @@
+# `link.svar` symlink replacement — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the brittle `link.svar` symlink with a typed `Metadata.svar_link` field (path reference + fingerprint), migrate `Metadata.version` to `SemanticVersion`, and document the on-disk format.
+
+**Architecture:** Extend the existing `Metadata` pydantic model with a nested `SvarLink` field; dispatch read-side resolution on `Metadata.version`; keep a legacy fallback that reads the old symlink for pre-bump datasets; provide `migrate_svar_link()` to upgrade in place. No new sidecar files.
+
+**Tech Stack:** Python, pydantic v2, `pydantic-extra-types` (SemanticVersion), polars, numpy memmap, pytest, pixi.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-svar-link-replacement-design.md`
+
+**NEXT_VERSION placeholder:** Throughout this plan, `NEXT_VERSION` is the next published genvarloader release. Read it once at the start of Task 1 (commitizen / `pyproject.toml`'s configured version-bumping convention) and substitute the literal string (e.g. `"0.3.0"`) everywhere this plan references it. Do not leave the placeholder in code.
+
+---
+
+## File Structure
+
+**New files:**
+- `python/genvarloader/_dataset/_svar_link.py` — `SvarFingerprint`, `SvarLink`, `_resolve_svar`, `_verify_fingerprint`, `migrate_svar_link`. One file for everything svar-link-related so the boundary is obvious.
+- `tests/dataset/test_svar_link.py` — all new tests for this feature (write/read roundtrip, override, mismatch, missing, sibling, legacy, migration, schema, version parsing).
+- `docs/source/format.md` — on-disk format documentation + changelog.
+
+**Modified files:**
+- `python/genvarloader/_dataset/_write.py` — switch `version` field to `SemanticVersion`; add `svar_link` field to `Metadata`; populate it from `_write_from_svar`; remove the symlink write.
+- `python/genvarloader/_dataset/_reconstruct.py` — replace `Version` import; accept `SvarLink | None` and use `_resolve_svar`; update the `>= Version("0.18.0")` comparison.
+- `python/genvarloader/_dataset/_impl.py` — add `svar=` kwarg to all three `Dataset.open` overloads; thread it to `Haps.from_path`; emit deprecation warning when legacy path is taken.
+- `python/genvarloader/__init__.py` — re-export `migrate_svar_link`.
+- `pyproject.toml` — add `pydantic-extra-types` with the `semver` extra.
+- `docs/source/index.md` — add `format` to the toctree.
+
+---
+
+## Task 1: Add `pydantic-extra-types` dependency and confirm `NEXT_VERSION`
+
+**Files:**
+- Modify: `pyproject.toml`
+- Read: `pyproject.toml` (for the current version), `CHANGELOG.md` if present
+
+- [ ] **Step 1: Inspect current version & decide `NEXT_VERSION`**
+
+Run: `grep -E '^version' pyproject.toml`
+Expected: a line like `version = "0.2.1"`.
+
+Pick `NEXT_VERSION` as the next minor bump under commitizen's conventional-commits scheme (e.g. `0.2.1` → `0.3.0`). Record the chosen value at the top of every subsequent file you touch — substitute the literal value where this plan says `NEXT_VERSION`.
+
+- [ ] **Step 2: Add `pydantic-extra-types` to dependencies**
+
+Edit `pyproject.toml`, in the `[project] dependencies` array (the same one that contains `"pydantic>=2,<3"`), add:
+
+```toml
+"pydantic-extra-types[semver]>=2.10",
+```
+
+- [ ] **Step 3: Install and verify**
+
+Run: `pixi install -e dev`
+Then: `pixi run -e dev python -c "from pydantic_extra_types.semantic_version import SemanticVersion; print(SemanticVersion('0.18.0'))"`
+Expected: `0.18.0` printed; no ImportError.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml pixi.lock
+git commit -m "build: add pydantic-extra-types dep for SemanticVersion"
+```
+
+---
+
+## Task 2: Create `_svar_link.py` with `SvarFingerprint` and `SvarLink` models
+
+**Files:**
+- Create: `python/genvarloader/_dataset/_svar_link.py`
+- Test: `tests/dataset/test_svar_link.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/dataset/test_svar_link.py`:
+
+```python
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from genvarloader._dataset._svar_link import SvarFingerprint, SvarLink
+
+
+def test_svar_link_roundtrip():
+    link = SvarLink(
+        relative_path="../foo.svar",
+        absolute_path="/abs/path/foo.svar",
+        fingerprint=SvarFingerprint(n_variants=10, variant_idxs_bytes=42),
+    )
+    payload = link.model_dump_json()
+    parsed = SvarLink.model_validate_json(payload)
+    assert parsed == link
+
+
+def test_svar_link_rejects_malformed_fingerprint():
+    bad = '{"relative_path":"a","absolute_path":"b","fingerprint":{"n_variants":"not_an_int","variant_idxs_bytes":1}}'
+    with pytest.raises(ValidationError):
+        SvarLink.model_validate_json(bad)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py::test_svar_link_roundtrip -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'genvarloader._dataset._svar_link'`.
+
+- [ ] **Step 3: Implement the models**
+
+Create `python/genvarloader/_dataset/_svar_link.py`:
+
+```python
+"""Resolution and integrity for the GVL dataset → SVAR back-reference."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class SvarFingerprint(BaseModel):
+    n_variants: int
+    variant_idxs_bytes: int
+
+
+class SvarLink(BaseModel):
+    relative_path: str
+    absolute_path: str
+    fingerprint: SvarFingerprint
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py -v`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genvarloader/_dataset/_svar_link.py tests/dataset/test_svar_link.py
+git commit -m "feat(dataset): add SvarLink / SvarFingerprint pydantic models"
+```
+
+---
+
+## Task 3: Migrate `Metadata.version` to `SemanticVersion` and add `svar_link` field
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_write.py:25-50`, `:133`
+- Test: `tests/dataset/test_svar_link.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/dataset/test_svar_link.py`:
+
+```python
+import json
+
+from genvarloader._dataset._write import Metadata
+from pydantic_extra_types.semantic_version import SemanticVersion
+
+
+def test_metadata_version_parses_existing_strings():
+    payload = json.dumps(
+        {
+            "samples": ["s1"],
+            "contigs": ["1"],
+            "n_regions": 1,
+            "version": "0.18.0",
+        }
+    )
+    m = Metadata.model_validate_json(payload)
+    assert isinstance(m.version, SemanticVersion)
+    assert m.version == SemanticVersion("0.18.0")
+
+
+def test_metadata_version_serializes_back_to_string():
+    m = Metadata(
+        samples=["s1"],
+        contigs=["1"],
+        n_regions=1,
+        version=SemanticVersion("0.18.0"),
+    )
+    dumped = json.loads(m.model_dump_json())
+    assert dumped["version"] == "0.18.0"
+
+
+def test_metadata_svar_link_defaults_to_none():
+    m = Metadata(samples=["s1"], contigs=["1"], n_regions=1)
+    assert m.svar_link is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py -v`
+Expected: the three new tests FAIL (the current `Metadata` uses `packaging.version.Version` and has no `svar_link`).
+
+- [ ] **Step 3: Update `_write.py` imports and `Metadata`**
+
+In `python/genvarloader/_dataset/_write.py`:
+
+Replace lines 25-26:
+
+```python
+from packaging.version import Version
+from pydantic import BaseModel, BeforeValidator, PlainSerializer, WithJsonSchema
+```
+
+with:
+
+```python
+from pydantic import BaseModel
+from pydantic_extra_types.semantic_version import SemanticVersion
+
+from ._svar_link import SvarLink
+```
+
+Replace the `Metadata` class (currently `_write.py:36-54`) with:
+
+```python
+class Metadata(BaseModel, arbitrary_types_allowed=True):
+    samples: list[str]
+    contigs: list[str]
+    n_regions: int
+    ploidy: int | None = None
+    max_jitter: int = 0
+    version: SemanticVersion | None = None
+    svar_link: SvarLink | None = None
+
+    @property
+    def n_samples(self) -> int:
+        return len(self.samples)
+```
+
+Also update line 133:
+
+```python
+metadata: dict[str, Any] = {"version": Version(version("genvarloader"))}
+```
+
+to:
+
+```python
+metadata: dict[str, Any] = {"version": SemanticVersion(version("genvarloader"))}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py -v`
+Expected: all five tests in this file PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genvarloader/_dataset/_write.py tests/dataset/test_svar_link.py
+git commit -m "refactor(dataset): use SemanticVersion in Metadata, add svar_link field"
+```
+
+---
+
+## Task 4: Update `_reconstruct.py` Version comparison
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_reconstruct.py:21`, `:227`, `:265`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/dataset/test_svar_link.py`:
+
+```python
+def test_semantic_version_ordering_for_one_based_dispatch():
+    """The legacy comparison '>= 0.18.0' must still work under SemanticVersion."""
+    assert SemanticVersion("0.18.0") >= SemanticVersion("0.18.0")
+    assert SemanticVersion("0.20.0") >= SemanticVersion("0.18.0")
+    assert not (SemanticVersion("0.17.5") >= SemanticVersion("0.18.0"))
+```
+
+- [ ] **Step 2: Run it to verify the lib comparison works**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py::test_semantic_version_ordering_for_one_based_dispatch -v`
+Expected: PASS (this is a sanity check on the library; you still need to update `_reconstruct.py` so the production code uses the new type).
+
+- [ ] **Step 3: Update imports and type hints in `_reconstruct.py`**
+
+Replace line 21:
+
+```python
+from packaging.version import Version
+```
+
+with:
+
+```python
+from pydantic_extra_types.semantic_version import SemanticVersion
+```
+
+Replace line 227:
+
+```python
+        version: Version | None,
+```
+
+with:
+
+```python
+        version: SemanticVersion | None,
+```
+
+Replace line 265:
+
+```python
+                one_based=version is not None and version >= Version("0.18.0"),
+```
+
+with:
+
+```python
+                one_based=version is not None and version >= SemanticVersion("0.18.0"),
+```
+
+- [ ] **Step 4: Run the dataset tests to ensure nothing regressed**
+
+Run: `pixi run -e dev pytest tests/dataset/ -v -x --timeout=120`
+Expected: All existing tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genvarloader/_dataset/_reconstruct.py tests/dataset/test_svar_link.py
+git commit -m "refactor(dataset): switch Haps.from_path version compare to SemanticVersion"
+```
+
+---
+
+## Task 5: Populate `svar_link` in `_write_from_svar` (replace symlink)
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_write.py` (function `_write_from_svar`, currently ending at `:657`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/dataset/test_svar_link.py`:
+
+```python
+import shutil
+
+import genvarloader as gvl
+
+
+@pytest.fixture
+def svar_dataset_paths(tmp_path):
+    """Locate the canonical test svar and produce a fresh GVL dataset from it.
+
+    Mirrors the existing svar fixtures used in `tests/dataset/`.
+    """
+    # The repo's pixi-gen task produces a test svar under tests/data/.
+    # Look up the exact path by searching tests/data for *.svar.
+    repo_root = Path(__file__).resolve().parents[2]
+    svar_candidates = list((repo_root / "tests" / "data").rglob("*.svar"))
+    assert svar_candidates, "Run `pixi run -e dev gen` to materialize test svar"
+    svar_path = svar_candidates[0]
+    bed_path = next((repo_root / "tests" / "data").rglob("*.bed"))
+
+    gvl_path = tmp_path / "ds.gvl"
+    gvl.write(path=gvl_path, bed=bed_path, variants=svar_path, overwrite=True)
+    return gvl_path, svar_path
+
+
+def test_write_from_svar_records_svar_link_and_no_symlink(svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+
+    # No symlink in the new layout.
+    assert not (gvl_path / "genotypes" / "link.svar").exists()
+    assert not (gvl_path / "genotypes" / "link.svar").is_symlink()
+
+    # Metadata records the svar.
+    metadata = Metadata.model_validate_json(
+        (gvl_path / "metadata.json").read_text()
+    )
+    assert metadata.svar_link is not None
+    assert Path(metadata.svar_link.absolute_path) == svar_path.resolve()
+    # relative_path should resolve back to the svar from the dataset dir.
+    assert (gvl_path / metadata.svar_link.relative_path).resolve() == svar_path.resolve()
+    # Fingerprint matches the source.
+    expected_bytes = (svar_path / "variant_idxs.npy").stat().st_size
+    assert metadata.svar_link.fingerprint.variant_idxs_bytes == expected_bytes
+    assert metadata.svar_link.fingerprint.n_variants > 0
+```
+
+- [ ] **Step 2: Run it to verify failure**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py::test_write_from_svar_records_svar_link_and_no_symlink -v`
+Expected: FAIL — `link.svar` symlink still exists and `metadata.svar_link is None`.
+
+- [ ] **Step 3: Update `_write_from_svar`**
+
+In `python/genvarloader/_dataset/_write.py`, locate the line at the end of `_write_from_svar`:
+
+```python
+    (out_dir / "link.svar").symlink_to(svar.path.resolve(), target_is_directory=True)
+```
+
+Replace it with:
+
+```python
+    import os as _os
+
+    from ._svar_link import SvarFingerprint, SvarLink as _SvarLink
+
+    svar_resolved = svar.path.resolve()
+    variant_idxs_path = svar_resolved / "variant_idxs.npy"
+    svar_link_obj = _SvarLink(
+        relative_path=_os.path.relpath(svar_resolved, start=out_dir.parent).replace(
+            _os.sep, "/"
+        ),
+        absolute_path=str(svar_resolved),
+        fingerprint=SvarFingerprint(
+            n_variants=svar.index.height,
+            variant_idxs_bytes=variant_idxs_path.stat().st_size,
+        ),
+    )
+    # Store it on the in-memory metadata dict so `write()` serializes it.
+    # _write_from_svar can't see `metadata` directly — return it.
+    # See updated return below.
+```
+
+The return signature must change so `write()` can pick up the `SvarLink`. Change the function signature and final return:
+
+```python
+def _write_from_svar(
+    path: Path,
+    bed: pl.DataFrame,
+    svar: SparseVar,
+    samples: list[str],
+    extend_to_length: bool,
+) -> tuple[pl.DataFrame, "SvarLink"]:
+    ...
+    return bed.with_columns(chromEnd=pl.Series(max_ends)), svar_link_obj
+```
+
+And in the top-level `write()` function (currently `_write.py:253-256`):
+
+```python
+        elif isinstance(variants, SparseVar):
+            gvl_bed = _write_from_svar(
+                path, gvl_bed, variants, samples, extend_to_length
+            )
+```
+
+change to:
+
+```python
+        elif isinstance(variants, SparseVar):
+            gvl_bed, _svar_link = _write_from_svar(
+                path, gvl_bed, variants, samples, extend_to_length
+            )
+            metadata["svar_link"] = _svar_link
+```
+
+(The local `import` inside `_write_from_svar` is for clarity; if the linter prefers top-of-file, move `from ._svar_link import SvarFingerprint, SvarLink` to the existing imports block at the top of the file and drop the inline imports.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py::test_write_from_svar_records_svar_link_and_no_symlink -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run all dataset tests**
+
+Run: `pixi run -e dev pytest tests/dataset/ -v -x --timeout=120`
+Expected: All PASS. (Existing tests should still work because read-side resolution is changed in Task 6, but they ran from the existing symlink layout — until you regenerate, you'll have a mix. Re-run `pixi run -e dev gen` first if pre-existing fixture data still expects the old layout. If gen-produced data is read-only test input, it's fine to leave; tests in this file produce their own dataset via `gvl.write`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/genvarloader/_dataset/_write.py tests/dataset/test_svar_link.py
+git commit -m "feat(write): record SvarLink in metadata, drop link.svar symlink"
+```
+
+---
+
+## Task 6: Implement `_resolve_svar` and `_verify_fingerprint`
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_svar_link.py`
+- Test: `tests/dataset/test_svar_link.py`
+
+- [ ] **Step 1: Write failing tests for each resolution branch**
+
+Append to `tests/dataset/test_svar_link.py`:
+
+```python
+from genvarloader._dataset._svar_link import _resolve_svar, _verify_fingerprint
+
+
+def _make_link(svar_path: Path, gvl_path: Path, override_bytes: int | None = None):
+    return SvarLink(
+        relative_path=str(Path("../") / svar_path.name),  # not necessarily correct, test resolver handles it
+        absolute_path=str(svar_path.resolve()),
+        fingerprint=SvarFingerprint(
+            n_variants=10,
+            variant_idxs_bytes=override_bytes
+            if override_bytes is not None
+            else (svar_path / "variant_idxs.npy").stat().st_size,
+        ),
+    )
+
+
+def test_resolve_svar_prefers_override(svar_dataset_paths, tmp_path):
+    gvl_path, svar_path = svar_dataset_paths
+    # Pretend the recorded paths are nonsense — override still wins.
+    link = SvarLink(
+        relative_path="does/not/exist",
+        absolute_path="/does/not/exist",
+        fingerprint=SvarFingerprint(
+            n_variants=1,
+            variant_idxs_bytes=(svar_path / "variant_idxs.npy").stat().st_size,
+        ),
+    )
+    resolved = _resolve_svar(gvl_path, link, override=svar_path)
+    assert resolved == svar_path
+
+
+def test_resolve_svar_uses_relative_path(svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    metadata = Metadata.model_validate_json((gvl_path / "metadata.json").read_text())
+    resolved = _resolve_svar(gvl_path, metadata.svar_link, override=None)
+    assert resolved.resolve() == svar_path.resolve()
+
+
+def test_resolve_svar_falls_back_to_sibling(tmp_path, svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    sibling_target = gvl_path.parent / "sibling.svar"
+    shutil.copytree(svar_path, sibling_target)
+
+    # Build a link with broken relative/absolute paths.
+    link = SvarLink(
+        relative_path="nowhere",
+        absolute_path="/nowhere",
+        fingerprint=SvarFingerprint(
+            n_variants=1,
+            variant_idxs_bytes=(sibling_target / "variant_idxs.npy").stat().st_size,
+        ),
+    )
+    resolved = _resolve_svar(gvl_path, link, override=None)
+    assert resolved.resolve() == sibling_target.resolve()
+
+
+def test_resolve_svar_raises_when_not_found(tmp_path):
+    gvl_path = tmp_path / "ds.gvl"
+    gvl_path.mkdir()
+    link = SvarLink(
+        relative_path="nowhere",
+        absolute_path="/nowhere",
+        fingerprint=SvarFingerprint(n_variants=1, variant_idxs_bytes=1),
+    )
+    with pytest.raises(FileNotFoundError, match="svar="):
+        _resolve_svar(gvl_path, link, override=None)
+
+
+def test_verify_fingerprint_mismatch_raises(svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    bogus_link = SvarLink(
+        relative_path=str(svar_path),
+        absolute_path=str(svar_path),
+        fingerprint=SvarFingerprint(n_variants=999999, variant_idxs_bytes=1),
+    )
+    with pytest.raises(ValueError, match="fingerprint"):
+        _verify_fingerprint(svar_path, bogus_link)
+
+
+def test_verify_fingerprint_ok(svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    metadata = Metadata.model_validate_json((gvl_path / "metadata.json").read_text())
+    _verify_fingerprint(svar_path, metadata.svar_link)  # does not raise
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py -v`
+Expected: the new resolver/verifier tests FAIL — `_resolve_svar`, `_verify_fingerprint` not defined.
+
+- [ ] **Step 3: Implement `_resolve_svar` and `_verify_fingerprint`**
+
+Edit `python/genvarloader/_dataset/_svar_link.py`, appending:
+
+```python
+import json
+
+
+def _resolve_svar(
+    gvl_path: Path,
+    link: SvarLink | None,
+    override: Path | str | None,
+) -> Path:
+    """Resolve the SVAR directory referenced by a GVL dataset.
+
+    Order: override → link.relative_path → link.absolute_path → sibling *.svar.
+    Raises FileNotFoundError if nothing resolves.
+    """
+    if override is not None:
+        p = Path(override)
+        if not p.is_dir():
+            raise FileNotFoundError(
+                f"svar override path does not exist or is not a directory: {p}"
+            )
+        return p
+
+    if link is not None:
+        rel = (gvl_path / link.relative_path).resolve()
+        if rel.is_dir():
+            return rel
+        absp = Path(link.absolute_path)
+        if absp.is_dir():
+            return absp
+
+    siblings = sorted(gvl_path.parent.glob("*.svar"))
+    if len(siblings) == 1:
+        return siblings[0]
+
+    expected = (
+        Path(link.absolute_path).name if link is not None else "<unknown>.svar"
+    )
+    raise FileNotFoundError(
+        f"Could not locate svar '{expected}' for GVL dataset at {gvl_path}. "
+        f"Tried: stored relative path, stored absolute path, sibling *.svar. "
+        f"Pass `svar=` to `Dataset.open(...)` to override."
+    )
+
+
+def _verify_fingerprint(svar_path: Path, link: SvarLink | None) -> None:
+    """Compare the recorded fingerprint against the resolved svar. Raises ValueError on mismatch.
+
+    Skips silently when `link` is None (legacy dataset path).
+    """
+    if link is None:
+        return
+
+    variant_idxs = svar_path / "variant_idxs.npy"
+    if not variant_idxs.exists():
+        raise FileNotFoundError(
+            f"Expected variant_idxs.npy at {variant_idxs}; the resolved svar is malformed."
+        )
+
+    observed_bytes = variant_idxs.stat().st_size
+
+    # SparseVar's own metadata records n_variants implicitly via its index;
+    # to avoid importing genoray here, read variant_idxs.npy's shape via numpy header.
+    # But simpler: trust the byte size as the primary check, and read index.arrow row count.
+    try:
+        import polars as pl
+
+        n_variants_observed = pl.scan_ipc(svar_path / "index.arrow").select(
+            pl.len()
+        ).collect().item()
+    except Exception as exc:
+        raise ValueError(
+            f"Could not read variant index at {svar_path / 'index.arrow'}: {exc}"
+        ) from exc
+
+    exp = link.fingerprint
+    mismatches = []
+    if n_variants_observed != exp.n_variants:
+        mismatches.append(
+            f"n_variants: expected {exp.n_variants}, observed {n_variants_observed}"
+        )
+    if observed_bytes != exp.variant_idxs_bytes:
+        mismatches.append(
+            f"variant_idxs_bytes: expected {exp.variant_idxs_bytes}, "
+            f"observed {observed_bytes}"
+        )
+    if mismatches:
+        raise ValueError(
+            f"svar fingerprint mismatch at {svar_path}: " + "; ".join(mismatches)
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genvarloader/_dataset/_svar_link.py tests/dataset/test_svar_link.py
+git commit -m "feat(dataset): add _resolve_svar and _verify_fingerprint"
+```
+
+---
+
+## Task 7: Wire the resolver into `Haps.from_path` with version-dispatched legacy fallback
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_reconstruct.py:219-275`
+- Modify: `python/genvarloader/_dataset/_impl.py:121-225`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/dataset/test_svar_link.py`:
+
+```python
+import warnings
+
+
+def test_open_dataset_after_relocation_via_override(tmp_path, svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    moved = tmp_path / "moved.svar"
+    shutil.move(str(svar_path), str(moved))
+
+    ds = gvl.Dataset.open(gvl_path, svar=moved)
+    _ = ds[0, 0]  # force eager load
+
+
+def test_open_dataset_mismatched_svar_raises(tmp_path, svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    fake = tmp_path / "fake.svar"
+    shutil.copytree(svar_path, fake)
+    # Truncate variant_idxs.npy to change its size (but keep file usable as path).
+    target = fake / "variant_idxs.npy"
+    target.write_bytes(target.read_bytes()[:-8])
+    with pytest.raises(ValueError, match="fingerprint"):
+        gvl.Dataset.open(gvl_path, svar=fake)
+
+
+def test_open_dataset_legacy_symlink_layout(tmp_path, svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    # Synthesize a legacy dataset: bump version down, strip svar_link, restore symlink.
+    meta_path = gvl_path / "metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta["version"] = "0.18.0"
+    meta.pop("svar_link", None)
+    meta_path.write_text(json.dumps(meta))
+    (gvl_path / "genotypes" / "link.svar").symlink_to(
+        svar_path.resolve(), target_is_directory=True
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ds = gvl.Dataset.open(gvl_path)
+        _ = ds[0, 0]
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and "link.svar" in str(w.message)
+            for w in caught
+        )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py::test_open_dataset_after_relocation_via_override -v`
+Expected: FAIL — `Dataset.open` does not accept `svar=`.
+
+- [ ] **Step 3: Update `Haps.from_path`**
+
+In `python/genvarloader/_dataset/_reconstruct.py`, change the `from_path` signature (around line 219-231) by adding two new keyword params after `version`:
+
+```python
+        version: SemanticVersion | None,
+        svar_link: "SvarLink | None" = None,
+        svar_override: Path | str | None = None,
+```
+
+Add imports near the top of the file:
+
+```python
+import warnings
+from pathlib import Path
+
+from ._svar_link import SvarLink, _resolve_svar, _verify_fingerprint
+```
+
+Replace the body of the `if svar_meta_path.exists():` branch (currently `_reconstruct.py:235-260`) — which is currently keyed on the existence of `svar_meta.json` — with version-dispatched logic:
+
+```python
+        if svar_meta_path.exists():
+            with open(svar_meta_path) as f:
+                metadata = json.load(f)
+            shape = cast(tuple[int, ...], tuple(metadata["shape"]))
+            dtype = np.dtype(metadata["dtype"])
+
+            offset_path = path / "genotypes" / "offsets.npy"
+
+            # Decide which layout to read from.
+            NEXT_VERSION = SemanticVersion("NEXT_VERSION")  # substitute literal
+            is_new_layout = (
+                svar_link is not None
+                and version is not None
+                and version >= NEXT_VERSION
+            )
+
+            if is_new_layout:
+                svar_path = _resolve_svar(path, svar_link, svar_override)
+                _verify_fingerprint(svar_path, svar_link)
+            else:
+                legacy_link = path / "genotypes" / "link.svar"
+                if not legacy_link.exists():
+                    raise FileNotFoundError(
+                        f"Legacy GVL dataset at {path} is missing its link.svar "
+                        f"symlink and has no svar_link metadata. "
+                        f"Pass `svar=` to Dataset.open(...) to recover, or "
+                        f"re-run `gvl.write`."
+                    )
+                warnings.warn(
+                    f"GVL dataset at {path} uses the legacy link.svar symlink. "
+                    f"Run `genvarloader.migrate_svar_link(path)` to upgrade.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                svar_path = legacy_link.resolve()
+
+            geno_path = svar_path / "variant_idxs.npy"
+            dosage_path = svar_path / "dosages.npy"
+
+            offsets = np.memmap(offset_path, shape=shape, dtype=dtype, mode="r")
+            v_idxs = np.memmap(geno_path, dtype=V_IDX_TYPE, mode="r")
+            rag_shape = (*shape[1:], None)
+            genotypes = Ragged.from_offsets(v_idxs, rag_shape, offsets.reshape(2, -1))
+
+            if dosage_path.exists():
+                dosages = np.memmap(dosage_path, dtype=DOSAGE_TYPE, mode="r")
+                dosages = Ragged.from_offsets(
+                    dosages, rag_shape, offsets.reshape(2, -1)
+                )
+
+            logger.info("Loading variant data.")
+            variants = _Variants.from_table(svar_path / "index.arrow")
+```
+
+(Note: the `dosages = None` on line 233 of the original is preserved before the `if`.)
+
+- [ ] **Step 4: Update `Dataset.open` in `_impl.py`**
+
+In `python/genvarloader/_dataset/_impl.py`, add `svar: str | Path | None = None` as a keyword-only argument to all three `Dataset.open` definitions (two `@overload` + the impl, currently lines 86-133). Example for the implementation:
+
+```python
+    @staticmethod
+    def open(
+        path: str | Path,
+        reference: str | Path | Reference | None = None,
+        jitter: int = 0,
+        rng: int | np.random.Generator | None = False,
+        deterministic: bool = True,
+        rc_neg: bool = True,
+        min_af: float | None = None,
+        max_af: float | None = None,
+        region_names: str | None = None,
+        splice_info: str | tuple[str, str] | None = None,
+        var_filter: Literal["exonic"] | None = None,
+        *,
+        svar: str | Path | None = None,
+    ) -> RaggedDataset[MaybeRSEQ, MaybeRTRK]:
+```
+
+(Apply the same trailing `*, svar: str | Path | None = None` to the two `@overload` stubs.)
+
+In the docstring, under Parameters, add:
+
+```
+        svar
+            Override the recorded SVAR location. Use when the original SVAR has
+            moved and the dataset cannot find it via the stored relative/absolute
+            path or by sibling discovery.
+```
+
+Then, at the `Haps.from_path(...)` call site (currently `_impl.py:209-219`), thread the new args:
+
+```python
+            seqs = Haps.from_path(
+                path=path,
+                reference=reference,
+                regions=regions,
+                samples=samples,
+                ploidy=ploidy,
+                version=metadata.version,
+                svar_link=metadata.svar_link,
+                svar_override=svar,
+                min_af=min_af,
+                max_af=max_af,
+                filter=var_filter,
+            )
+```
+
+- [ ] **Step 5: Run all the new tests**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Run the full dataset test suite to catch regressions**
+
+Run: `pixi run -e dev pytest tests/dataset/ -v -x --timeout=120`
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add python/genvarloader/_dataset/_reconstruct.py python/genvarloader/_dataset/_impl.py tests/dataset/test_svar_link.py
+git commit -m "feat(dataset): version-dispatched svar resolution with legacy fallback"
+```
+
+---
+
+## Task 8: Implement `migrate_svar_link` and expose it on the package
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_svar_link.py`
+- Modify: `python/genvarloader/__init__.py`
+- Test: `tests/dataset/test_svar_link.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/dataset/test_svar_link.py`:
+
+```python
+def test_migrate_svar_link_upgrades_legacy_dataset(tmp_path, svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    # Synthesize a legacy dataset (same as the legacy-open test).
+    meta_path = gvl_path / "metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta["version"] = "0.18.0"
+    meta.pop("svar_link", None)
+    meta_path.write_text(json.dumps(meta))
+    (gvl_path / "genotypes" / "link.svar").symlink_to(
+        svar_path.resolve(), target_is_directory=True
+    )
+
+    gvl.migrate_svar_link(gvl_path)
+
+    upgraded = json.loads(meta_path.read_text())
+    assert "svar_link" in upgraded and upgraded["svar_link"] is not None
+    assert upgraded["version"] == "NEXT_VERSION"  # substitute literal
+    assert not (gvl_path / "genotypes" / "link.svar").exists()
+
+    # Dataset still opens normally — no DeprecationWarning this time.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ds = gvl.Dataset.open(gvl_path)
+        _ = ds[0, 0]
+        assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_migrate_svar_link_is_idempotent(svar_dataset_paths):
+    gvl_path, _ = svar_dataset_paths
+    # Already on the new layout from the fixture; migrate is a no-op.
+    before = (gvl_path / "metadata.json").read_text()
+    gvl.migrate_svar_link(gvl_path)
+    after = (gvl_path / "metadata.json").read_text()
+    assert before == after
+
+
+def test_migrate_svar_link_refuses_dangling_symlink(tmp_path, svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    meta_path = gvl_path / "metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta["version"] = "0.18.0"
+    meta.pop("svar_link", None)
+    meta_path.write_text(json.dumps(meta))
+    (gvl_path / "genotypes" / "link.svar").symlink_to(
+        tmp_path / "does_not_exist.svar", target_is_directory=True
+    )
+    with pytest.raises(FileNotFoundError):
+        gvl.migrate_svar_link(gvl_path)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py::test_migrate_svar_link_upgrades_legacy_dataset -v`
+Expected: FAIL — `gvl.migrate_svar_link` is undefined.
+
+- [ ] **Step 3: Implement `migrate_svar_link`**
+
+Append to `python/genvarloader/_dataset/_svar_link.py`:
+
+```python
+import os
+from typing import Union
+
+from pydantic_extra_types.semantic_version import SemanticVersion
+
+NEXT_VERSION = SemanticVersion("NEXT_VERSION")  # substitute literal at top of file
+
+
+def migrate_svar_link(gvl_path: Union[str, Path]) -> None:
+    """Upgrade a pre-NEXT_VERSION GVL dataset's `link.svar` symlink into
+    a `Metadata.svar_link` entry, then remove the symlink.
+
+    Idempotent. No-op if the dataset already carries `svar_link`.
+    Raises FileNotFoundError if the legacy symlink is dangling.
+    """
+    gvl_path = Path(gvl_path)
+    meta_path = gvl_path / "metadata.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(f"No metadata.json at {meta_path}")
+
+    raw = json.loads(meta_path.read_text())
+    if raw.get("svar_link") is not None:
+        return  # already migrated
+
+    symlink = gvl_path / "genotypes" / "link.svar"
+    if not symlink.exists() and not symlink.is_symlink():
+        return  # dataset has no svar dependency; nothing to do
+
+    target = symlink.resolve(strict=False)
+    if not target.is_dir():
+        raise FileNotFoundError(
+            f"link.svar at {symlink} points to {target}, which does not exist. "
+            f"Cannot migrate."
+        )
+
+    variant_idxs = target / "variant_idxs.npy"
+    import polars as pl  # delayed to keep cold-import cheap
+
+    n_variants = pl.scan_ipc(target / "index.arrow").select(pl.len()).collect().item()
+
+    link = SvarLink(
+        relative_path=os.path.relpath(target, start=gvl_path).replace(os.sep, "/"),
+        absolute_path=str(target),
+        fingerprint=SvarFingerprint(
+            n_variants=n_variants,
+            variant_idxs_bytes=variant_idxs.stat().st_size,
+        ),
+    )
+
+    raw["svar_link"] = link.model_dump()
+    raw["version"] = str(NEXT_VERSION)
+
+    # Atomic-ish rewrite.
+    tmp = meta_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(raw))
+    tmp.replace(meta_path)
+
+    symlink.unlink()
+```
+
+- [ ] **Step 4: Re-export from the package**
+
+Edit `python/genvarloader/__init__.py` — append (or place with other imports):
+
+```python
+from ._dataset._svar_link import migrate_svar_link  # noqa: F401
+```
+
+If there is an `__all__`, add `"migrate_svar_link"` to it.
+
+- [ ] **Step 5: Run tests**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/genvarloader/_dataset/_svar_link.py python/genvarloader/__init__.py tests/dataset/test_svar_link.py
+git commit -m "feat: add migrate_svar_link for upgrading legacy datasets"
+```
+
+---
+
+## Task 9: Roundtrip-relocation test (relative path preserved)
+
+**Files:**
+- Test: `tests/dataset/test_svar_link.py`
+
+- [ ] **Step 1: Add the test**
+
+Append to `tests/dataset/test_svar_link.py`:
+
+```python
+def test_open_after_joint_relocation_preserves_relative(tmp_path, svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+
+    # Move both into a new parent, preserving sibling layout.
+    new_parent = tmp_path / "relocated"
+    new_parent.mkdir()
+    new_gvl = new_parent / gvl_path.name
+    new_svar = new_parent / svar_path.name
+    shutil.move(str(gvl_path), str(new_gvl))
+    shutil.move(str(svar_path), str(new_svar))
+
+    ds = gvl.Dataset.open(new_gvl)
+    _ = ds[0, 0]
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pixi run -e dev pytest tests/dataset/test_svar_link.py::test_open_after_joint_relocation_preserves_relative -v`
+Expected: PASS — relative_path resolves correctly.
+
+If it fails, the relative path computed in Task 5 likely used the wrong base; double-check it computes relative to `out_dir.parent` (i.e., the dataset root), not `out_dir` itself.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/dataset/test_svar_link.py
+git commit -m "test: cover GVL+svar joint relocation via stored relative path"
+```
+
+---
+
+## Task 10: Write `docs/source/format.md` and update toctree
+
+**Files:**
+- Create: `docs/source/format.md`
+- Modify: `docs/source/index.md`
+
+- [ ] **Step 1: Create the format doc**
+
+Create `docs/source/format.md`:
+
+````markdown
+# Dataset format
+
+A GVL dataset is a directory written by [`gvl.write`](api.md#genvarloader.write) and read
+by [`gvl.Dataset.open`](api.md#genvarloader.Dataset.open). This page is the authoritative
+description of its on-disk layout.
+
+## Directory layout
+
+```
+dataset_dir/
+├── metadata.json          # the Metadata schema (below)
+├── input_regions.arrow    # original BED regions + region-index map
+├── genotypes/             # present iff variants were provided to gvl.write
+│   ├── offsets.npy        # per (region, sample, ploidy) offsets into variant_idxs.npy
+│   ├── svar_meta.json     # shape + dtype of offsets.npy — present iff source was .svar
+│   ├── variant_idxs.npy   # variant indices; absent when sourced from .svar
+│   ├── dosages.npy        # optional, absent when sourced from .svar
+│   └── variants.arrow     # variant table; absent when sourced from .svar
+└── intervals/             # or annot_intervals/ when annotated; present iff tracks given
+```
+
+When the dataset was built from an `.svar`, the heavy per-variant arrays (`variant_idxs.npy`,
+`dosages.npy`, `index.arrow`) are **not duplicated** into the dataset. Instead the dataset
+records a back-reference to the source `.svar` in `metadata.json` (see `svar_link` below).
+
+## `metadata.json` schema
+
+`metadata.json` is the serialization of `genvarloader._dataset._write.Metadata`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `samples` | `list[str]` | Sample identifiers, sorted. |
+| `contigs` | `list[str]` | Contig names used to interpret BED coords. |
+| `n_regions` | `int` | Number of regions (after jitter padding). |
+| `ploidy` | `int \| None` | Ploidy when the dataset has genotypes. |
+| `max_jitter` | `int` | Maximum coordinate jitter (defaults to 0). |
+| `version` | `SemanticVersion \| None` | Package version that wrote this dataset. Drives format dispatch. |
+| `svar_link` | `SvarLink \| None` | Back-reference to a source `.svar`, when present. |
+
+`SvarLink`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `relative_path` | `str` | POSIX path from `dataset_dir` to the `.svar`. |
+| `absolute_path` | `str` | Original absolute path; used as a fallback. |
+| `fingerprint` | `SvarFingerprint` | Integrity check (see below). |
+
+`SvarFingerprint`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `n_variants` | `int` | Row count of the svar's `index.arrow`. |
+| `variant_idxs_bytes` | `int` | Byte size of the svar's `variant_idxs.npy`. |
+
+## SVAR resolution at open time
+
+When opening a dataset whose `metadata.svar_link` is non-null,
+[`Dataset.open`](api.md#genvarloader.Dataset.open) resolves the svar in this order:
+
+1. Caller-provided `svar=...` argument.
+2. `svar_link.relative_path` resolved against the dataset directory.
+3. `svar_link.absolute_path`.
+4. A unique `*.svar` directory next to the dataset.
+
+If none match, a `FileNotFoundError` is raised naming the expected `.svar` basename. After
+resolution, the fingerprint is verified; a mismatch raises `ValueError` and lists both
+expected and observed values.
+
+## Format changelog
+
+| Version | Change |
+|---------|--------|
+| `< 0.18.0` | Variant coordinates stored 0-based. |
+| `0.18.0` | Variant coordinates switched to 1-based. |
+| `NEXT_VERSION` | `metadata.json` gains `svar_link`; old `genotypes/link.svar` symlink layout deprecated. `Metadata.version` typed as `SemanticVersion` (on-disk JSON unchanged). |
+
+> **Upgrading legacy datasets.** A dataset written before `NEXT_VERSION` that was built from
+> an `.svar` will still open (with a `DeprecationWarning`). Run
+> `genvarloader.migrate_svar_link(path)` to convert the symlink layout to the new metadata
+> layout in place.
+
+````
+
+Substitute the literal `NEXT_VERSION` value in the changelog table.
+
+- [ ] **Step 2: Add to toctree**
+
+In `docs/source/index.md`, edit the toctree at the top:
+
+```
+dataset
+write
+format
+geuvadis
+...
+```
+
+(Insert `format` after `write` and before `geuvadis`.)
+
+- [ ] **Step 3: Build the docs to confirm rendering**
+
+Run: `pixi run -e docs doc`
+Expected: build succeeds with no warnings about missing references.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/source/format.md docs/source/index.md
+git commit -m "docs: add dataset on-disk format reference + changelog"
+```
+
+---
+
+## Task 11: Final verification
+
+- [ ] **Step 1: Full test suite**
+
+Run: `pixi run -e dev pytest tests/ -v --timeout=300`
+Expected: all tests pass.
+
+- [ ] **Step 2: Lint**
+
+Run: `pixi run -e dev ruff check python/`
+Then: `pixi run -e dev basedpyright python/`
+Expected: clean (or only pre-existing issues).
+
+- [ ] **Step 3: Confirm no `Version` from `packaging` left in the project**
+
+Run: `grep -rn 'from packaging.version' python/`
+Expected: no matches (or only matches outside the dataset module if any).
+
+- [ ] **Step 4: Confirm no `link.svar` writes remain**
+
+Run: `grep -rn 'link.svar' python/`
+Expected: only matches inside the legacy-fallback branch of `_reconstruct.py` and the migration code in `_svar_link.py`.
+
+- [ ] **Step 5: Commit any cleanup**
+
+If any small fixups are needed, commit them now. Otherwise this is a no-op.

--- a/docs/superpowers/plans/2026-05-21-svar-link-replacement.md
+++ b/docs/superpowers/plans/2026-05-21-svar-link-replacement.md
@@ -55,7 +55,7 @@ Edit `pyproject.toml`, in the `[project] dependencies` array (the same one that 
 - [ ] **Step 3: Install and verify**
 
 Run: `pixi install -e dev`
-Then: `pixi run -e dev python -c "from pydantic_extra_types.semantic_version import SemanticVersion; print(SemanticVersion('0.18.0'))"`
+Then: `pixi run -e dev python -c "from pydantic_extra_types.semantic_version import SemanticVersion; print(SemanticVersion.parse('0.18.0'))"`
 Expected: `0.18.0` printed; no ImportError.
 
 - [ ] **Step 4: Commit**
@@ -175,7 +175,7 @@ def test_metadata_version_parses_existing_strings():
     )
     m = Metadata.model_validate_json(payload)
     assert isinstance(m.version, SemanticVersion)
-    assert m.version == SemanticVersion("0.18.0")
+    assert m.version == SemanticVersion.parse("0.18.0")
 
 
 def test_metadata_version_serializes_back_to_string():
@@ -183,7 +183,7 @@ def test_metadata_version_serializes_back_to_string():
         samples=["s1"],
         contigs=["1"],
         n_regions=1,
-        version=SemanticVersion("0.18.0"),
+        version=SemanticVersion.parse("0.18.0"),
     )
     dumped = json.loads(m.model_dump_json())
     assert dumped["version"] == "0.18.0"
@@ -274,9 +274,9 @@ Append to `tests/dataset/test_svar_link.py`:
 ```python
 def test_semantic_version_ordering_for_one_based_dispatch():
     """The legacy comparison '>= 0.18.0' must still work under SemanticVersion."""
-    assert SemanticVersion("0.18.0") >= SemanticVersion("0.18.0")
-    assert SemanticVersion("0.20.0") >= SemanticVersion("0.18.0")
-    assert not (SemanticVersion("0.17.5") >= SemanticVersion("0.18.0"))
+    assert SemanticVersion.parse("0.18.0") >= SemanticVersion.parse("0.18.0")
+    assert SemanticVersion.parse("0.20.0") >= SemanticVersion.parse("0.18.0")
+    assert not (SemanticVersion.parse("0.17.5") >= SemanticVersion.parse("0.18.0"))
 ```
 
 - [ ] **Step 2: Run it to verify the lib comparison works**
@@ -319,7 +319,7 @@ Replace line 265:
 with:
 
 ```python
-                one_based=version is not None and version >= SemanticVersion("0.18.0"),
+                one_based=version is not None and version >= SemanticVersion.parse("0.18.0"),
 ```
 
 - [ ] **Step 4: Run the dataset tests to ensure nothing regressed**
@@ -785,7 +785,7 @@ Replace the body of the `if svar_meta_path.exists():` branch (currently `_recons
             offset_path = path / "genotypes" / "offsets.npy"
 
             # Decide which layout to read from.
-            NEXT_VERSION = SemanticVersion("NEXT_VERSION")  # substitute literal
+            NEXT_VERSION = SemanticVersion.parse("0.25.0")  # substitute literal
             is_new_layout = (
                 svar_link is not None
                 and version is not None
@@ -980,7 +980,7 @@ from typing import Union
 
 from pydantic_extra_types.semantic_version import SemanticVersion
 
-NEXT_VERSION = SemanticVersion("NEXT_VERSION")  # substitute literal at top of file
+NEXT_VERSION = SemanticVersion.parse("0.25.0")  # substitute literal at top of file
 
 
 def migrate_svar_link(gvl_path: Union[str, Path]) -> None:

--- a/pixi.lock
+++ b/pixi.lock
@@ -168,6 +168,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/21/48/92dddc8df65b576c9d30752650c89301b5222d4ac10187724796cedfd723/pysam-0.24.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl
@@ -200,6 +201,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/85/f4f06a30e63bbbaa42685122b7b0718c43ccb37b6e58f8a160b563b6fc37/selectolax-0.4.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -335,6 +337,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/d9/110de31880016e2afc52d8580b397dbe47615defbf09ca8cf55f56c62165/pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
@@ -370,6 +373,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/96/34/ef34ef77f1ee38fc8e4f9775217a613b452916e633c4f1d98f31db52c4a5/zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -546,6 +550,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/21/48/92dddc8df65b576c9d30752650c89301b5222d4ac10187724796cedfd723/pysam-0.24.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
@@ -595,6 +600,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -743,6 +749,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/d9/110de31880016e2afc52d8580b397dbe47615defbf09ca8cf55f56c62165/pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
@@ -775,6 +782,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/34/ef34ef77f1ee38fc8e4f9775217a613b452916e633c4f1d98f31db52c4a5/zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -971,6 +979,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
@@ -1044,6 +1053,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
@@ -1208,6 +1218,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
@@ -1283,6 +1294,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
@@ -1492,6 +1504,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
@@ -1579,6 +1592,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
@@ -1754,6 +1768,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
@@ -1826,6 +1841,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
@@ -2381,6 +2397,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/21/48/92dddc8df65b576c9d30752650c89301b5222d4ac10187724796cedfd723/pysam-0.24.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl
@@ -2413,6 +2430,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/85/f4f06a30e63bbbaa42685122b7b0718c43ccb37b6e58f8a160b563b6fc37/selectolax-0.4.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -2613,6 +2631,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/2c/d4d96c78e72031f3171fb3a584b557d79d191e9bb4e93747f793c18f8623/fast_histogram-0.14-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/d9/110de31880016e2afc52d8580b397dbe47615defbf09ca8cf55f56c62165/pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
@@ -2645,6 +2664,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/34/ef34ef77f1ee38fc8e4f9775217a613b452916e633c4f1d98f31db52c4a5/zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -2831,6 +2851,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/21/48/92dddc8df65b576c9d30752650c89301b5222d4ac10187724796cedfd723/pysam-0.24.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl
@@ -2863,6 +2884,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/85/f4f06a30e63bbbaa42685122b7b0718c43ccb37b6e58f8a160b563b6fc37/selectolax-0.4.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -2998,6 +3020,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/d9/110de31880016e2afc52d8580b397dbe47615defbf09ca8cf55f56c62165/pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
@@ -3033,6 +3056,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/96/34/ef34ef77f1ee38fc8e4f9775217a613b452916e633c4f1d98f31db52c4a5/zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -3222,6 +3246,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/6d/2e2a80cda66b152ec143ceb1784e56d8abc6abeeeb65f8ef6aa52c731038/pysam-0.24.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/dc/1843828349729a86f8d9f79b19bd6e7eaa358a5682f13a0af667dae0c1d0/cyvcf2-0.32.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl
@@ -3255,6 +3280,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/b2/04438111b57e3591c09dfa9f220609ae1afacf436fba124a328dbdb9b7b2/genvarloader_cli-0.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -3383,6 +3409,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl
@@ -3416,6 +3443,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -3605,6 +3633,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/53/21f7b97e82772caa61541348427f42435120b32961c92d16f9c8ce9757d6/cslug-1.0.0-py3-none-any.whl
@@ -3638,6 +3667,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/91/c9/65f89382870c8cf8277b06680f81ea7621324de4c49fbce7276e0fd17ce5/cyvcf2-0.32.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -3764,6 +3794,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/c2/a70f0dc599de9cdc3fa4a1459b8719157adf170ec7b60158caf3fbb19e66/awkward_cpp-52-cp312-cp312-macosx_11_0_arm64.whl
@@ -3797,6 +3828,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9c/6b/4c343f767fa61131fc03b3de278dfcff024485996d7d6c917b55b0f9ce16/selectolax-0.4.8-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -3988,6 +4020,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/53/21f7b97e82772caa61541348427f42435120b32961c92d16f9c8ce9757d6/cslug-1.0.0-py3-none-any.whl
@@ -4021,6 +4054,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -4148,6 +4182,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/ca/c7eaa8e62db8fb37ce942b1ea0c6d7abfe3786ca193957afa25e71b81b66/pyarrow-21.0.0-cp313-cp313-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl
@@ -4182,6 +4217,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -4487,6 +4523,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/21/48/92dddc8df65b576c9d30752650c89301b5222d4ac10187724796cedfd723/pysam-0.24.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
@@ -4536,6 +4573,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -4748,6 +4786,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/2c/d4d96c78e72031f3171fb3a584b557d79d191e9bb4e93747f793c18f8623/fast_histogram-0.14-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/d9/110de31880016e2afc52d8580b397dbe47615defbf09ca8cf55f56c62165/pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a3/4e184e2800deff39f6bd422b5f2a37019aa5a03dd279789c8b3a7a092a79/seqpro-0.11.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
@@ -4780,6 +4819,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/34/ef34ef77f1ee38fc8e4f9775217a613b452916e633c4f1d98f31db52c4a5/zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/a6/aa38bddc9f8d90e5ce14023f06ccbf642ab5d507da1ffafb031c0f332dc6/numerary-0.4.4-py3-none-any.whl
@@ -11187,6 +11227,7 @@ packages:
   - pyarrow
   - pyranges
   - pydantic>=2,<3
+  - pydantic-extra-types[semver]>=2.10
   - more-itertools
   - tqdm
   - pybigwig
@@ -11855,6 +11896,34 @@ packages:
   - opt-einsum>=3.3 ; extra == 'opt-einsum'
   - pyyaml ; extra == 'pyyaml'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
+  name: pydantic-extra-types
+  version: 2.11.1
+  sha256: 1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1
+  requires_dist:
+  - pydantic>=2.5.2
+  - typing-extensions
+  - cron-converter>=1.2.2 ; extra == 'all'
+  - pendulum>=3.0.0,<4.0.0 ; extra == 'all'
+  - phonenumbers>=8,<10 ; extra == 'all'
+  - pycountry>=23 ; extra == 'all'
+  - pymongo>=4.0.0,<5.0.0 ; extra == 'all'
+  - python-ulid>=1,<2 ; python_full_version < '3.9' and extra == 'all'
+  - python-ulid>=1,<4 ; python_full_version >= '3.9' and extra == 'all'
+  - pytz>=2024.1 ; extra == 'all'
+  - semver>=3.0.2 ; extra == 'all'
+  - semver~=3.0.2 ; extra == 'all'
+  - tzdata>=2024.1 ; extra == 'all'
+  - uuid-utils>=0.6.0 ; python_full_version < '3.14' and extra == 'all'
+  - cron-converter>=1.2.2 ; extra == 'cron'
+  - pendulum>=3.0.0,<4.0.0 ; extra == 'pendulum'
+  - phonenumbers>=8,<10 ; extra == 'phonenumbers'
+  - pycountry>=23 ; extra == 'pycountry'
+  - python-ulid>=1,<2 ; python_full_version < '3.9' and extra == 'python-ulid'
+  - python-ulid>=1,<4 ; python_full_version >= '3.9' and extra == 'python-ulid'
+  - semver>=3.0.2 ; extra == 'semver'
+  - uuid-utils>=0.6.0 ; python_full_version < '3.14' and extra == 'uuid-utils'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/17/d9/110de31880016e2afc52d8580b397dbe47615defbf09ca8cf55f56c62165/pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl
   name: pyarrow
   version: 21.0.0
@@ -14489,6 +14558,11 @@ packages:
   requires_dist:
   - anyio>=3.0.0
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
+  name: semver
+  version: 3.0.4
+  sha256: 9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl
   name: coloredlogs
   version: 15.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pyarrow",
     "pyranges",
     "pydantic>=2,<3",
+    "pydantic-extra-types[semver]>=2.10",
     "more-itertools",
     "tqdm",
     "pybigwig",

--- a/python/genvarloader/__init__.py
+++ b/python/genvarloader/__init__.py
@@ -18,6 +18,7 @@ from ._table import Table
 from ._dataset._impl import ArrayDataset, Dataset, RaggedDataset
 from ._dataset._rag_variants import RaggedVariants
 from ._dataset._reference import RefDataset, Reference
+from ._dataset._svar_link import migrate_svar_link
 from ._dataset._write import get_splice_bed, write
 from ._dummy import get_dummy_dataset
 from ._ragged import RaggedAnnotatedHaps, RaggedIntervals
@@ -29,6 +30,7 @@ __version__ = importlib.metadata.version("genvarloader")
 
 __all__ = [
     "write",
+    "migrate_svar_link",
     "get_splice_bed",
     "Dataset",
     "BigWigs",

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -101,6 +101,8 @@ class Dataset:
         region_names: str | None = None,
         splice_info: str | tuple[str, str] | None = None,
         var_filter: Literal["exonic"] | None = None,
+        *,
+        svar: str | Path | None = None,
     ) -> RaggedDataset[MaybeRSEQ, MaybeRTRK]: ...
     @staticmethod
     @overload
@@ -116,6 +118,8 @@ class Dataset:
         region_names: str | None = None,
         splice_info: str | tuple[str, str] | None = None,
         var_filter: Literal["exonic"] | None = None,
+        *,
+        svar: str | Path | None = None,
     ) -> RaggedDataset[RaggedSeqs, MaybeRTRK]: ...
     @staticmethod
     def open(
@@ -130,6 +134,8 @@ class Dataset:
         region_names: str | None = None,
         splice_info: str | tuple[str, str] | None = None,
         var_filter: Literal["exonic"] | None = None,
+        *,
+        svar: str | Path | None = None,
     ) -> RaggedDataset[MaybeRSEQ, MaybeRTRK]:
         """Open a dataset from a path. If no reference genome is provided, the dataset cannot yield sequences.
         Will initialize the dataset such that it will return tracks and haplotypes (reference sequences if no genotypes) if possible.
@@ -162,6 +168,10 @@ class Dataset:
             If False, splicing will be disabled.
         var_filter
             Whether to filter variants. If set to :code:`"exonic"`, only exonic variants will be applied.
+        svar
+            Override the recorded SVAR location. Use when the original SVAR has
+            moved and the dataset cannot find it via the stored relative/absolute
+            path or by sibling discovery.
         """
         path = Path(path)
         if not path.exists():
@@ -213,6 +223,8 @@ class Dataset:
                 samples=samples,
                 ploidy=ploidy,
                 version=metadata.version,
+                svar_link=metadata.svar_link,
+                svar_override=svar,
                 min_af=min_af,
                 max_af=max_af,
                 filter=var_filter,

--- a/python/genvarloader/_dataset/_reconstruct.py
+++ b/python/genvarloader/_dataset/_reconstruct.py
@@ -19,6 +19,8 @@ from genoray.exprs import ILEN
 from loguru import logger
 from numpy.typing import NDArray
 from pydantic_extra_types.semantic_version import SemanticVersion
+
+import warnings
 from seqpro.rag import OFFSET_TYPE, Ragged
 from tqdm.auto import tqdm
 from typing_extensions import assert_never
@@ -43,6 +45,7 @@ from ._insertion_fill import lower as _lower_insertion_fills
 from ._intervals import intervals_to_tracks, tracks_to_intervals
 from ._rag_variants import RaggedVariants
 from ._reference import Reference, get_reference
+from ._svar_link import SvarLink, _resolve_svar, _verify_fingerprint
 from ._tracks import shift_and_realign_tracks_sparse
 from ._utils import splits_sum_le_value
 
@@ -225,6 +228,8 @@ class Haps(Reconstructor[_H]):
         samples: list[str],
         ploidy: int,
         version: SemanticVersion | None,
+        svar_link: "SvarLink | None" = None,
+        svar_override: "Path | str | None" = None,
         min_af: float | None = None,
         max_af: float | None = None,
         filter: Literal["exonic"] | None = None,
@@ -240,8 +245,38 @@ class Haps(Reconstructor[_H]):
             dtype = np.dtype(metadata["dtype"])
 
             offset_path = path / "genotypes" / "offsets.npy"
-            geno_path = path / "genotypes" / "link.svar" / "variant_idxs.npy"
-            dosage_path = path / "genotypes" / "link.svar" / "dosages.npy"
+
+            if svar_link is not None:
+                svar_path = _resolve_svar(path, svar_link, svar_override)
+                _verify_fingerprint(svar_path, svar_link)
+            else:
+                legacy_link = path / "genotypes" / "link.svar"
+                if svar_override is not None:
+                    svar_path = Path(svar_override)
+                    if not svar_path.is_dir():
+                        raise FileNotFoundError(
+                            f"svar override does not exist: {svar_path}"
+                        )
+                elif legacy_link.exists():
+                    warnings.warn(
+                        f"GVL dataset at {path} uses the legacy link.svar "
+                        f"symlink. Run "
+                        f"`genvarloader.migrate_svar_link({str(path)!r})` "
+                        f"to upgrade.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    svar_path = legacy_link.resolve()
+                else:
+                    raise FileNotFoundError(
+                        f"Legacy GVL dataset at {path} is missing its link.svar "
+                        f"symlink and has no svar_link metadata. "
+                        f"Pass `svar=` to Dataset.open(...) to recover, or "
+                        f"re-run `gvl.write`."
+                    )
+
+            geno_path = svar_path / "variant_idxs.npy"
+            dosage_path = svar_path / "dosages.npy"
 
             offsets = np.memmap(offset_path, shape=shape, dtype=dtype, mode="r")
             v_idxs = np.memmap(geno_path, dtype=V_IDX_TYPE, mode="r")
@@ -255,9 +290,7 @@ class Haps(Reconstructor[_H]):
                 )
 
             logger.info("Loading variant data.")
-            variants = _Variants.from_table(
-                path / "genotypes" / "link.svar" / "index.arrow"
-            )
+            variants = _Variants.from_table(svar_path / "index.arrow")
         else:
             logger.info("Loading variant data.")
             variants = _Variants.from_table(

--- a/python/genvarloader/_dataset/_reconstruct.py
+++ b/python/genvarloader/_dataset/_reconstruct.py
@@ -18,7 +18,7 @@ from genoray._types import DOSAGE_TYPE, POS_TYPE, V_IDX_TYPE
 from genoray.exprs import ILEN
 from loguru import logger
 from numpy.typing import NDArray
-from packaging.version import Version
+from pydantic_extra_types.semantic_version import SemanticVersion
 from seqpro.rag import OFFSET_TYPE, Ragged
 from tqdm.auto import tqdm
 from typing_extensions import assert_never
@@ -224,7 +224,7 @@ class Haps(Reconstructor[_H]):
         regions: NDArray[np.int32],
         samples: list[str],
         ploidy: int,
-        version: Version | None,
+        version: SemanticVersion | None,
         min_af: float | None = None,
         max_af: float | None = None,
         filter: Literal["exonic"] | None = None,
@@ -262,7 +262,8 @@ class Haps(Reconstructor[_H]):
             logger.info("Loading variant data.")
             variants = _Variants.from_table(
                 path / "genotypes" / "variants.arrow",
-                one_based=version is not None and version >= Version("0.18.0"),
+                one_based=version is not None
+                and version >= SemanticVersion.parse("0.18.0"),
             )
             v_idxs = np.memmap(
                 path / "genotypes" / "variant_idxs.npy",

--- a/python/genvarloader/_dataset/_svar_link.py
+++ b/python/genvarloader/_dataset/_svar_link.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -95,3 +97,57 @@ def _verify_fingerprint(svar_path: Path, link: SvarLink | None) -> None:
         raise ValueError(
             f"svar fingerprint mismatch at {svar_path}: " + "; ".join(mismatches)
         )
+
+
+def migrate_svar_link(gvl_path: str | Path) -> None:
+    """Upgrade a legacy GVL dataset's ``link.svar`` symlink to an
+    ``svar_link`` entry in ``metadata.json`` and remove the symlink.
+
+    Idempotent. No-op when ``svar_link`` is already populated, or when the
+    dataset has no SVAR dependency.
+    Raises FileNotFoundError if the legacy symlink is dangling.
+    """
+    gvl_path = Path(gvl_path)
+    meta_path = gvl_path / "metadata.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(f"No metadata.json at {meta_path}")
+
+    raw = json.loads(meta_path.read_text())
+    if raw.get("svar_link") is not None:
+        return
+
+    symlink = gvl_path / "genotypes" / "link.svar"
+    if not (symlink.exists() or symlink.is_symlink()):
+        return
+
+    target = symlink.resolve(strict=False)
+    if not target.is_dir():
+        raise FileNotFoundError(
+            f"link.svar at {symlink} points to {target}, which does not exist. "
+            f"Cannot migrate."
+        )
+
+    variant_idxs = target / "variant_idxs.npy"
+
+    import polars as pl
+
+    n_variants = (
+        pl.scan_ipc(target / "index.arrow").select(pl.len()).collect().item()
+    )
+
+    link = SvarLink(
+        relative_path=os.path.relpath(target, start=gvl_path).replace(os.sep, "/"),
+        absolute_path=str(target),
+        fingerprint=SvarFingerprint(
+            n_variants=n_variants,
+            variant_idxs_bytes=variant_idxs.stat().st_size,
+        ),
+    )
+
+    raw["svar_link"] = link.model_dump()
+
+    tmp = meta_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(raw))
+    tmp.replace(meta_path)
+
+    symlink.unlink()

--- a/python/genvarloader/_dataset/_svar_link.py
+++ b/python/genvarloader/_dataset/_svar_link.py
@@ -70,8 +70,7 @@ def _verify_fingerprint(svar_path: Path, link: SvarLink | None) -> None:
     variant_idxs = svar_path / "variant_idxs.npy"
     if not variant_idxs.exists():
         raise FileNotFoundError(
-            f"Expected variant_idxs.npy at {variant_idxs}; "
-            f"resolved svar is malformed."
+            f"Expected variant_idxs.npy at {variant_idxs}; resolved svar is malformed."
         )
 
     observed_bytes = variant_idxs.stat().st_size
@@ -131,9 +130,7 @@ def migrate_svar_link(gvl_path: str | Path) -> None:
 
     import polars as pl
 
-    n_variants = (
-        pl.scan_ipc(target / "index.arrow").select(pl.len()).collect().item()
-    )
+    n_variants = pl.scan_ipc(target / "index.arrow").select(pl.len()).collect().item()
 
     link = SvarLink(
         relative_path=os.path.relpath(target, start=gvl_path).replace(os.sep, "/"),

--- a/python/genvarloader/_dataset/_svar_link.py
+++ b/python/genvarloader/_dataset/_svar_link.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from pydantic import BaseModel
 
 
@@ -14,3 +16,82 @@ class SvarLink(BaseModel):
     relative_path: str
     absolute_path: str
     fingerprint: SvarFingerprint
+
+
+def _resolve_svar(
+    gvl_path: Path,
+    link: SvarLink | None,
+    override: Path | str | None,
+) -> Path:
+    """Resolve the SVAR directory referenced by a GVL dataset.
+
+    Order: override → link.relative_path → link.absolute_path → sibling *.svar.
+    Raises FileNotFoundError if none resolve to a directory.
+    """
+    if override is not None:
+        p = Path(override)
+        if not p.is_dir():
+            raise FileNotFoundError(
+                f"svar override path does not exist or is not a directory: {p}"
+            )
+        return p
+
+    if link is not None:
+        rel = (gvl_path / link.relative_path).resolve()
+        if rel.is_dir():
+            return rel
+        absp = Path(link.absolute_path)
+        if absp.is_dir():
+            return absp
+
+    siblings = sorted(gvl_path.parent.glob("*.svar"))
+    if len(siblings) == 1:
+        return siblings[0]
+
+    expected = Path(link.absolute_path).name if link is not None else "<unknown>.svar"
+    raise FileNotFoundError(
+        f"Could not locate svar '{expected}' for GVL dataset at {gvl_path}. "
+        f"Tried: stored relative path, stored absolute path, sibling *.svar. "
+        f"Pass `svar=` to `Dataset.open(...)` to override."
+    )
+
+
+def _verify_fingerprint(svar_path: Path, link: SvarLink | None) -> None:
+    """Compare the recorded fingerprint against the resolved svar.
+
+    No-op when ``link`` is None (legacy dataset).
+    Raises ValueError on mismatch, FileNotFoundError on missing variant_idxs.npy.
+    """
+    if link is None:
+        return
+
+    variant_idxs = svar_path / "variant_idxs.npy"
+    if not variant_idxs.exists():
+        raise FileNotFoundError(
+            f"Expected variant_idxs.npy at {variant_idxs}; "
+            f"resolved svar is malformed."
+        )
+
+    observed_bytes = variant_idxs.stat().st_size
+
+    import polars as pl
+
+    n_variants_observed = (
+        pl.scan_ipc(svar_path / "index.arrow").select(pl.len()).collect().item()
+    )
+
+    exp = link.fingerprint
+    mismatches: list[str] = []
+    if n_variants_observed != exp.n_variants:
+        mismatches.append(
+            f"n_variants: expected {exp.n_variants}, observed {n_variants_observed}"
+        )
+    if observed_bytes != exp.variant_idxs_bytes:
+        mismatches.append(
+            f"variant_idxs_bytes: expected {exp.variant_idxs_bytes}, "
+            f"observed {observed_bytes}"
+        )
+    if mismatches:
+        raise ValueError(
+            f"svar fingerprint mismatch at {svar_path}: " + "; ".join(mismatches)
+        )

--- a/python/genvarloader/_dataset/_svar_link.py
+++ b/python/genvarloader/_dataset/_svar_link.py
@@ -1,0 +1,16 @@
+"""Resolution and integrity for the GVL dataset → SVAR back-reference."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SvarFingerprint(BaseModel):
+    n_variants: int
+    variant_idxs_bytes: int
+
+
+class SvarLink(BaseModel):
+    relative_path: str
+    absolute_path: str
+    fingerprint: SvarFingerprint

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -247,9 +247,10 @@ def write(
                 path, gvl_bed, variants, effective_max_mem, extend_to_length
             )
         elif isinstance(variants, SparseVar):
-            gvl_bed = _write_from_svar(
+            gvl_bed, _svar_link = _write_from_svar(
                 path, gvl_bed, variants, samples, extend_to_length
             )
+            metadata["svar_link"] = _svar_link
         metadata["ploidy"] = variants.ploidy
         # free memory
         del variants
@@ -578,7 +579,7 @@ def _write_from_svar(
     svar: SparseVar,
     samples: list[str],
     extend_to_length: bool,
-):
+) -> tuple[pl.DataFrame, SvarLink]:
     out_dir = path / "genotypes"
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -648,9 +649,24 @@ def _write_from_svar(
     pbar.close()
     offsets.flush()
 
-    (out_dir / "link.svar").symlink_to(svar.path.resolve(), target_is_directory=True)
+    import os
 
-    return bed.with_columns(chromEnd=pl.Series(max_ends))
+    from ._svar_link import SvarFingerprint
+
+    svar_resolved = svar.path.resolve()
+    variant_idxs_path = svar_resolved / "variant_idxs.npy"
+    svar_link = SvarLink(
+        relative_path=os.path.relpath(svar_resolved, start=path).replace(
+            os.sep, "/"
+        ),
+        absolute_path=str(svar_resolved),
+        fingerprint=SvarFingerprint(
+            n_variants=svar.index.height,
+            variant_idxs_bytes=variant_idxs_path.stat().st_size,
+        ),
+    )
+
+    return bed.with_columns(chromEnd=pl.Series(max_ends)), svar_link
 
 
 def _write_phased_variants_chunk(

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -656,9 +656,7 @@ def _write_from_svar(
     svar_resolved = svar.path.resolve()
     variant_idxs_path = svar_resolved / "variant_idxs.npy"
     svar_link = SvarLink(
-        relative_path=os.path.relpath(svar_resolved, start=path).replace(
-            os.sep, "/"
-        ),
+        relative_path=os.path.relpath(svar_resolved, start=path).replace(os.sep, "/"),
         absolute_path=str(svar_resolved),
         fingerprint=SvarFingerprint(
             n_variants=svar.index.height,

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -264,7 +264,7 @@ def write(
 
     _metadata = Metadata(**metadata)
     with open(path / "metadata.json", "w") as f:
-        json.dump(_metadata.model_dump(), f)
+        f.write(_metadata.model_dump_json())
 
     logger.info("Finished writing.")
     warnings.simplefilter("default")

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Sequence
 from importlib.metadata import version
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from .._types import IntervalTrack
@@ -22,14 +22,15 @@ from loguru import logger
 from more_itertools import mark_ends
 from natsort import natsorted
 from numpy.typing import NDArray
-from packaging.version import Version
-from pydantic import BaseModel, BeforeValidator, PlainSerializer, WithJsonSchema
+from pydantic import BaseModel
+from pydantic_extra_types.semantic_version import SemanticVersion
 from seqpro.rag import Ragged
 from tqdm.auto import tqdm
 
 from .._ragged import INTERVAL_DTYPE
 from .._utils import lengths_to_offsets, normalize_contig_name
 from .._variants._utils import path_is_pgen, path_is_vcf
+from ._svar_link import SvarLink
 from ._utils import bed_to_regions, splits_sum_le_value
 
 
@@ -39,15 +40,8 @@ class Metadata(BaseModel, arbitrary_types_allowed=True):
     n_regions: int
     ploidy: int | None = None
     max_jitter: int = 0
-    version: (
-        Annotated[
-            Version,
-            BeforeValidator(lambda v: Version(v) if isinstance(v, str) else v),
-            PlainSerializer(lambda v: str(v), return_type=str),
-            WithJsonSchema({"type": "string"}, mode="serialization"),
-        ]
-        | None
-    ) = None
+    version: SemanticVersion | None = None
+    svar_link: SvarLink | None = None
 
     @property
     def n_samples(self) -> int:
@@ -130,7 +124,9 @@ def write(
 
     max_mem = parse_memory(max_mem)
 
-    metadata: dict[str, Any] = {"version": Version(version("genvarloader"))}
+    metadata: dict[str, Any] = {
+        "version": SemanticVersion.parse(version("genvarloader"))
+    }
     path = Path(path)
     if path.exists() and overwrite:
         logger.info("Found existing GVL store, overwriting.")

--- a/tests/dataset/test_svar_link.py
+++ b/tests/dataset/test_svar_link.py
@@ -1,11 +1,17 @@
 import json
+import shutil
 from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 from pydantic_extra_types.semantic_version import SemanticVersion
 
-from genvarloader._dataset._svar_link import SvarFingerprint, SvarLink
+from genvarloader._dataset._svar_link import (
+    SvarFingerprint,
+    SvarLink,
+    _resolve_svar,
+    _verify_fingerprint,
+)
 from genvarloader._dataset._write import Metadata
 
 
@@ -100,3 +106,72 @@ def test_write_from_svar_records_svar_link_and_no_symlink(svar_dataset_paths):
     expected_bytes = (svar_path / "variant_idxs.npy").stat().st_size
     assert metadata.svar_link.fingerprint.variant_idxs_bytes == expected_bytes
     assert metadata.svar_link.fingerprint.n_variants > 0
+
+
+def test_resolve_svar_prefers_override(svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    link = SvarLink(
+        relative_path="does/not/exist",
+        absolute_path="/does/not/exist",
+        fingerprint=SvarFingerprint(
+            n_variants=1,
+            variant_idxs_bytes=(svar_path / "variant_idxs.npy").stat().st_size,
+        ),
+    )
+    assert _resolve_svar(gvl_path, link, override=svar_path) == svar_path
+
+
+def test_resolve_svar_uses_relative_path(svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    metadata = Metadata.model_validate_json(
+        (gvl_path / "metadata.json").read_text()
+    )
+    resolved = _resolve_svar(gvl_path, metadata.svar_link, override=None)
+    assert resolved.resolve() == svar_path.resolve()
+
+
+def test_resolve_svar_falls_back_to_sibling(tmp_path, svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    sibling = gvl_path.parent / "sibling.svar"
+    shutil.copytree(svar_path, sibling)
+    link = SvarLink(
+        relative_path="nowhere",
+        absolute_path="/nowhere",
+        fingerprint=SvarFingerprint(
+            n_variants=1,
+            variant_idxs_bytes=(sibling / "variant_idxs.npy").stat().st_size,
+        ),
+    )
+    resolved = _resolve_svar(gvl_path, link, override=None)
+    assert resolved.resolve() == sibling.resolve()
+
+
+def test_resolve_svar_raises_when_not_found(tmp_path):
+    gvl_path = tmp_path / "ds.gvl"
+    gvl_path.mkdir()
+    link = SvarLink(
+        relative_path="nowhere",
+        absolute_path="/nowhere",
+        fingerprint=SvarFingerprint(n_variants=1, variant_idxs_bytes=1),
+    )
+    with pytest.raises(FileNotFoundError, match="svar="):
+        _resolve_svar(gvl_path, link, override=None)
+
+
+def test_verify_fingerprint_mismatch_raises(svar_dataset_paths):
+    _, svar_path = svar_dataset_paths
+    bogus = SvarLink(
+        relative_path=str(svar_path),
+        absolute_path=str(svar_path),
+        fingerprint=SvarFingerprint(n_variants=999_999, variant_idxs_bytes=1),
+    )
+    with pytest.raises(ValueError, match="fingerprint"):
+        _verify_fingerprint(svar_path, bogus)
+
+
+def test_verify_fingerprint_ok(svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+    metadata = Metadata.model_validate_json(
+        (gvl_path / "metadata.json").read_text()
+    )
+    _verify_fingerprint(svar_path, metadata.svar_link)

--- a/tests/dataset/test_svar_link.py
+++ b/tests/dataset/test_svar_link.py
@@ -175,3 +175,79 @@ def test_verify_fingerprint_ok(svar_dataset_paths):
         (gvl_path / "metadata.json").read_text()
     )
     _verify_fingerprint(svar_path, metadata.svar_link)
+
+
+def test_open_dataset_via_recorded_svar_link(svar_dataset_paths):
+    import genvarloader as gvl
+
+    gvl_path, _ = svar_dataset_paths
+    ref = _DATA_DIR / "fasta" / "hg38.fa.bgz"
+    ds = (
+        gvl.Dataset.open(gvl_path, reference=ref)
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+    _ = ds[0, 0]
+
+
+def test_open_dataset_after_relocation_via_override(tmp_path, svar_dataset_paths):
+    import genvarloader as gvl
+
+    gvl_path, svar_path = svar_dataset_paths
+    moved = tmp_path / "moved.svar"
+    shutil.copytree(svar_path, moved)
+
+    # Break the stored paths by relocating the dataset (so relative & absolute fail).
+    moved_gvl = tmp_path / "elsewhere" / "ds.gvl"
+    moved_gvl.parent.mkdir()
+    shutil.copytree(gvl_path, moved_gvl)
+
+    ref = _DATA_DIR / "fasta" / "hg38.fa.bgz"
+    ds = (
+        gvl.Dataset.open(moved_gvl, reference=ref, svar=moved)
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+    _ = ds[0, 0]
+
+
+def test_open_dataset_mismatched_svar_raises(tmp_path, svar_dataset_paths):
+    import genvarloader as gvl
+
+    gvl_path, svar_path = svar_dataset_paths
+    fake = tmp_path / "fake.svar"
+    shutil.copytree(svar_path, fake)
+    target = fake / "variant_idxs.npy"
+    target.write_bytes(target.read_bytes()[:-8])
+    with pytest.raises(ValueError, match="fingerprint"):
+        gvl.Dataset.open(gvl_path, svar=fake)
+
+
+def test_open_dataset_legacy_symlink_layout(tmp_path, svar_dataset_paths):
+    import warnings as _warnings
+
+    import genvarloader as gvl
+
+    gvl_path, svar_path = svar_dataset_paths
+    meta_path = gvl_path / "metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta["version"] = "0.18.0"
+    meta.pop("svar_link", None)
+    meta_path.write_text(json.dumps(meta))
+    (gvl_path / "genotypes" / "link.svar").symlink_to(
+        svar_path.resolve(), target_is_directory=True
+    )
+
+    ref = _DATA_DIR / "fasta" / "hg38.fa.bgz"
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        ds = (
+            gvl.Dataset.open(gvl_path, reference=ref)
+            .with_seqs("haplotypes")
+            .with_tracks(False)
+        )
+        _ = ds[0, 0]
+        assert any(
+            issubclass(w.category, DeprecationWarning) and "link.svar" in str(w.message)
+            for w in caught
+        )

--- a/tests/dataset/test_svar_link.py
+++ b/tests/dataset/test_svar_link.py
@@ -97,12 +97,12 @@ def test_write_from_svar_records_svar_link_and_no_symlink(svar_dataset_paths):
     link_path = gvl_path / "genotypes" / "link.svar"
     assert not link_path.exists() and not link_path.is_symlink()
 
-    metadata = Metadata.model_validate_json(
-        (gvl_path / "metadata.json").read_text()
-    )
+    metadata = Metadata.model_validate_json((gvl_path / "metadata.json").read_text())
     assert metadata.svar_link is not None
     assert Path(metadata.svar_link.absolute_path) == svar_path.resolve()
-    assert (gvl_path / metadata.svar_link.relative_path).resolve() == svar_path.resolve()
+    assert (
+        gvl_path / metadata.svar_link.relative_path
+    ).resolve() == svar_path.resolve()
     expected_bytes = (svar_path / "variant_idxs.npy").stat().st_size
     assert metadata.svar_link.fingerprint.variant_idxs_bytes == expected_bytes
     assert metadata.svar_link.fingerprint.n_variants > 0
@@ -123,9 +123,7 @@ def test_resolve_svar_prefers_override(svar_dataset_paths):
 
 def test_resolve_svar_uses_relative_path(svar_dataset_paths):
     gvl_path, svar_path = svar_dataset_paths
-    metadata = Metadata.model_validate_json(
-        (gvl_path / "metadata.json").read_text()
-    )
+    metadata = Metadata.model_validate_json((gvl_path / "metadata.json").read_text())
     resolved = _resolve_svar(gvl_path, metadata.svar_link, override=None)
     assert resolved.resolve() == svar_path.resolve()
 
@@ -171,9 +169,7 @@ def test_verify_fingerprint_mismatch_raises(svar_dataset_paths):
 
 def test_verify_fingerprint_ok(svar_dataset_paths):
     gvl_path, svar_path = svar_dataset_paths
-    metadata = Metadata.model_validate_json(
-        (gvl_path / "metadata.json").read_text()
-    )
+    metadata = Metadata.model_validate_json((gvl_path / "metadata.json").read_text())
     _verify_fingerprint(svar_path, metadata.svar_link)
 
 

--- a/tests/dataset/test_svar_link.py
+++ b/tests/dataset/test_svar_link.py
@@ -296,6 +296,26 @@ def test_migrate_svar_link_is_idempotent(svar_dataset_paths):
     assert before == after
 
 
+def test_open_after_joint_relocation_preserves_relative(tmp_path, svar_dataset_paths):
+    import genvarloader as gvl
+
+    gvl_path, svar_path = svar_dataset_paths
+    new_parent = tmp_path / "relocated"
+    new_parent.mkdir()
+    new_gvl = new_parent / gvl_path.name
+    new_svar = new_parent / svar_path.name
+    shutil.copytree(gvl_path, new_gvl)
+    shutil.copytree(svar_path, new_svar)
+
+    ref = _DATA_DIR / "fasta" / "hg38.fa.bgz"
+    ds = (
+        gvl.Dataset.open(new_gvl, reference=ref)
+        .with_seqs("haplotypes")
+        .with_tracks(False)
+    )
+    _ = ds[0, 0]
+
+
 def test_migrate_svar_link_refuses_dangling_symlink(tmp_path, svar_dataset_paths):
     import genvarloader as gvl
 

--- a/tests/dataset/test_svar_link.py
+++ b/tests/dataset/test_svar_link.py
@@ -57,3 +57,10 @@ def test_metadata_version_serializes_back_to_string():
 def test_metadata_svar_link_defaults_to_none():
     m = Metadata(samples=["s1"], contigs=["1"], n_regions=1)
     assert m.svar_link is None
+
+
+def test_semantic_version_ordering_for_one_based_dispatch():
+    """The legacy comparison '>= 0.18.0' must still work under SemanticVersion."""
+    assert SemanticVersion.parse("0.18.0") >= SemanticVersion.parse("0.18.0")
+    assert SemanticVersion.parse("0.20.0") >= SemanticVersion.parse("0.18.0")
+    assert not (SemanticVersion.parse("0.17.5") >= SemanticVersion.parse("0.18.0"))

--- a/tests/dataset/test_svar_link.py
+++ b/tests/dataset/test_svar_link.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from genvarloader._dataset._svar_link import SvarFingerprint, SvarLink
+
+
+def test_svar_link_roundtrip():
+    link = SvarLink(
+        relative_path="../foo.svar",
+        absolute_path="/abs/path/foo.svar",
+        fingerprint=SvarFingerprint(n_variants=10, variant_idxs_bytes=42),
+    )
+    payload = link.model_dump_json()
+    parsed = SvarLink.model_validate_json(payload)
+    assert parsed == link
+
+
+def test_svar_link_rejects_malformed_fingerprint():
+    bad = (
+        '{"relative_path":"a","absolute_path":"b",'
+        '"fingerprint":{"n_variants":"not_an_int","variant_idxs_bytes":1}}'
+    )
+    with pytest.raises(ValidationError):
+        SvarLink.model_validate_json(bad)

--- a/tests/dataset/test_svar_link.py
+++ b/tests/dataset/test_svar_link.py
@@ -64,3 +64,39 @@ def test_semantic_version_ordering_for_one_based_dispatch():
     assert SemanticVersion.parse("0.18.0") >= SemanticVersion.parse("0.18.0")
     assert SemanticVersion.parse("0.20.0") >= SemanticVersion.parse("0.18.0")
     assert not (SemanticVersion.parse("0.17.5") >= SemanticVersion.parse("0.18.0"))
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DATA_DIR = _REPO_ROOT / "tests" / "data"
+
+
+@pytest.fixture
+def svar_dataset_paths(tmp_path):
+    """Produce a fresh GVL dataset built from the canonical test svar."""
+    import genvarloader as gvl
+
+    svar_path = _DATA_DIR / "filtered.svar"
+    bed_path = _DATA_DIR / "source.bed"
+    assert svar_path.is_dir(), f"missing fixture {svar_path}; run pixi run -e dev gen"
+    assert bed_path.exists(), f"missing fixture {bed_path}"
+
+    gvl_path = tmp_path / "ds.gvl"
+    gvl.write(path=gvl_path, bed=bed_path, variants=svar_path, overwrite=True)
+    return gvl_path, svar_path
+
+
+def test_write_from_svar_records_svar_link_and_no_symlink(svar_dataset_paths):
+    gvl_path, svar_path = svar_dataset_paths
+
+    link_path = gvl_path / "genotypes" / "link.svar"
+    assert not link_path.exists() and not link_path.is_symlink()
+
+    metadata = Metadata.model_validate_json(
+        (gvl_path / "metadata.json").read_text()
+    )
+    assert metadata.svar_link is not None
+    assert Path(metadata.svar_link.absolute_path) == svar_path.resolve()
+    assert (gvl_path / metadata.svar_link.relative_path).resolve() == svar_path.resolve()
+    expected_bytes = (svar_path / "variant_idxs.npy").stat().st_size
+    assert metadata.svar_link.fingerprint.variant_idxs_bytes == expected_bytes
+    assert metadata.svar_link.fingerprint.n_variants > 0

--- a/tests/dataset/test_svar_link.py
+++ b/tests/dataset/test_svar_link.py
@@ -251,3 +251,62 @@ def test_open_dataset_legacy_symlink_layout(tmp_path, svar_dataset_paths):
             issubclass(w.category, DeprecationWarning) and "link.svar" in str(w.message)
             for w in caught
         )
+
+
+def test_migrate_svar_link_upgrades_legacy_dataset(tmp_path, svar_dataset_paths):
+    import warnings as _warnings
+
+    import genvarloader as gvl
+
+    gvl_path, svar_path = svar_dataset_paths
+    meta_path = gvl_path / "metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta["version"] = "0.18.0"
+    meta.pop("svar_link", None)
+    meta_path.write_text(json.dumps(meta))
+    (gvl_path / "genotypes" / "link.svar").symlink_to(
+        svar_path.resolve(), target_is_directory=True
+    )
+
+    gvl.migrate_svar_link(gvl_path)
+
+    upgraded = json.loads(meta_path.read_text())
+    assert upgraded.get("svar_link") is not None
+    assert not (gvl_path / "genotypes" / "link.svar").exists()
+
+    ref = _DATA_DIR / "fasta" / "hg38.fa.bgz"
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        ds = (
+            gvl.Dataset.open(gvl_path, reference=ref)
+            .with_seqs("haplotypes")
+            .with_tracks(False)
+        )
+        _ = ds[0, 0]
+        assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_migrate_svar_link_is_idempotent(svar_dataset_paths):
+    import genvarloader as gvl
+
+    gvl_path, _ = svar_dataset_paths
+    before = (gvl_path / "metadata.json").read_text()
+    gvl.migrate_svar_link(gvl_path)
+    after = (gvl_path / "metadata.json").read_text()
+    assert before == after
+
+
+def test_migrate_svar_link_refuses_dangling_symlink(tmp_path, svar_dataset_paths):
+    import genvarloader as gvl
+
+    gvl_path, _ = svar_dataset_paths
+    meta_path = gvl_path / "metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta["version"] = "0.18.0"
+    meta.pop("svar_link", None)
+    meta_path.write_text(json.dumps(meta))
+    (gvl_path / "genotypes" / "link.svar").symlink_to(
+        tmp_path / "does_not_exist.svar", target_is_directory=True
+    )
+    with pytest.raises(FileNotFoundError):
+        gvl.migrate_svar_link(gvl_path)

--- a/tests/dataset/test_svar_link.py
+++ b/tests/dataset/test_svar_link.py
@@ -1,9 +1,12 @@
+import json
 from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
+from pydantic_extra_types.semantic_version import SemanticVersion
 
 from genvarloader._dataset._svar_link import SvarFingerprint, SvarLink
+from genvarloader._dataset._write import Metadata
 
 
 def test_svar_link_roundtrip():
@@ -24,3 +27,33 @@ def test_svar_link_rejects_malformed_fingerprint():
     )
     with pytest.raises(ValidationError):
         SvarLink.model_validate_json(bad)
+
+
+def test_metadata_version_parses_existing_strings():
+    payload = json.dumps(
+        {
+            "samples": ["s1"],
+            "contigs": ["1"],
+            "n_regions": 1,
+            "version": "0.18.0",
+        }
+    )
+    m = Metadata.model_validate_json(payload)
+    assert isinstance(m.version, SemanticVersion)
+    assert m.version == SemanticVersion.parse("0.18.0")
+
+
+def test_metadata_version_serializes_back_to_string():
+    m = Metadata(
+        samples=["s1"],
+        contigs=["1"],
+        n_regions=1,
+        version=SemanticVersion.parse("0.18.0"),
+    )
+    dumped = json.loads(m.model_dump_json())
+    assert dumped["version"] == "0.18.0"
+
+
+def test_metadata_svar_link_defaults_to_none():
+    m = Metadata(samples=["s1"], contigs=["1"], n_regions=1)
+    assert m.svar_link is None


### PR DESCRIPTION
## Summary

- Replaces the brittle `genotypes/link.svar` symlink with a typed `Metadata.svar_link` field (relative + absolute path + fingerprint) serialized into `metadata.json`.
- Adds `Dataset.open(..., svar=...)` to override the recorded SVAR location, plus 4-tier resolution (override → relative → absolute → unique sibling `*.svar`).
- Verifies a light fingerprint (`n_variants`, `variant_idxs.npy` byte size) at open time; mismatch raises `ValueError`.
- Migrates `Metadata.version` from custom-validated `packaging.Version` to `pydantic_extra_types.SemanticVersion`, dropping boilerplate.
- Adds `genvarloader.migrate_svar_link(path)` to upgrade legacy datasets in place; legacy `link.svar` layout still reads with a `DeprecationWarning`.
- New docs page `docs/source/format.md` documents the on-disk format, `Metadata` schema, and a format changelog.

## Design & plan

- Spec: `docs/superpowers/specs/2026-05-21-svar-link-replacement-design.md`
- Plan: `docs/superpowers/plans/2026-05-21-svar-link-replacement.md`

## Test plan

- [x] `pixi run -e dev pytest tests/` — 453 passed, 5 skipped, 2 xfailed
- [x] `pixi run -e dev ruff check python/` — clean
- [x] `pixi run -e docs doc` — builds
- [x] New `tests/dataset/test_svar_link.py` covers: roundtrip schema, version parse/serialize, write-side `svar_link` recorded with no symlink, 4-tier resolver, fingerprint mismatch + ok, open via recorded link, override after relocation, joint relocation preserves relative, legacy symlink still works with `DeprecationWarning`, `migrate_svar_link` upgrades + idempotent + refuses dangling symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)