### PR TITLE
ci(release): fix dry-run gate broken by github.event_name in reusable workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,11 @@ on:
       tag:
         description: 'Tag to release (e.g. v0.25.0)'
         required: true
+      dry_run:
+        description: 'Build the release body but do not create a GH release'
+        type: boolean
+        required: false
+        default: false
   workflow_call:
     inputs:
       tag:
@@ -54,7 +59,7 @@ jobs:
           fi
 
       - name: Dry-run summary
-        if: github.event_name == 'workflow_call' && inputs.dry_run == true
+        if: inputs.dry_run == true
         run: |
           {
             echo "## Dry-run: release ${{ steps.tag.outputs.tag }}"
@@ -67,7 +72,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create GitHub release
-        if: ${{ !(github.event_name == 'workflow_call' && inputs.dry_run == true) }}
+        if: inputs.dry_run == false
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
## Bug

The previous dry-run gate in ``release.yaml`` was:

\`\`\`yaml
- name: Dry-run summary
  if: github.event_name == 'workflow_call' && inputs.dry_run == true
- name: Create GitHub release
  if: \${{ !(github.event_name == 'workflow_call' && inputs.dry_run == true) }}
\`\`\`

In a reusable workflow invoked via ``workflow_call``, ``github.event_name`` is the **parent** trigger (here, ``workflow_dispatch`` from ``release-pipeline.yaml``), **not** ``workflow_call``. So the condition was always false: ``Dry-run summary`` skipped, ``Create GitHub release`` ran.

The dry-run of run [26254656039](https://github.com/mcvickerlab/GenVarLoader/actions/runs/26254656039) consequently created a real ``v0.25.0`` tag and GH release with a placeholder body. The tag and release were manually cleaned up before this PR. PyPI publish, push-to-stable, and the bump commit were not affected — they correctly gate on ``inputs.dry_run`` directly.

## Fix

Gate on ``inputs.dry_run`` directly. Also add ``dry_run`` to the ``workflow_dispatch`` input list so the standalone form supports dry-run too.

## Test plan

- [ ] After merge, dispatch ``Release pipeline`` with ``increment=auto, dry_run=true`` and confirm ``release`` step shows ``Dry-run summary`` ✅ and ``Create GitHub release`` skipped.
- [ ] Confirm no v0.25.0 tag/release is created.