### PR TITLE
Temporarily disable gvl.Table to avoid polars-bio segfault on py3.13

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11282,7 +11282,6 @@ packages:
   - hirola>=0.3,<0.4
   - seqpro>=0.11.0
   - genoray>=2.4.0,<3
-  - polars-bio>=0.20,<0.21
   - genvarloader-cli>=0.1.0 ; extra == 'cli'
   - tbb ; extra == 'tbb'
   - pyomp ; extra == 'pyomp'

--- a/pixi.toml
+++ b/pixi.toml
@@ -104,7 +104,6 @@ awkward = "*"
 pydantic = ">=2,<3"
 hypothesis = "*"
 filelock = "*"
-polars-bio = ">=0.20,<0.21"
 
 [feature.py311.dependencies]
 python = "3.11.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "hirola>=0.3,<0.4",
     "seqpro>=0.11.0",
     "genoray>=2.4.0,<3",
-    "polars-bio>=0.20,<0.21",
 ]
 
 [project.optional-dependencies]

--- a/python/genvarloader/_table.py
+++ b/python/genvarloader/_table.py
@@ -24,8 +24,30 @@ if TYPE_CHECKING:
 CANONICAL_COLS = ("sample_id", "chrom", "start", "end", "value")
 
 
+#: ``gvl.Table`` is temporarily disabled: its backend, ``polars-bio``,
+#: intermittently segfaults the interpreter during overlap queries (a
+#: non-deterministic native-runtime issue observed on CPython 3.12 and 3.13).
+#: ``polars-bio`` has been removed from genvarloader's direct dependencies (it
+#: remains an indirect dependency of ``genoray``). Re-enable by reverting this
+#: commit once the upstream issue is resolved.
+#: Upstream: https://github.com/biodatageeks/polars-bio/issues/395
+_TABLE_DISABLED_MSG = (
+    "gvl.Table is temporarily disabled because its polars-bio backend "
+    "intermittently segfaults during overlap queries (upstream "
+    "https://github.com/biodatageeks/polars-bio/issues/395). Use gvl.BigWigs "
+    "for track input in the meantime."
+)
+
+
 class Table:
-    """Long-form interval track keyed by ``(sample_id, chrom, start, end, value)``."""
+    """Long-form interval track keyed by ``(sample_id, chrom, start, end, value)``.
+
+    .. warning::
+        Temporarily disabled. Constructing a :class:`Table` raises
+        :class:`NotImplementedError` while the ``polars-bio`` segfault
+        (`#395 <https://github.com/biodatageeks/polars-bio/issues/395>`_) is
+        unresolved. Use :class:`BigWigs` for track input in the meantime.
+    """
 
     name: str
     samples: list[str]
@@ -37,6 +59,7 @@ class Table:
         data: pl.DataFrame | Mapping[str, pl.DataFrame],
         column_map: Mapping[str, str] | None = None,
     ) -> None:
+        raise NotImplementedError(_TABLE_DISABLED_MSG)
         self.name = name
         df = self._normalize_input(data, column_map)
         df = df.cast(

--- a/tests/integration/dataset/test_write_tracks_e2e.py
+++ b/tests/integration/dataset/test_write_tracks_e2e.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 import genvarloader as gvl
@@ -7,13 +6,13 @@ import polars as pl
 import pytest
 from genvarloader._table import Table
 
-# polars-bio's overlap kernel segfaults on CPython 3.12 (passes on 3.11 and 3.13).
-# The eager pb.overlap done by Table writes poisons the process so a later lazy
-# pb.overlap().collect() (the variant write path) crashes the interpreter.
+# gvl.Table is temporarily disabled (polars-bio backend intermittently segfaults
+# on CPython 3.12 and 3.13; polars-bio removed as a direct dependency, still
+# transitive via genoray). These Table-driven end-to-end write tests are skipped
+# until it is re-enabled.
 # Upstream: https://github.com/biodatageeks/polars-bio/issues/395
-pytestmark = pytest.mark.skipif(
-    sys.version_info[:2] == (3, 12),
-    reason="polars-bio overlap segfaults on py3.12; see "
+pytestmark = pytest.mark.skip(
+    reason="gvl.Table temporarily disabled pending polars-bio segfault fix; see "
     "https://github.com/biodatageeks/polars-bio/issues/395",
 )
 

--- a/tests/unit/dataset/test_write_tracks.py
+++ b/tests/unit/dataset/test_write_tracks.py
@@ -1,15 +1,14 @@
-import sys
-
 import genvarloader as gvl
 import polars as pl
 import pytest
 
-# polars-bio's overlap kernel segfaults on CPython 3.12 (passes on 3.11 and 3.13);
-# Table-driven gvl.write poisons the interpreter for later variant writes.
+# gvl.Table is temporarily disabled (polars-bio backend intermittently segfaults
+# on CPython 3.12 and 3.13; polars-bio removed as a direct dependency, still
+# transitive via genoray). These Table-driven write tests are skipped until it
+# is re-enabled.
 # Upstream: https://github.com/biodatageeks/polars-bio/issues/395
-pytestmark = pytest.mark.skipif(
-    sys.version_info[:2] == (3, 12),
-    reason="polars-bio overlap segfaults on py3.12; see "
+pytestmark = pytest.mark.skip(
+    reason="gvl.Table temporarily disabled pending polars-bio segfault fix; see "
     "https://github.com/biodatageeks/polars-bio/issues/395",
 )
 

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1,19 +1,17 @@
-import sys
-
 import numpy as np
 import polars as pl
 import pytest
 from genvarloader._table import Table
 from genvarloader._utils import lengths_to_offsets
 
-# polars-bio's overlap kernel segfaults on CPython 3.12 (passes on 3.11 and 3.13).
-# The eager pb.overlap done by Table operations poisons the process so that a
-# later lazy pb.overlap().collect() (variant write path) crashes. Skip the whole
-# module on 3.12 to avoid poisoning the shared interpreter for downstream tests.
+# gvl.Table is temporarily disabled: its polars-bio backend intermittently
+# segfaults during overlap queries (observed on CPython 3.12 and 3.13).
+# polars-bio is no longer a direct dependency (still transitive via genoray).
+# These functional tests are skipped until it is re-enabled; see
+# tests/unit/test_table_disabled.py for the active disabled-state assertion.
 # Upstream: https://github.com/biodatageeks/polars-bio/issues/395
-pytestmark = pytest.mark.skipif(
-    sys.version_info[:2] == (3, 12),
-    reason="polars-bio overlap segfaults on py3.12; see "
+pytestmark = pytest.mark.skip(
+    reason="gvl.Table temporarily disabled pending polars-bio segfault fix; see "
     "https://github.com/biodatageeks/polars-bio/issues/395",
 )
 

--- a/tests/unit/test_table_disabled.py
+++ b/tests/unit/test_table_disabled.py
@@ -1,0 +1,34 @@
+"""gvl.Table is temporarily disabled because its polars-bio backend
+intermittently segfaults during overlap queries (observed on CPython 3.12 and
+3.13). polars-bio has been removed as a direct dependency (it remains transitive
+via genoray). This asserts the disabled state so the functional Table tests
+(skipped) can be re-enabled deliberately once the upstream issue is resolved.
+
+Upstream: https://github.com/biodatageeks/polars-bio/issues/395
+"""
+
+import polars as pl
+import pytest
+
+import genvarloader as gvl
+
+
+def test_table_construction_raises_not_implemented():
+    df = pl.DataFrame(
+        {
+            "sample_id": ["s0"],
+            "chrom": ["chr1"],
+            "start": [0],
+            "end": [10],
+            "value": [1.0],
+        }
+    )
+    with pytest.raises(NotImplementedError, match="temporarily disabled"):
+        gvl.Table("signal", df)
+
+
+def test_table_from_path_raises_not_implemented(tmp_path):
+    p = tmp_path / "track.csv"
+    p.write_text("sample_id,chrom,start,end,value\ns0,chr1,0,10,1.0\n")
+    with pytest.raises(NotImplementedError, match="temporarily disabled"):
+        gvl.Table.from_path("signal", p)


### PR DESCRIPTION
## Summary

`polars-bio`'s overlap kernel intermittently segfaults the interpreter (`SIGSEGV` in `polars_bio/range_op_io.py:_range_source`) — a **non-deterministic** native-runtime issue (upstream [biodatageeks/polars-bio#395](https://github.com/biodatageeks/polars-bio/issues/395)). It was previously dodged with a **py3.12-only** test skip, but it now also hits **py3.13** (confirmed: same code passes/fails across adjacent commits and re-runs).

`gvl.Table` is the only genvarloader consumer of polars-bio's `overlap`, and it's not yet used by anyone. So this disables it rather than chasing an unverified version bump (#395 is still open):

- `Table.__init__` now raises `NotImplementedError` pointing at the upstream issue (use `gvl.BigWigs` for track input).
- Its functional tests (`test_table.py`, `test_write_tracks.py`, `test_write_tracks_e2e.py`) are skipped on **all** versions (was py3.12-only).
- `polars-bio` removed as a **direct** dependency (`pyproject.toml` + `pixi.toml`). It remains an **indirect** dependency of `genoray` (which imports it in `_var_ranges.py`), so it stays installed — genvarloader just no longer pins it directly.
- New `tests/unit/test_table_disabled.py` asserts the disabled state, so the skipped Table tests can be re-enabled deliberately once #395 is resolved.

Re-enable later by reverting this commit (and revisiting a polars-bio bump) once upstream fixes the segfault.

## Test Plan

- [x] `tests/unit/test_table_disabled.py` passes (Table construction / `from_path` raise `NotImplementedError`).
- [x] Table functional modules skip on all versions (19 skipped locally).
- [x] `ruff check` clean on changed files.
- [ ] CI py3.10–3.13 green (the goal — py3.13 no longer crashes since the Table overlap path is disabled). CI generates test data via the `test` task; local full-suite run here was blocked only by ungenerated `tests/data` (gitignored), not by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)