### PR TITLE
docs(superpowers): post-implementation notes for release-pipeline

### DIFF
--- a/docs/superpowers/plans/2026-05-21-release-pipeline.md
+++ b/docs/superpowers/plans/2026-05-21-release-pipeline.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** GitHub Actions, commitizen (`v$version` tags), maturin, `uv publish`, pixi, `softprops/action-gh-release@v3`, `PyO3/maturin-action@v1`, `astral-sh/setup-uv@v7`.
 
-**Reference spec:** `docs/superpowers/specs/2026-05-21-release-pipeline-design.md`
+**Reference spec:** `docs/superpowers/specs/2026-05-21-release-pipeline-design.md` — see the **"Post-implementation notes"** section there for the bugs surfaced during code review and post-merge validation (six total). The plan below is the original task list as executed; PRs #171, #172, #173, #175 patched issues found after the initial PR #168 landed.
 
 **Validation note:** GitHub Actions has no offline test harness. Each task's verification step is either (a) `actionlint` if available, otherwise a YAML syntax check via `python -c "import yaml; yaml.safe_load(open('...'))"`, and (b) a `workflow_dispatch`-triggered dry run after the orchestrator lands (Task 7). Do not delete the old workflow files until Task 7 passes.
 

--- a/docs/superpowers/specs/2026-05-21-release-pipeline-design.md
+++ b/docs/superpowers/specs/2026-05-21-release-pipeline-design.md
@@ -148,3 +148,46 @@ Add a second job `cargo-test` running `cargo test --release` on `ubuntu-latest`.
 ## Open questions
 
 None — all decisions made during brainstorming. Implementation plan can proceed.
+
+---
+
+## Post-implementation notes (2026-05-21)
+
+The pipeline shipped and released v0.25.0 on the day of design. Six real bugs were caught — three by code review pre-merge, three by post-merge validation runs. Capturing them here so the next person to adapt this pattern (or copy it to another repo) doesn't repeat them.
+
+### Bugs caught in code review (before merge)
+
+These were flagged on PR #168 by the code-quality reviewer subagent. All would have surfaced on the first or second use of the pipeline.
+
+1. **`push:` trigger on `release.yaml` races with `workflow_call`.** Both fire on the tag push from commitizen; second one duplicates or errors. Removed the `push:` trigger; orchestrator is the sole entry point. Standalone `workflow_dispatch` remains as an escape hatch.
+2. **Partial-bump auto-recovery is unsafe.** The original spec proposed `cz bump --files-only` + new tag push when an orphan tag is detected. Commitizen computes the next version from `pyproject.toml`, which can collide with the orphan. Replaced with a hard-fail that prints actionable remediation (delete orphan, or hand-bump pyproject to match). Auto-recovery in this scenario is dangerous; humans should resolve.
+3. **`cz bump --dry-run` does not modify files**, so reading `cz version --project` after it returns the *current* version, not the projected one. Fixed by parsing the projected version from `cz bump --dry-run` stdout (`-> X.Y.Z` or `tag to create: vX.Y.Z`).
+4. **`sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}`** is broken under `workflow_call`. `github.ref` in a reusable workflow is the **caller's** ref, never a tag ref — so sccache was always on, defeating the disable-on-release intent. Changed to `sccache: ${{ inputs.tag == '' }}` (tag pinned = release build = no sccache).
+5. **`merge.yaml` had `environment: pypi` and `id-token: write`** copy-pasted from the old workflow. Neither is needed — the rebase + push authenticates via the `COMMITIZEN` PAT. Removed both.
+6. **`commitizen-action@master`** was unpinned. Pinned to `0.27.1`. Worth re-pinning periodically.
+
+### Bugs caught in post-merge validation
+
+These are all variants of one underlying issue: **GitHub Actions evaluates `github.*` context against the *originating* event, not against `workflow_call`.** In a reusable workflow invoked by `release-pipeline.yaml`, `github.event_name` is `workflow_dispatch` (from the user's button click on the orchestrator), and `github.ref` is the orchestrator's dispatch ref. This trips up anything that tries to detect "am I being called by another workflow?"
+
+7. **Dry-run UX bug: missing changelog section.** In the fresh-bump dry-run path, the projected tag (e.g. `v0.25.0`) has no section in `docs/source/changelog.md` because commitizen only writes it during the real bump. The awk extractor errored, failing the run. Fix (PR #171): when `body.md` is empty AND `inputs.dry_run == true`, emit a placeholder body and continue.
+8. **Dry-run gate in `release.yaml` was structurally broken** (PR #172). The condition `github.event_name == 'workflow_call' && inputs.dry_run == true` always evaluates false in the reusable workflow (see above). So `Dry-run summary` skipped and `Create GitHub release` ran. `softprops/action-gh-release@v3` then auto-created the tag `v0.25.0` from `main` HEAD with the placeholder body. Cleanup required deleting the orphan release and tag.
+    - **Lesson:** never gate dry-run on `github.event_name == 'workflow_call'`. Always check `inputs.dry_run` directly. The same input should be declared on both `workflow_call` and `workflow_dispatch`.
+    - PyPI publish, push-to-stable, and the bump commit were unaffected — those gates correctly used `inputs.dry_run`.
+9. **`publish.yaml` can't pin to a projected tag that doesn't exist** (PR #173). After fixing #8, the next dry-run failed because `publish.yaml`'s `actions/checkout` was passed `ref: v0.25.0` — a tag that never exists in dry-run (no real bump). Fix: in `release-pipeline.yaml`, only pass the tag to `publish` when `inputs.dry_run == false` OR `inputs.skip_bump == true`. Otherwise pass `''` so checkout falls back to the caller's ref.
+10. **`release.yaml`'s checkout had no `ref:`** (PR #175). The first real release failed because the release job pulled the orchestrator's dispatch commit — the **parent** of the bump commit pushed seconds earlier — so the changelog at that ref didn't have the new version's section yet. Fix: `ref: ${{ inputs.dry_run == false && inputs.tag || '' }}`. Real mode pins to the just-pushed tag; dry-run falls back to caller ref.
+
+### Lessons for the next adapter
+
+- **`workflow_run` triggers are also a footgun** (the old GVL pipeline used them) — they look like they will work and then silently miss events or pull the wrong ref. Prefer reusable workflows (`workflow_call`).
+- **Reusable workflows always pull the *dispatcher's* ref by default.** If a sibling job has pushed a commit since dispatch (like `bump`), and a downstream job needs that commit, pin its checkout to the new tag explicitly. This bit us twice (issues 9 and 10) for the same reason.
+- **`github.event_name` and `github.ref` lie inside reusable workflows.** Don't use them for dry-run gating, recovery detection, or tag-vs-branch dispatch. Use `inputs.*` instead.
+- **Dry-run is genuinely valuable but takes deliberate design** at every step that touches external state: changelog parsing, tag checkout, release creation, publish, push. Each needs a dry-run-aware fallback that doesn't depend on artifacts only created in real mode.
+- **The recovery path (`skip_bump=true, tag=<existing>`) earned its keep on the first real release** — the initial run failed mid-flight (bug 10) and recovery completed the release/publish/merge against the orphan tag without any manual git surgery. Keep this affordance in any adaptation.
+
+### Things that worked well
+
+- Code-quality reviewer subagent caught the high-impact bugs before merge (six issues, all real).
+- The orchestrator's `if: always() && needs.X.result == 'success'` gating let us isolate failures to their job rather than aborting the run — useful for diagnosis.
+- Tag-pinned checkouts in publish.yaml (Task 4) meant the recovery-path dry-run validated the full wheel matrix against a stable, known tag. That validation gave confidence the build itself was sound; the bugs we found later were all in the surrounding plumbing.
+- All cleanup of the dry-run misfire was scriptable (`gh release delete --cleanup-tag`). The blast radius never reached PyPI, `stable`, or the source tree.


### PR DESCRIPTION
Adds a post-mortem section to ``docs/superpowers/specs/2026-05-21-release-pipeline-design.md`` capturing the six real bugs that surfaced while landing the new release pipeline:

- 3 caught by code review on #168 (push-trigger race, unsafe partial-bump recovery, ``cz bump --dry-run`` doesn't update files, plus sccache/environment/pin polish).
- 3 caught by post-merge validation (#171 missing-changelog UX, #172 ``github.event_name`` misuse → orphan v0.25.0 release, #173 publish can't pin nonexistent tag, #175 release.yaml needed ``ref: inputs.tag``).

Headline lesson: in a reusable workflow, ``github.event_name`` reports the **parent** event and ``github.ref`` is the dispatcher's ref. Don't gate on either; use ``inputs.*`` directly. Dry-run also needs deliberate plumbing at every step that touches external state.

Plan file gets a one-line pointer back to the spec for these notes.