### PR TITLE
ci(release-pipeline): don't pin publish to nonexistent tag in fresh-bump dry-run

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -90,7 +90,11 @@ jobs:
     secrets: inherit
     with:
       dry_run: ${{ inputs.dry_run }}
-      tag: ${{ needs.bump.outputs.tag || needs.resolve.outputs.tag }}
+      # In dry-run + fresh-bump the projected tag does not exist on the remote
+      # (the real bump was skipped), so we can't pin checkouts to it. Fall back
+      # to the caller's ref (main). Real releases and dry-run + skip_bump both
+      # have a real tag to pin to.
+      tag: ${{ (inputs.dry_run == false || inputs.skip_bump == true) && (needs.bump.outputs.tag || needs.resolve.outputs.tag) || '' }}
 
   merge:
     needs: publish


### PR DESCRIPTION
## Bug

Run [26255604817](https://github.com/mcvickerlab/GenVarLoader/actions/runs/26255604817) (fresh-bump dry-run, after #172 merged) failed in publish: every wheel job's ``actions/checkout`` could not resolve ``ref: v0.25.0`` because the projected tag never exists on the remote in a dry-run (the real bump was skipped, as designed).

## Fix

In ``release-pipeline.yaml``, only pass the tag to publish when it's guaranteed to exist:
- Real release (``dry_run=false``): pass tag — the bump just created it.
- Dry-run + ``skip_bump=true``: pass tag — the user supplied an existing tag, already validated by ``resolve``.
- Dry-run + fresh-bump (``skip_bump=false``): pass ``''`` — publish.yaml falls back to the caller's ref (main).

This is the last known dry-run gap. The recovery-path dry-run continues to pin to the supplied tag, validating the tag-pinning code path.

## Test plan

- [ ] After merge, re-dispatch with ``increment=auto, dry_run=true`` and confirm all wheel jobs succeed.
- [ ] Confirm the next ``skip_bump=true`` dry-run still pins to the supplied tag (e.g. ``v0.24.1``).