### PR TITLE
ci(release): check out the tag in real mode

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # In real mode, pin to the just-pushed tag so the changelog includes
+          # the new section (bump's commit is past the orchestrator's dispatch
+          # ref). In dry-run, the tag does not exist; fall back to caller's ref.
+          ref: ${{ inputs.dry_run == false && inputs.tag || '' }}
 
       - name: Resolve tag
         id: tag


### PR DESCRIPTION
## Bug

Real-release run [26256735180](https://github.com/mcvickerlab/GenVarLoader/actions/runs/26256735180) failed at the ``release`` job. The ``Extract changelog section`` step couldn't find ``## v0.25.0`` because ``actions/checkout`` had no ``ref:`` — so it checked out the orchestrator's dispatch commit, which is the **parent** of the bump commit just pushed by the ``bump`` job. The changelog at that point doesn't have the v0.25.0 section yet.

## State after the failed run

- main: advanced with the bump commit (v0.25.0 written to pyproject + changelog)
- Tag ``v0.25.0``: pushed to remote
- GH release: not created
- PyPI: not published (publish skipped because release failed)
- stable: not pushed (merge skipped)

## Fix

Pin ``release.yaml``'s checkout to ``inputs.tag`` in real mode. In dry-run the tag doesn't exist on the remote; fall back to the caller's ref (the dry-run code path already tolerates a missing changelog section with a placeholder).

## Recovery after merge

\`\`\`
gh workflow run release-pipeline.yaml --ref main \\
  -f skip_bump=true -f tag=v0.25.0 -f dry_run=false
\`\`\`

This goes resolve → (skip bump) → release → publish → merge. The bump is already done; we just need to finish the rest against the existing tag.

## Test plan

- [ ] After merge, dispatch the recovery command above and confirm GH release v0.25.0 is created, wheels publish to PyPI, and main → stable merge happens.