### PR TITLE
refactor(reconstruct): ReconstructionRequest + restructure _get_haplotypes (PR5)

### DIFF
--- a/docs/superpowers/specs/2026-05-23-refactor-campaign-design.md
+++ b/docs/superpowers/specs/2026-05-23-refactor-campaign-design.md
@@ -1,6 +1,6 @@
 # Refactor Campaign: Readability + Targeted Architecture
 
-**Status:** In progress — PR0, PR1, attrs migration, PR2 shipped; PR3 dropped after investigation; PR4+ pending
+**Status:** In progress — PR0, PR1, attrs migration, PR2, PR4, PR5 shipped; PR3 dropped after investigation; PR5c (dead-code), PR6, PR7 pending
 **Date:** 2026-05-23
 **Scope:** `python/genvarloader/` (no Rust changes)
 
@@ -13,11 +13,14 @@
 | 2026-05-23 | #183 | attrs → stdlib dataclasses migration (out-of-band, not numbered in the campaign) | `refactor/attrs-to-dataclass` | Merged. 10 source files + tests migrated to `@dataclass(slots=True)`; `attrs` dropped from `pyproject.toml` / `pixi.toml`. Zero behavioral changes. Motivated by pyrefly's weaker support for attrs. |
 | 2026-05-23 | #185 | PR2 — VCF + PGEN writer dedup via shared `_write_phased_chunked` helper | `refactor/pr2-write-dedup` | Merged. `_write.py`: 832 → 817 lines (−15 net). `_write_from_vcf` / `_write_from_pgen` collapsed to small setup + per-region generators that feed a shared aggregation helper. SVAR untouched (per scope refinement). |
 | 2026-05-23 | — | PR3 dropped after investigation (see "PR3 dropped" section below) | `refactor/pr3-collapse-datasets` (closed) | Dropped. Probed phantom-types + self-typed overloads; concluded the ~150 lines of overload stubs encode the Array/Ragged ADT in Python's type system and are not deletable boilerplate. Net realistic deletion would be ~30 lines of `super()` bodies — not worth the architectural churn. |
+| 2026-05-23 | #187 | PR4 — `OpenRequest` + decompose `Dataset.open` | `refactor/pr4-open-request` | Merged. `_impl.py`: 2156 → 2015 (−141). New `_dataset/_open.py` (262 lines) houses `OpenRequest` with 10 small stage methods. `Dataset.open` becomes a ~20-line facade. Public API unchanged. |
+| 2026-05-23 | (this PR) | PR5 — `ReconstructionRequest` + restructure `Haps._get_haplotypes` | `refactor/pr5-reconstruction-request` | `_reconstruct.py`: 1595 → 1682 lines (+87 net; reorganization adds dataclass + helper, deletes ~30 lines of overloads). `Haps._get_haplotypes` overload triplet replaced with `_reconstruct_haplotypes` / `_reconstruct_annotated_haplotypes`. Splice permutation prep extracted into shared `_permute_request_for_splice`. `get_haps_and_shifts` now a two-stage op (`_prepare_request` → dispatch). Spec revised inline to reflect audit findings; PR5c (dead-code in `write_transformed_track`) carved out as separate small PR. |
 
 **Current state of heavyweight files (post the merged PRs):**
 
-- `_dataset/_impl.py` — 2156 lines (was 2253; −97)
-- `_dataset/_reconstruct.py` — 1595 lines (was 1525; +70 from factory + view-state work, expected)
+- `_dataset/_impl.py` — 2015 lines (was 2253; −238 net, post-PR4)
+- `_dataset/_reconstruct.py` — 1682 lines (was 1525; +157 net, post-PR1 factory + post-PR5 ReconstructionRequest reorganization)
+- `_dataset/_open.py` — 262 lines (new in PR4)
 - `_dataset/_write.py` — 817 lines (was 832; −15 after PR2)
 - `_dataset/_reference.py` — 756 lines (unchanged-ish)
 - `_dataset/_genotypes.py` — 571 lines (unchanged)
@@ -302,28 +305,38 @@ PR1 because settings are already a value object.
 **Risk:** low–medium. Splits a 206-line method; needs careful parity testing.
 **Win:** `open()` shrinks to ~30 lines; resolution stages testable in isolation.
 
-### PR5 — `ReconstructionRequest` + extract haplotype kernel
+### PR5 — `ReconstructionRequest` + restructure `Haps._get_haplotypes` (revised after audit)
 
-Introduce a `ReconstructionRequest` value object describing *what* to reconstruct
-(region, sample, splice plan if any, annotation flag). The three overloads of
-`Haps._get_haplotypes` collapse to one method taking the request. Same treatment
-for `Tracks.write_transformed_track` (166 lines) — split the insertion-fill
-strategies into named helpers.
+**Audit findings (2026-05-23, before implementation):**
 
-**Critical for forward compatibility:** the haplotype-reconstruction *kernel*
-must remain callable independent of region-major iteration. The current
-`Haps._get_haplotypes` does too much — it mixes the per-window reconstruction
-kernel with iteration plumbing. The kernel is extracted as a pure function (or
-method on `Haps`) that takes (variants, samples, reference window, optional
-splice plan) and returns sequences. This was originally scoped to the old PR5
-(Pipeline composition); since that PR is no longer needed, the kernel extraction
-folds in here.
+- ✅ Verified: `Haps._get_haplotypes` is 3 signatures (2 `@overload` stubs + impl) in ~167 lines, with two distinct internal paths (no-splice ~50 lines, splice-plan ~80 lines).
+- ❌ Disproven: `Tracks.write_transformed_track` is 166 lines, but line 1189 unconditionally raises `NotImplementedError` — the 145 lines below are unreachable dead code. There is **zero insertion-fill branching** in it. The actual insertion-fill dispatch lives in `_dataset/_tracks.py:_apply_insertion_fill` (a small numba helper, ~30 lines, not 166). Moved to a separate small PR (see PR5c below).
+- ❌ Already done: the "haplotype-reconstruction kernel must be callable independent of region-major iteration" is already true. `_dataset/_genotypes.py:reconstruct_haplotypes_from_sparse` is a numba-jit pure function taking raw arrays (variants, samples, ref window, optional keep mask, optional annotation buffers). A future variant-major class can call it directly. No further kernel extraction needed.
+- ⚠️ Misframed: a `ReconstructionRequest` for `_get_haplotypes` alone (one caller chain) buys little. The *real* opportunity is to extract `_prepare_request()` out of `get_haps_and_shifts` (the ~60 lines that compute `geno_offset_idx`, `keep`, `keep_offsets`, `shifts`, `out_offsets`, `diffs`, `hap_lengths`) into a frozen dataclass `ReconstructionRequest` consumed by `_get_haplotypes` and `_get_variants`. That gives a clean prep → dispatch seam and a stable shape for the future variant-major class to construct directly.
 
-**Touches:** `_dataset/_reconstruct.py`, callers.
-**Risk:** medium. Numerical parity verification.
-**Win:** overload triplet disappears; 167-line and 166-line methods
-decomposed; future variant-major class can construct requests without going
-through region-major iteration.
+**Revised scope (PR5):**
+
+1. Introduce `ReconstructionRequest` (frozen dataclass with `slots=True`) holding the per-batch prep state.
+2. Extract `Haps._prepare_request()` returning a `ReconstructionRequest`.
+3. Replace `Haps._get_haplotypes` (2 overloads + 1 impl) with two named methods: `_reconstruct_haplotypes(req)` and `_reconstruct_annotated_haplotypes(req)`. Drop the overload triplet entirely.
+4. Extract `_permute_request_for_splice(req)` as a shared helper for the splice-plan branch of both methods.
+5. Rewire `get_haps_and_shifts` to: `req = _prepare_request(...); dispatch on self.kind`. Preserve the 7-tuple return shape so `HapsTracks.__call__` consumers stay unchanged.
+
+**Out of scope (deferred to PR5c):**
+
+- `Tracks.write_transformed_track` dead-code deletion (145 lines under unconditional `NotImplementedError`).
+
+**Touches:** `_dataset/_reconstruct.py`.
+**Risk:** low. The kernel calls are unchanged (same args, same library call); the change is purely a reorganization of the Python wrapper around the numba kernel. Numerical parity is verified by the existing test suite (488 pytest + cargo).
+**Win:** overload triplet eliminated; `get_haps_and_shifts` is now a two-stage operation (prep → kernel); a future variant-major class can construct a `ReconstructionRequest` and call the kernel-facing methods directly without going through region-major preparation.
+
+### PR5c — Delete dead code in `Tracks.write_transformed_track`
+
+`Tracks.write_transformed_track` unconditionally raises `NotImplementedError` at line 1189 of `_dataset/_reconstruct.py`. The 145 lines of body below are unreachable. Replace the method body with `raise NotImplementedError(...)` and a one-line comment about why it's stubbed.
+
+**Touches:** `_dataset/_reconstruct.py`.
+**Risk:** None. Was unreachable.
+**Win:** ~145 lines deleted; the file gets clearer.
 
 ### PR6 — File splits
 
@@ -373,11 +386,16 @@ Final sweep:
   Refined scope (SVAR stays as-is).
 - ❌ **PR3 (dropped):** the "~150 lines of overload boilerplate" reading was
   wrong; the overloads encode the Array/Ragged ADT. See the PR3 section above.
-- **PR4 (next):** `OpenRequest` + decompose `Dataset.open`. Depends on PR1's
-  factory being merged (done). Creates `_dataset/_open.py`.
-- **PR5** is the largest remaining architectural change and carries
-  numerical-parity risk. Sequenced after PRs 1, 2, 4 so the surrounding code is
-  already tidied (clearer blast radius, easier review).
+- ✅ **PR4 (shipped #187):** `OpenRequest` + decompose `Dataset.open`.
+  `_impl.py`: 2156 → 2015. New `_dataset/_open.py` with 10 small stage methods.
+- ✅ **PR5 (this PR):** `ReconstructionRequest` + restructure
+  `Haps._get_haplotypes`. Audit (before implementation) revealed two of the
+  original spec's premises were wrong (kernel already extracted; insertion-fill
+  branching not in `write_transformed_track`); spec was revised inline.
+  Parity-risk turned out to be low (kernel call args unchanged); the existing
+  test suite is the parity check.
+- **PR5c (next, small):** delete the 145 dead lines under
+  `Tracks.write_transformed_track`'s unconditional `NotImplementedError`.
 - **PR6** is mechanical and only worth doing once the boundaries from PRs 1, 5
   are real.
 - **PR7** is a finisher.

--- a/python/genvarloader/_dataset/_reconstruct.py
+++ b/python/genvarloader/_dataset/_reconstruct.py
@@ -718,9 +718,7 @@ class Haps(Reconstructor[_H]):
         data = self.variants.info[attr][genos.data]
         return Ragged.from_offsets(data, genos.shape, genos.offsets)
 
-    def _reconstruct_haplotypes(
-        self, req: ReconstructionRequest
-    ) -> Ragged[np.bytes_]:
+    def _reconstruct_haplotypes(self, req: ReconstructionRequest) -> Ragged[np.bytes_]:
         """Reconstruct haplotype byte sequences from sparse genotypes."""
         assert self.reference is not None
 

--- a/python/genvarloader/_dataset/_reconstruct.py
+++ b/python/genvarloader/_dataset/_reconstruct.py
@@ -6,7 +6,7 @@ import json
 import warnings
 from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
-from typing import Literal, Protocol, TypeVar, cast, overload
+from typing import Literal, Protocol, TypeVar, cast
 
 import awkward as ak
 import numpy as np
@@ -50,6 +50,44 @@ from ._tracks import shift_and_realign_tracks_sparse
 from ._utils import splits_sum_le_value
 
 T = TypeVar("T", covariant=True)
+
+
+@dataclass(frozen=True, slots=True)
+class ReconstructionRequest:
+    """Per-batch prep state for haplotype reconstruction.
+
+    Describes *what* to reconstruct: which variants apply for each
+    ``(region, sample, ploid)`` triple, what shifts to apply, where to write,
+    and (optionally) how to splice the output. Produced by
+    :meth:`Haps._prepare_request`; consumed by
+    :meth:`Haps._reconstruct_haplotypes` and
+    :meth:`Haps._reconstruct_annotated_haplotypes`.
+
+    Decoupled from region-major iteration: a caller (e.g. a future
+    variant-major reconstructor) can build a :class:`ReconstructionRequest`
+    directly and invoke the kernel-facing methods without going through
+    :meth:`Haps.get_haps_and_shifts`.
+    """
+
+    geno_offset_idx: NDArray[np.intp]
+    """Shape ``(batch, ploidy)``. Indices into the sparse-genotype offsets."""
+    regions: NDArray[np.int32]
+    """Shape ``(batch, 3)``. Regions ``(contig_idx, start, end)``."""
+    shifts: NDArray[np.int32]
+    """Shape ``(batch, ploidy)``. Per-haplotype shifts."""
+    out_offsets: NDArray[np.integer]
+    """Shape ``(batch*ploidy + 1)``. Offsets into the kernel's output buffer.
+    For spliced requests this is ``splice_plan.permuted_out_offsets``."""
+    diffs: NDArray[np.int32]
+    """Shape ``(batch, ploidy)``. Per-haplotype length deltas vs reference."""
+    hap_lengths: NDArray[np.int32]
+    """Shape ``(batch, ploidy)``. Per-haplotype output lengths."""
+    keep: NDArray[np.bool_] | None
+    """Optional keep mask (e.g. exonic filter), packed across batch*ploidy."""
+    keep_offsets: NDArray[np.integer] | None
+    """Offsets matching ``keep``, when ``keep`` is not None."""
+    splice_plan: SplicePlan | None
+    """If set, reconstruct into a spliced layout."""
 
 
 @dataclass(slots=True)
@@ -463,6 +501,56 @@ class Haps(Reconstructor[_H]):
         NDArray[np.bool_] | None,
         NDArray[np.int64] | None,
     ]:
+        req = self._prepare_request(
+            idx=idx,
+            regions=regions,
+            output_length=output_length,
+            rng=rng,
+            deterministic=deterministic,
+            splice_plan=splice_plan,
+        )
+
+        # (b p l), (b p l), (b p l)
+        if issubclass(self.kind, RaggedSeqs):
+            out = self._reconstruct_haplotypes(req)
+        elif issubclass(self.kind, RaggedAnnotatedHaps):
+            haps, annot_v_idx, annot_pos = self._reconstruct_annotated_haplotypes(req)
+            out = RaggedAnnotatedHaps(haps, annot_v_idx, annot_pos)
+        elif issubclass(self.kind, RaggedVariants):
+            if splice_plan is not None:
+                raise NotImplementedError(
+                    "Spliced output is not supported for RaggedVariants."
+                )
+            out = self._get_variants(
+                idx=idx,
+                regions=req.regions,
+                shifts=req.shifts,
+                keep=req.keep,
+                keep_offsets=req.keep_offsets,
+            )
+        else:
+            assert_never(self.kind)
+
+        return (
+            out,  # type: ignore | pylance doesn't like this but it's correct behavior for the signature
+            req.geno_offset_idx,
+            req.shifts,
+            req.diffs,
+            req.hap_lengths,
+            req.keep,
+            req.keep_offsets,
+        )
+
+    def _prepare_request(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.integer],
+        output_length: Literal["ragged", "variable"] | int,
+        rng: np.random.Generator,
+        deterministic: bool,
+        splice_plan: SplicePlan | None = None,
+    ) -> ReconstructionRequest:
+        """Compute the per-batch prep state for haplotype reconstruction."""
         ploidy = cast(int, self.genotypes.shape[-2])
         batch_size = len(idx)
         # (b)
@@ -474,9 +562,6 @@ class Haps(Reconstructor[_H]):
             raise NotImplementedError(
                 "Filtering by AF is not supported for haplotype output yet."
             )
-        else:
-            keep = None
-            keep_offsets = None
 
         if self.filter == "exonic":
             keep, keep_offsets = choose_exonic_variants(
@@ -506,19 +591,15 @@ class Haps(Reconstructor[_H]):
             # by up to:
             # the difference in length between the haplotype and the region
             # PLUS the difference in length between the region and the output_length
-            # (b)
-            # (b p)
             max_shift = diffs.clip(min=0)
-            # (b p) + (b 1)
             max_shift += (lengths - output_length).clip(min=0)[:, None]
-            # (b p)
             shifts = rng.integers(0, max_shift + 1, dtype=np.int32)
 
         if not isinstance(output_length, int):
-            # (b p)
             out_lengths = hap_lengths
         else:
             out_lengths = np.full((batch_size, ploidy), output_length, dtype=np.int32)
+
         if splice_plan is None:
             # (b*p+1)
             out_offsets = lengths_to_offsets(out_lengths, OFFSET_TYPE)
@@ -526,53 +607,16 @@ class Haps(Reconstructor[_H]):
             # Plan owns the (permuted) per-element offsets the kernel will use.
             out_offsets = splice_plan.permuted_out_offsets
 
-        # (b p l), (b p l), (b p l)
-        if issubclass(self.kind, RaggedSeqs):
-            out = self._get_haplotypes(
-                geno_offset_idx=geno_offset_idx,
-                regions=regions,
-                out_offsets=out_offsets,
-                shifts=shifts,
-                keep=keep,
-                keep_offsets=keep_offsets,
-                annotate=False,
-                splice_plan=splice_plan,
-            )
-        elif issubclass(self.kind, RaggedAnnotatedHaps):
-            haps, maybe_annot_v_idx, maybe_annot_pos = self._get_haplotypes(
-                geno_offset_idx=geno_offset_idx,
-                regions=regions,
-                out_offsets=out_offsets,
-                shifts=shifts,
-                keep=keep,
-                keep_offsets=keep_offsets,
-                annotate=True,
-                splice_plan=splice_plan,
-            )
-            out = RaggedAnnotatedHaps(haps, maybe_annot_v_idx, maybe_annot_pos)
-        elif issubclass(self.kind, RaggedVariants):
-            if splice_plan is not None:
-                raise NotImplementedError(
-                    "Spliced output is not supported for RaggedVariants."
-                )
-            out = self._get_variants(
-                idx=idx,
-                regions=regions,
-                shifts=shifts,
-                keep=keep,
-                keep_offsets=keep_offsets,
-            )
-        else:
-            assert_never(self.kind)
-
-        return (
-            out,  # type: ignore | pylance doesn't like this but it's correct behavior for the signature
-            geno_offset_idx,
-            shifts,
-            diffs,
-            hap_lengths,
-            keep,
-            keep_offsets,
+        return ReconstructionRequest(
+            geno_offset_idx=geno_offset_idx,
+            regions=regions.astype(np.int32, copy=False),
+            shifts=shifts,
+            out_offsets=out_offsets,
+            diffs=diffs,
+            hap_lengths=hap_lengths,
+            keep=keep,
+            keep_offsets=keep_offsets,
+            splice_plan=splice_plan,
         )
 
     @staticmethod
@@ -674,90 +718,24 @@ class Haps(Reconstructor[_H]):
         data = self.variants.info[attr][genos.data]
         return Ragged.from_offsets(data, genos.shape, genos.offsets)
 
-    @overload
-    def _get_haplotypes(
-        self,
-        geno_offset_idx: NDArray[np.integer],
-        regions: NDArray[np.integer],
-        out_offsets: NDArray[OFFSET_TYPE],
-        shifts: NDArray[np.integer],
-        keep: NDArray[np.bool_] | None,
-        keep_offsets: NDArray[OFFSET_TYPE] | None,
-        annotate: Literal[False],
-        splice_plan: SplicePlan | None = ...,
-    ) -> Ragged[np.bytes_]: ...
-    @overload
-    def _get_haplotypes(
-        self,
-        geno_offset_idx: NDArray[np.integer],
-        regions: NDArray[np.integer],
-        out_offsets: NDArray[OFFSET_TYPE],
-        shifts: NDArray[np.integer],
-        keep: NDArray[np.bool_] | None,
-        keep_offsets: NDArray[OFFSET_TYPE] | None,
-        annotate: Literal[True],
-        splice_plan: SplicePlan | None = ...,
-    ) -> tuple[Ragged[np.bytes_], Ragged[np.int32], Ragged[np.int32]]: ...
-
-    def _get_haplotypes(
-        self,
-        geno_offset_idx: NDArray[np.integer],
-        regions: NDArray[np.integer],
-        out_offsets: NDArray[OFFSET_TYPE],
-        shifts: NDArray[np.integer],
-        keep: NDArray[np.bool_] | None,
-        keep_offsets: NDArray[OFFSET_TYPE] | None,
-        annotate: bool,
-        splice_plan: SplicePlan | None = None,
-    ) -> (
-        Ragged[np.bytes_]
-        | tuple[Ragged[np.bytes_], Ragged[V_IDX_TYPE], Ragged[np.int32]]
-    ):
-        """Reconstruct haplotypes from sparse genotypes.
-
-        Parameters
-        ----------
-        geno_offset_idx
-            Shape: (queries). The genotype offset indices. i.e. the dataset indices.
-        regions
-            Shape: (queries). The regions to reconstruct.
-        out_offsets
-            Shape: (queries+1). Offsets for haplotypes and annotations.
-        shifts
-            Shape: (queries, ploidy). The shift for each haplotype.
-        keep
-            Ragged array, shape: (variants). Whether to keep each variant. Implicitly has the same offsets
-            as the sparse genotypes corresponding to geno_offset_idx.
-        """
+    def _reconstruct_haplotypes(
+        self, req: ReconstructionRequest
+    ) -> Ragged[np.bytes_]:
+        """Reconstruct haplotype byte sequences from sparse genotypes."""
         assert self.reference is not None
 
-        if splice_plan is None:
+        if req.splice_plan is None:
             haps = Ragged.from_offsets(
-                np.empty(out_offsets[-1], np.uint8), (*shifts.shape, None), out_offsets
+                np.empty(req.out_offsets[-1], np.uint8),
+                (*req.shifts.shape, None),
+                req.out_offsets,
             )
-
-            if annotate:
-                annot_v_idxs = Ragged.from_offsets(
-                    np.empty(out_offsets[-1], V_IDX_TYPE),
-                    (*shifts.shape, None),
-                    out_offsets,
-                )
-                annot_positions = Ragged.from_offsets(
-                    np.empty(out_offsets[-1], np.int32),
-                    (*shifts.shape, None),
-                    out_offsets,
-                )
-            else:
-                annot_v_idxs = None
-                annot_positions = None
-
-            # don't need to pass annot offsets because they are the same as haps offsets
             reconstruct_haplotypes_from_sparse(
-                geno_offset_idxs=geno_offset_idx,
+                geno_offset_idxs=req.geno_offset_idx,
                 out=haps.data,
                 out_offsets=haps.offsets,
-                regions=regions,
-                shifts=shifts,
+                regions=req.regions,
+                shifts=req.shifts,
                 geno_offsets=self.genotypes.offsets,
                 geno_v_idxs=self.genotypes.data,
                 v_starts=self.variants.start,
@@ -767,63 +745,120 @@ class Haps(Reconstructor[_H]):
                 ref=self.reference.reference,
                 ref_offsets=self.reference.offsets,
                 pad_char=self.reference.pad_char,
-                keep=keep,
-                keep_offsets=keep_offsets,
-                annot_v_idxs=annot_v_idxs.data
-                if annot_v_idxs is not None
-                else annot_v_idxs,
-                annot_ref_pos=annot_positions.data
-                if annot_positions is not None
-                else annot_positions,
+                keep=req.keep,
+                keep_offsets=req.keep_offsets,
+                annot_v_idxs=None,
+                annot_ref_pos=None,
             )
-            haps = cast(Ragged[np.bytes_], haps.view("S1"))
-
-            if annotate:
-                return haps, annot_v_idxs, annot_positions  # type: ignore
-            else:
-                return haps
+            return cast(Ragged[np.bytes_], haps.view("S1"))
 
         # ---- splice plan path ----
-        # geno_offset_idx, shifts have shape (B, P). Flatten to (B*P,) in
-        # (query, ploidy) C-order, then permute. Then call the kernel with
-        # ploidy=1 over the B*P flattened queries.
-        P = shifts.shape[1] if shifts.ndim > 1 else 1
-        perm = splice_plan.perm
-        flat_geno_idx = geno_offset_idx.reshape(-1)[perm].astype(np.intp, copy=False)
-        flat_shifts = shifts.reshape(-1)[perm].astype(np.int32, copy=False)
-        # regions has shape (B, 3). For (B*P, 3), each query repeats P times
-        # consecutively, then we apply the same perm.
-        regions_flat = np.repeat(regions, P, axis=0)
-        permuted_regions = regions_flat[perm]
+        flat_geno_idx, flat_shifts, permuted_regions, keep_perm, keep_offsets_perm = (
+            self._permute_request_for_splice(req)
+        )
+        splice_plan = req.splice_plan
 
-        # keep / keep_offsets: per-k granularity (length B*P + 1).
-        if keep is not None and keep_offsets is not None:
-            keep_lens = np.diff(keep_offsets)
-            keep_lens_perm = keep_lens[perm]
-            keep_offsets_perm = lengths_to_offsets(
-                keep_lens_perm.astype(np.int64), dtype=np.int64
-            )
-            keep_perm = np.empty(int(keep_lens_perm.sum()), dtype=np.bool_)
-            write_cursor = 0
-            for k_old in perm:
-                s = int(keep_offsets[k_old])
-                e = int(keep_offsets[k_old + 1])
-                width = e - s
-                keep_perm[write_cursor : write_cursor + width] = keep[s:e]
-                write_cursor += width
-        else:
-            keep_perm = None
-            keep_offsets_perm = None
-
-        # Allocate output buffers sized for the total permuted bytes.
         total = int(splice_plan.permuted_out_offsets[-1])
         out_buf = np.empty(total, np.uint8)
-        if annotate:
-            annot_v_buf = np.empty(total, V_IDX_TYPE)
-            annot_pos_buf = np.empty(total, np.int32)
-        else:
-            annot_v_buf = None
-            annot_pos_buf = None
+
+        reconstruct_haplotypes_from_sparse(
+            geno_offset_idxs=flat_geno_idx.reshape(-1, 1),
+            out=out_buf,
+            out_offsets=splice_plan.permuted_out_offsets,
+            regions=permuted_regions,
+            shifts=flat_shifts.reshape(-1, 1),
+            geno_offsets=self.genotypes.offsets,
+            geno_v_idxs=self.genotypes.data,
+            v_starts=self.variants.start,
+            ilens=self.variants.ilen,
+            alt_alleles=self.variants.alt.data.view(np.uint8),
+            alt_offsets=self.variants.alt.offsets,
+            ref=self.reference.reference,
+            ref_offsets=self.reference.offsets,
+            pad_char=self.reference.pad_char,
+            keep=keep_perm,
+            keep_offsets=keep_offsets_perm,
+            annot_v_idxs=None,
+            annot_ref_pos=None,
+        )
+
+        # Return per-element Ragged. The caller applies RC and re-wraps with
+        # group_offsets / out_shape afterwards.
+        per_elem_shape = (splice_plan.permuted_lengths.shape[0], None)
+        return cast(
+            Ragged[np.bytes_],
+            Ragged.from_offsets(
+                out_buf.view("S1"),
+                per_elem_shape,
+                splice_plan.permuted_out_offsets,
+            ),
+        )
+
+    def _reconstruct_annotated_haplotypes(
+        self, req: ReconstructionRequest
+    ) -> tuple[Ragged[np.bytes_], Ragged[V_IDX_TYPE], Ragged[np.int32]]:
+        """Reconstruct haplotypes plus per-nucleotide annotations.
+
+        Returns the haplotype bytes, the variant index at each position
+        (or -1 for reference), and the reference coordinate at each position
+        (or -1 for padded bases).
+        """
+        assert self.reference is not None
+
+        if req.splice_plan is None:
+            haps = Ragged.from_offsets(
+                np.empty(req.out_offsets[-1], np.uint8),
+                (*req.shifts.shape, None),
+                req.out_offsets,
+            )
+            annot_v_idxs = Ragged.from_offsets(
+                np.empty(req.out_offsets[-1], V_IDX_TYPE),
+                (*req.shifts.shape, None),
+                req.out_offsets,
+            )
+            annot_positions = Ragged.from_offsets(
+                np.empty(req.out_offsets[-1], np.int32),
+                (*req.shifts.shape, None),
+                req.out_offsets,
+            )
+
+            # annot offsets match haps offsets, so we share them.
+            reconstruct_haplotypes_from_sparse(
+                geno_offset_idxs=req.geno_offset_idx,
+                out=haps.data,
+                out_offsets=haps.offsets,
+                regions=req.regions,
+                shifts=req.shifts,
+                geno_offsets=self.genotypes.offsets,
+                geno_v_idxs=self.genotypes.data,
+                v_starts=self.variants.start,
+                ilens=self.variants.ilen,
+                alt_alleles=self.variants.alt.data.view(np.uint8),
+                alt_offsets=self.variants.alt.offsets,
+                ref=self.reference.reference,
+                ref_offsets=self.reference.offsets,
+                pad_char=self.reference.pad_char,
+                keep=req.keep,
+                keep_offsets=req.keep_offsets,
+                annot_v_idxs=annot_v_idxs.data,
+                annot_ref_pos=annot_positions.data,
+            )
+            return (
+                cast(Ragged[np.bytes_], haps.view("S1")),
+                annot_v_idxs,
+                annot_positions,
+            )
+
+        # ---- splice plan path ----
+        flat_geno_idx, flat_shifts, permuted_regions, keep_perm, keep_offsets_perm = (
+            self._permute_request_for_splice(req)
+        )
+        splice_plan = req.splice_plan
+
+        total = int(splice_plan.permuted_out_offsets[-1])
+        out_buf = np.empty(total, np.uint8)
+        annot_v_buf = np.empty(total, V_IDX_TYPE)
+        annot_pos_buf = np.empty(total, np.int32)
 
         reconstruct_haplotypes_from_sparse(
             geno_offset_idxs=flat_geno_idx.reshape(-1, 1),
@@ -846,8 +881,6 @@ class Haps(Reconstructor[_H]):
             annot_ref_pos=annot_pos_buf,
         )
 
-        # Return per-element Ragged. The caller (Task 5) will apply RC and
-        # re-wrap with group_offsets / out_shape after that.
         per_elem_shape = (splice_plan.permuted_lengths.shape[0], None)
         haps_rag = cast(
             Ragged[np.bytes_],
@@ -857,15 +890,69 @@ class Haps(Reconstructor[_H]):
                 splice_plan.permuted_out_offsets,
             ),
         )
-        if annotate:
-            annot_v_rag = Ragged.from_offsets(
-                annot_v_buf, per_elem_shape, splice_plan.permuted_out_offsets
+        annot_v_rag = Ragged.from_offsets(
+            annot_v_buf, per_elem_shape, splice_plan.permuted_out_offsets
+        )
+        annot_pos_rag = Ragged.from_offsets(
+            annot_pos_buf, per_elem_shape, splice_plan.permuted_out_offsets
+        )
+        return haps_rag, annot_v_rag, annot_pos_rag
+
+    def _permute_request_for_splice(
+        self, req: ReconstructionRequest
+    ) -> tuple[
+        NDArray[np.intp],
+        NDArray[np.int32],
+        NDArray[np.int32],
+        NDArray[np.bool_] | None,
+        NDArray[np.integer] | None,
+    ]:
+        """Permute the per-element arrays in ``req`` according to ``splice_plan.perm``.
+
+        ``geno_offset_idx`` and ``shifts`` have shape ``(B, P)``; flatten to
+        ``(B*P,)`` in (query, ploidy) C-order, then permute. The kernel then
+        runs with ploidy=1 over the ``B*P`` flattened queries.
+        """
+        assert req.splice_plan is not None
+        splice_plan = req.splice_plan
+        ploidy = req.shifts.shape[1] if req.shifts.ndim > 1 else 1
+        perm = splice_plan.perm
+
+        flat_geno_idx = req.geno_offset_idx.reshape(-1)[perm].astype(
+            np.intp, copy=False
+        )
+        flat_shifts = req.shifts.reshape(-1)[perm].astype(np.int32, copy=False)
+        # regions has shape (B, 3). For (B*P, 3), each query repeats P times
+        # consecutively, then we apply the same perm.
+        regions_flat = np.repeat(req.regions, ploidy, axis=0)
+        permuted_regions = regions_flat[perm]
+
+        # keep / keep_offsets: per-k granularity (length B*P + 1).
+        if req.keep is not None and req.keep_offsets is not None:
+            keep_lens = np.diff(req.keep_offsets)
+            keep_lens_perm = keep_lens[perm]
+            keep_offsets_perm = lengths_to_offsets(
+                keep_lens_perm.astype(np.int64), dtype=np.int64
             )
-            annot_pos_rag = Ragged.from_offsets(
-                annot_pos_buf, per_elem_shape, splice_plan.permuted_out_offsets
-            )
-            return haps_rag, annot_v_rag, annot_pos_rag  # type: ignore
-        return haps_rag
+            keep_perm = np.empty(int(keep_lens_perm.sum()), dtype=np.bool_)
+            write_cursor = 0
+            for k_old in perm:
+                s = int(req.keep_offsets[k_old])
+                e = int(req.keep_offsets[k_old + 1])
+                width = e - s
+                keep_perm[write_cursor : write_cursor + width] = req.keep[s:e]
+                write_cursor += width
+        else:
+            keep_perm = None
+            keep_offsets_perm = None
+
+        return (
+            flat_geno_idx,
+            flat_shifts,
+            permuted_regions,
+            keep_perm,
+            keep_offsets_perm,
+        )
 
 
 class TrackType(enum.Enum):


### PR DESCRIPTION
## Summary

- Introduce `ReconstructionRequest` (frozen dataclass) holding the per-batch prep state.
- Extract `Haps._prepare_request` out of `get_haps_and_shifts` to compute it.
- Replace `Haps._get_haplotypes` (2 `@overload` stubs + 1 impl, ~167 lines) with two named methods: `_reconstruct_haplotypes(req)` and `_reconstruct_annotated_haplotypes(req)`. **Overload triplet eliminated.**
- Shared splice-plan permutation prep is extracted into `_permute_request_for_splice(req)`.
- `get_haps_and_shifts` becomes a two-stage op (`_prepare_request` → dispatch on `self.kind`). 7-tuple return shape preserved so `HapsTracks.__call__` consumers stay unchanged.

**Decoupling win:** a future variant-major reconstructor can construct a `ReconstructionRequest` directly and invoke the kernel-facing methods, without going through region-major `_prepare_request`.

## Spec audit folded in

Before implementing, I audited the original PR5 spec premises against the code and disproved two:

1. **"Extract the haplotype kernel"** — already done. `_dataset/_genotypes.py:reconstruct_haplotypes_from_sparse` is a pure numba function taking raw arrays. A future variant-major class can call it directly.
2. **"`Tracks.write_transformed_track` is 166 lines of insertion-fill branching"** — wrong. Line 1189 unconditionally raises `NotImplementedError`; the 145 lines below are unreachable dead code with zero insertion-fill branching. **Carved out as PR5c (next, small)** — delete the dead body.

Spec at `docs/superpowers/specs/2026-05-23-refactor-campaign-design.md` is updated inline to reflect these findings.

## Numerical parity

The kernel calls (`reconstruct_haplotypes_from_sparse`) are unchanged — same args, same library call. The change is a reorganization of the Python wrapper. Parity is verified by the existing test suite (488 pytest + cargo). The original spec's "medium parity risk" assessment turned out to be overstated.

## Test plan

- [x] `pixi run -e dev test` (488 pytest + cargo) — all pass
- [x] `pixi run -e dev ruff check python/` — clean
- [x] `pixi run -e dev pyrefly check` — 0 errors (baseline unchanged)

Part of the refactor campaign tracked in `docs/superpowers/specs/2026-05-23-refactor-campaign-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)