### PR TITLE
refactor(open): extract OpenRequest + decompose Dataset.open (PR4)

### DIFF
--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -9,7 +9,6 @@ import numpy as np
 import polars as pl
 import seqpro as sp
 from dataclasses import dataclass, replace
-from genoray._utils import ContigNormalizer
 from loguru import logger
 from numpy.typing import NDArray
 from seqpro.rag import DTYPE_co as DTYPE, Ragged, is_rag_dtype
@@ -44,8 +43,7 @@ from ._reconstruct import (
     _build_reconstructor,
 )
 from ._reference import Reference
-from ._utils import bed_to_regions, regions_to_bed
-from ._write import Metadata
+from ._utils import regions_to_bed
 
 if TORCH_AVAILABLE:
     import torch
@@ -180,161 +178,22 @@ class Dataset:
             moved and the dataset cannot find it via the stored relative/absolute
             path or by sibling discovery.
         """
-        path = Path(path)
-        if not path.exists():
-            raise FileNotFoundError(f"{path} does not exist.")
+        from ._open import OpenRequest
 
-        # read metadata
-        with _py_open(path / "metadata.json") as f:
-            metadata = Metadata.model_validate_json(f.read())
-        samples = metadata.samples
-        contigs = metadata.contigs
-        ploidy = metadata.ploidy
-        max_jitter = metadata.max_jitter
-
-        # read input regions and generate index map
-        bed = pl.read_ipc(path / "input_regions.arrow")
-        if region_names is not None:
-            _region_names = bed[region_names].to_list()
-        else:
-            _region_names = None
-        r_idx_map = bed["r_idx_map"].to_numpy().astype(np.intp)
-        idxer = DatasetIndexer.from_region_and_sample_idxs(
-            r_idxs=r_idx_map,
-            s_idxs=np.arange(len(samples)),
-            samples=samples,
-            regions=_region_names,
-        )
-        bed = bed.drop("r_idx_map")
-        sorted_bed = sp.bed.sort(bed)
-        regions = bed_to_regions(sorted_bed, ContigNormalizer(contigs))
-
-        has_genotypes = (path / "genotypes").exists()
-        if has_genotypes:
-            if ploidy is None:
-                raise ValueError("Malformed dataset: found genotypes but not ploidy.")
-
-        has_intervals = (path / "intervals").exists() or (
-            path / "annot_intervals"
-        ).exists()
-
-        if isinstance(reference, (str, Path)):
-            reference = Reference.from_path(reference, contigs)
-
-        if has_genotypes:
-            assert ploidy is not None
-            seqs = Haps.from_path(
-                path=path,
-                reference=reference,
-                regions=regions,
-                samples=samples,
-                ploidy=ploidy,
-                version=metadata.version,
-                svar_link=metadata.svar_link,
-                svar_override=svar,
-                min_af=min_af,
-                max_af=max_af,
-            )
-            if reference is None:
-                logger.warning(
-                    "No reference: dataset only has genotypes but no reference was given."
-                    " Resulting dataset can only support :code:`.with_seqs('variants')` to return RaggedVariants."
-                )
-        elif reference is not None:
-            seqs = Ref(reference=reference)
-        else:
-            seqs = None
-
-        if has_intervals:
-            tracks = Tracks.from_path(path, len(regions), len(samples))
-            tracks = tracks.with_tracks(list(tracks.intervals))
-        else:
-            tracks = None
-
-        if seqs is None and tracks is None:
-            raise RuntimeError(
-                "Malformed dataset: neither genotypes nor intervals found."
-            )
-
-        # Initial view kind: matches the default class produced for each storage shape.
-        if isinstance(seqs, Haps):
-            seqs_kind: (
-                Literal["haplotypes", "reference", "annotated", "variants"] | None
-            ) = "haplotypes"
-        elif isinstance(seqs, Ref):
-            seqs_kind = "reference"
-        else:
-            seqs_kind = None
-
-        recon = _build_reconstructor(seqs, tracks, seqs_kind)
-
-        splice_idxer = None
-        spliced_bed = None
-
-        if seqs is not None and reference is not None:
-            cnorm = ContigNormalizer(reference.contigs)
-            contig_lengths = dict(zip(reference.contigs, np.diff(reference.offsets)))
-            ds_contigs = bed["chrom"].unique().to_list()
-            normed_contigs = cnorm.norm(ds_contigs)
-            if any(c is None for c in normed_contigs):
-                raise ValueError(
-                    "Some regions in the dataset can not be mapped to a contig in the reference genome."
-                )
-            normed_contigs = cast(list[str], normed_contigs)
-            replacer = {
-                c: contig_lengths[norm_c]
-                for c, norm_c in zip(ds_contigs, normed_contigs)
-            }
-            out_of_bounds = bed.select(
-                (pl.col("chromStart") >= pl.col("chrom").replace_strict(replacer)).any()
-            ).item()
-            if out_of_bounds:
-                logger.warning(
-                    "Some regions in the dataset have a start coordinate that is out"
-                    " of bounds for the reference genome provided. This may happen if"
-                    " the dataset's regions are for a different reference genome."
-                )
-
-        dataset = RaggedDataset(
-            path=path,
-            output_length="ragged",
-            max_jitter=max_jitter,
+        return OpenRequest(
+            path=Path(path),
+            reference=reference,
             jitter=jitter,
-            contigs=contigs,
-            return_indices=False,
-            rc_neg=rc_neg,
+            rng=rng,
             deterministic=deterministic,
-            _idxer=idxer,
-            _sp_idxer=splice_idxer,
-            _full_bed=bed,
-            _spliced_bed=spliced_bed,
-            _full_regions=regions,
-            _seqs=seqs,
-            _tracks=tracks,
-            _seqs_kind=seqs_kind,
-            _recon=recon,
-            _rng=np.random.default_rng(rng),
-        )
-
-        if splice_info is not None or var_filter is not None:
-            # splice_info is only valid with haplotypes/reference sequence types.
-            # If the dataset still has the default "variants" sequence type (i.e.
-            # the caller hasn't called with_seqs yet), promote to "haplotypes" so
-            # _check_valid_state() doesn't reject splice_info=... up front.
-            if (
-                splice_info is not None
-                and isinstance(dataset._seqs, Haps)
-                and dataset.sequence_type == "variants"
-            ):
-                dataset = dataset.with_seqs("haplotypes")
-            dataset = dataset.with_settings(
-                splice_info=splice_info,
-                var_filter=var_filter,
-            )
-
-        logger.info(f"Opened dataset:\n{dataset}")
-
-        return dataset
+            rc_neg=rc_neg,
+            min_af=min_af,
+            max_af=max_af,
+            region_names=region_names,
+            splice_info=splice_info,
+            var_filter=var_filter,
+            svar=svar,
+        ).resolve()
 
     def with_settings(
         self,

--- a/python/genvarloader/_dataset/_open.py
+++ b/python/genvarloader/_dataset/_open.py
@@ -196,8 +196,7 @@ class OpenRequest:
             )
         normed_contigs = cast(list[str], normed_contigs)
         replacer = {
-            c: contig_lengths[norm_c]
-            for c, norm_c in zip(ds_contigs, normed_contigs)
+            c: contig_lengths[norm_c] for c, norm_c in zip(ds_contigs, normed_contigs)
         }
         out_of_bounds = bed.select(
             (pl.col("chromStart") >= pl.col("chrom").replace_strict(replacer)).any()

--- a/python/genvarloader/_dataset/_open.py
+++ b/python/genvarloader/_dataset/_open.py
@@ -1,0 +1,262 @@
+"""``OpenRequest`` — staged construction for :meth:`Dataset.open`.
+
+``Dataset.open`` is a thin facade that packages its arguments into an
+:class:`OpenRequest` and calls :meth:`OpenRequest.resolve`. The resolution
+stages live as small helpers on this class so each step can be read and
+reasoned about in isolation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, cast
+
+import numpy as np
+import polars as pl
+import seqpro as sp
+from genoray._utils import ContigNormalizer
+from loguru import logger
+from numpy.typing import NDArray
+
+from ._indexing import DatasetIndexer
+from ._reconstruct import Haps, Ref, Tracks, _build_reconstructor
+from ._reference import Reference
+from ._utils import bed_to_regions
+from ._write import Metadata
+
+if TYPE_CHECKING:
+    from ._impl import RaggedDataset
+
+
+_py_open = open
+
+
+SeqsKind = Literal["haplotypes", "reference", "annotated", "variants"] | None
+
+
+@dataclass(frozen=True, slots=True)
+class OpenRequest:
+    """Parsed, validated arguments for opening a dataset.
+
+    Construct directly or via :meth:`Dataset.open`. Call :meth:`resolve` to
+    produce the dataset.
+    """
+
+    path: Path
+    reference: str | Path | Reference | None = None
+    jitter: int = 0
+    rng: int | np.random.Generator | None = False
+    deterministic: bool = True
+    rc_neg: bool = True
+    min_af: float | None = None
+    max_af: float | None = None
+    region_names: str | None = None
+    splice_info: str | tuple[str, str] | None = None
+    var_filter: Literal["exonic"] | None = None
+    svar: str | Path | None = None
+
+    def resolve(self) -> RaggedDataset:
+        """Resolve the request into a :class:`Dataset`."""
+        self._validate_path()
+        metadata = self._load_metadata()
+        idxer, bed, regions = self._build_indexer(metadata)
+        reference = self._resolve_reference(metadata.contigs)
+        seqs = self._build_seqs(metadata, reference, regions)
+        tracks = self._build_tracks(len(regions), len(metadata.samples))
+
+        if seqs is None and tracks is None:
+            raise RuntimeError(
+                "Malformed dataset: neither genotypes nor intervals found."
+            )
+
+        seqs_kind = self._initial_seqs_kind(seqs)
+        recon = _build_reconstructor(seqs, tracks, seqs_kind)
+
+        self._check_reference_bounds(bed, seqs, reference)
+
+        dataset = self._assemble_dataset(
+            metadata=metadata,
+            bed=bed,
+            regions=regions,
+            idxer=idxer,
+            seqs=seqs,
+            tracks=tracks,
+            seqs_kind=seqs_kind,
+            recon=recon,
+        )
+
+        dataset = self._apply_post_settings(dataset)
+
+        logger.info(f"Opened dataset:\n{dataset}")
+        return dataset
+
+    # ---- stages ----
+
+    def _validate_path(self) -> None:
+        if not self.path.exists():
+            raise FileNotFoundError(f"{self.path} does not exist.")
+
+    def _load_metadata(self) -> Metadata:
+        with _py_open(self.path / "metadata.json") as f:
+            return Metadata.model_validate_json(f.read())
+
+    def _build_indexer(
+        self, metadata: Metadata
+    ) -> tuple[DatasetIndexer, pl.DataFrame, NDArray[np.int32]]:
+        bed = pl.read_ipc(self.path / "input_regions.arrow")
+        if self.region_names is not None:
+            _region_names = bed[self.region_names].to_list()
+        else:
+            _region_names = None
+        r_idx_map = bed["r_idx_map"].to_numpy().astype(np.intp)
+        idxer = DatasetIndexer.from_region_and_sample_idxs(
+            r_idxs=r_idx_map,
+            s_idxs=np.arange(len(metadata.samples)),
+            samples=metadata.samples,
+            regions=_region_names,
+        )
+        bed = bed.drop("r_idx_map")
+        sorted_bed = sp.bed.sort(bed)
+        regions = bed_to_regions(sorted_bed, ContigNormalizer(metadata.contigs))
+        return idxer, bed, regions
+
+    def _resolve_reference(self, contigs: list[str]) -> Reference | None:
+        if isinstance(self.reference, (str, Path)):
+            return Reference.from_path(self.reference, contigs)
+        return self.reference
+
+    def _has_genotypes(self) -> bool:
+        return (self.path / "genotypes").exists()
+
+    def _has_intervals(self) -> bool:
+        return (self.path / "intervals").exists() or (
+            self.path / "annot_intervals"
+        ).exists()
+
+    def _build_seqs(
+        self,
+        metadata: Metadata,
+        reference: Reference | None,
+        regions: NDArray[np.int32],
+    ) -> Haps | Ref | None:
+        if self._has_genotypes():
+            if metadata.ploidy is None:
+                raise ValueError("Malformed dataset: found genotypes but not ploidy.")
+            seqs = Haps.from_path(
+                path=self.path,
+                reference=reference,
+                regions=regions,
+                samples=metadata.samples,
+                ploidy=metadata.ploidy,
+                version=metadata.version,
+                svar_link=metadata.svar_link,
+                svar_override=self.svar,
+                min_af=self.min_af,
+                max_af=self.max_af,
+            )
+            if reference is None:
+                logger.warning(
+                    "No reference: dataset only has genotypes but no reference was given."
+                    " Resulting dataset can only support :code:`.with_seqs('variants')` to return RaggedVariants."
+                )
+            return seqs
+        if reference is not None:
+            return Ref(reference=reference)
+        return None
+
+    def _build_tracks(self, n_regions: int, n_samples: int) -> Tracks | None:
+        if not self._has_intervals():
+            return None
+        tracks = Tracks.from_path(self.path, n_regions, n_samples)
+        return tracks.with_tracks(list(tracks.intervals))
+
+    @staticmethod
+    def _initial_seqs_kind(seqs: Haps | Ref | None) -> SeqsKind:
+        # Default view kind for each storage shape.
+        if isinstance(seqs, Haps):
+            return "haplotypes"
+        if isinstance(seqs, Ref):
+            return "reference"
+        return None
+
+    @staticmethod
+    def _check_reference_bounds(
+        bed: pl.DataFrame, seqs: Haps | Ref | None, reference: Reference | None
+    ) -> None:
+        if seqs is None or reference is None:
+            return
+        cnorm = ContigNormalizer(reference.contigs)
+        contig_lengths = dict(zip(reference.contigs, np.diff(reference.offsets)))
+        ds_contigs = bed["chrom"].unique().to_list()
+        normed_contigs = cnorm.norm(ds_contigs)
+        if any(c is None for c in normed_contigs):
+            raise ValueError(
+                "Some regions in the dataset can not be mapped to a contig in the reference genome."
+            )
+        normed_contigs = cast(list[str], normed_contigs)
+        replacer = {
+            c: contig_lengths[norm_c]
+            for c, norm_c in zip(ds_contigs, normed_contigs)
+        }
+        out_of_bounds = bed.select(
+            (pl.col("chromStart") >= pl.col("chrom").replace_strict(replacer)).any()
+        ).item()
+        if out_of_bounds:
+            logger.warning(
+                "Some regions in the dataset have a start coordinate that is out"
+                " of bounds for the reference genome provided. This may happen if"
+                " the dataset's regions are for a different reference genome."
+            )
+
+    def _assemble_dataset(
+        self,
+        metadata: Metadata,
+        bed: pl.DataFrame,
+        regions: NDArray[np.int32],
+        idxer: DatasetIndexer,
+        seqs: Haps | Ref | None,
+        tracks: Tracks | None,
+        seqs_kind: SeqsKind,
+        recon,
+    ) -> RaggedDataset:
+        from ._impl import RaggedDataset
+
+        return RaggedDataset(
+            path=self.path,
+            output_length="ragged",
+            max_jitter=metadata.max_jitter,
+            jitter=self.jitter,
+            contigs=metadata.contigs,
+            return_indices=False,
+            rc_neg=self.rc_neg,
+            deterministic=self.deterministic,
+            _idxer=idxer,
+            _sp_idxer=None,
+            _full_bed=bed,
+            _spliced_bed=None,
+            _full_regions=regions,
+            _seqs=seqs,
+            _tracks=tracks,
+            _seqs_kind=seqs_kind,
+            _recon=recon,
+            _rng=np.random.default_rng(self.rng),
+        )
+
+    def _apply_post_settings(self, dataset: RaggedDataset) -> RaggedDataset:
+        if self.splice_info is None and self.var_filter is None:
+            return dataset
+        # splice_info is only valid with haplotypes/reference sequence types.
+        # If the dataset still has the default "variants" sequence type (i.e.
+        # the caller hasn't called with_seqs yet), promote to "haplotypes" so
+        # _check_valid_state() doesn't reject splice_info=... up front.
+        if (
+            self.splice_info is not None
+            and isinstance(dataset._seqs, Haps)
+            and dataset.sequence_type == "variants"
+        ):
+            dataset = dataset.with_seqs("haplotypes")
+        return dataset.with_settings(
+            splice_info=self.splice_info,
+            var_filter=self.var_filter,
+        )


### PR DESCRIPTION
## Summary

- `Dataset.open` was a 155-line method mixing arg unpacking, path validation, metadata loading, indexer build, source assembly (`Haps`/`Ref` + `Tracks`), reference-bounds check, dataset assembly, and post-construction settings application.
- New module `python/genvarloader/_dataset/_open.py` defines an `OpenRequest` frozen dataclass holding the parsed args plus a `.resolve()` method that orchestrates the stages, each as its own small method:
  - `_validate_path`
  - `_load_metadata`
  - `_build_indexer`
  - `_resolve_reference`
  - `_build_seqs`
  - `_build_tracks`
  - `_initial_seqs_kind`
  - `_check_reference_bounds`
  - `_assemble_dataset`
  - `_apply_post_settings`
- `Dataset.open` is now a thin facade (~20 lines) that constructs an `OpenRequest` and calls `.resolve()`. Public API unchanged; both `@overload` declarations on `Dataset.open` are preserved.
- `_impl.py`: 2156 → 2015 (−141 lines). New `_open.py`: 262 lines. Net: stages are now small enough to unit-test individually if/when desired.

## Test plan

- [x] `pixi run -e dev test` (488 pytest + cargo) — all pass
- [x] `pixi run -e dev ruff check python/` — clean
- [x] `pixi run -e dev pyrefly check` — 0 errors (baseline unchanged)

Part of the refactor campaign tracked in `docs/superpowers/specs/2026-05-23-refactor-campaign-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)