### PR TITLE
fix(utils): copy read-only inputs in idx_like_to_array

### DIFF
--- a/python/genvarloader/_utils.py
+++ b/python/genvarloader/_utils.py
@@ -89,7 +89,9 @@ def idx_like_to_array(idx: Idx, max_len: int) -> NDArray[np.integer]:
     # unable to type narrow from NDArray[bool] since it's a generic type
     _idx = cast(NDArray[np.integer], _idx)
 
-    # handle negative indices
+    # handle negative indices (non-mutating to support read-only inputs e.g. arrow-backed views)
+    if isinstance(_idx, np.ndarray) and not _idx.flags.writeable:
+        _idx = _idx.copy()
     _idx[_idx < 0] += max_len
 
     return _idx


### PR DESCRIPTION
## Summary

`idx_like_to_array` mutates its input in place:

```python
_idx[_idx < 0] += max_len
```

This crashes with `ValueError: assignment destination is read-only` when the input is a non-writeable ndarray — most commonly an arrow-backed view returned by `polars.Series.to_numpy()`.

We hit this downstream where `genvarformer.data.sources.modifiers.Cnv.align` passes `regions["index"].to_numpy()` into `Dataset.subset_to → idxer.subset_to → idx_like_to_array`. The `.to_numpy()` is zero-copy on arrow buffers and returns a read-only view.

## Fix

Copy when the input is non-writeable, otherwise mutate in place as before. Zero overhead in the common case (the writeable branch is unchanged); correct for the read-only case.

```python
if isinstance(_idx, np.ndarray) and not _idx.flags.writeable:
    _idx = _idx.copy()
_idx[_idx < 0] += max_len
```

## Test plan
- [ ] Existing tests pass: `pixi run -e dev test`
- [ ] Manual repro: pass an arrow-backed read-only array into `idx_like_to_array` (or hit it via `Dataset.subset_to(polars_series.to_numpy(), ...)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)