### PR TITLE
fix(open): default to variants when genotypes have no reference

### DIFF
--- a/python/genvarloader/_dataset/_open.py
+++ b/python/genvarloader/_dataset/_open.py
@@ -180,7 +180,9 @@ class OpenRequest:
     def _initial_seqs_kind(seqs: Haps | Ref | None) -> SeqsKind:
         # Default view kind for each storage shape.
         if isinstance(seqs, Haps):
-            return "haplotypes"
+            # Without a reference we can't reconstruct haplotypes; the only
+            # sequence view Haps.to_kind allows is RaggedVariants.
+            return "haplotypes" if seqs.reference is not None else "variants"
         if isinstance(seqs, Ref):
             return "reference"
         return None

--- a/skills/genvarloader/SKILL.md
+++ b/skills/genvarloader/SKILL.md
@@ -124,7 +124,7 @@ gvl.Dataset.open(
 )
 ```
 
-Without `reference=`, only variants/haplotypes are available (you can't produce reference-overlaid sequences). `svar=` overrides the recorded SVAR location.
+Without `reference=`, a genotypes-only dataset opens with the **`"variants"`** view by default (yielding `RaggedVariants`) — `Dataset.open(path)` just works, no `with_seqs` needed. The `"haplotypes"`, `"annotated"`, and `"reference"` views all require a reference; requesting one via `with_seqs` on a reference-less dataset raises a clear `ValueError`. `svar=` overrides the recorded SVAR location.
 
 **Format validation:** `Dataset.open` validates the dataset's `format_version` and structural integrity (file presence + sizes). An incompatible or corrupt dataset raises a `ValueError` instructing regeneration with `gvl.write`. Datasets do **not** auto-rebuild.
 
@@ -278,6 +278,7 @@ See `docs/source/format.md` for the full schema, versioning, and SVAR-link detai
 ## Common gotchas
 
 - **Symbolic / breakend variants are rejected, not skipped.** Remove them before `gvl.write` — e.g. `bcftools view -e 'ALT~"<" || ALT~"\["'` (drop SVs and breakends), or construct the genoray reader with `filter=genoray.exprs.is_biallelic & ~genoray.exprs.is_symbolic & ~genoray.exprs.is_breakend`. SVAR inputs must be built from an already-filtered source, since gvl validates but cannot re-filter a materialized `.svar`.
+- Opening a genotypes-only dataset without a `reference=` defaults to the `"variants"` view (`RaggedVariants`), not `"haplotypes"`. Only `"variants"` is available without a reference; `with_seqs("haplotypes" | "annotated" | "reference")` raises `ValueError` if no reference was provided.
 - `with_insertion_fill` raises unless the dataset has both haplotypes AND tracks active.
 - `min_af` / `max_af` raise unless the dataset is SVAR-backed.
 - `with_len(L)` requires `L + 2·jitter ≤ min(region_length) + 2·max_jitter` — set `max_jitter` accordingly at `write` time.

--- a/tests/unit/dataset/test_open_no_reference.py
+++ b/tests/unit/dataset/test_open_no_reference.py
@@ -21,7 +21,11 @@ def test_open_without_reference_defaults_to_variants(fixture_name, request):
 
 def test_open_without_reference_indexing_yields_variants(phased_vcf_gvl):
     ds = gvl.Dataset.open(phased_vcf_gvl)
-    # List indices (no squeeze) return the batched sequence object directly;
-    # scalar indices would squeeze to an awkward Record, so use lists here.
+    # List indices (no squeeze) return the batched output directly; scalar
+    # indices would squeeze to an awkward Record, so use lists here. A track
+    # may ride along as a (seqs, track) tuple if the variant source carries
+    # annotations (this is platform/bcftools dependent), so assert on the
+    # sequence channel rather than the exact tuple shape.
     out = ds[[0], [0]]
-    assert isinstance(out, gvl.RaggedVariants)
+    seqs = out[0] if isinstance(out, tuple) else out
+    assert isinstance(seqs, gvl.RaggedVariants)

--- a/tests/unit/dataset/test_open_no_reference.py
+++ b/tests/unit/dataset/test_open_no_reference.py
@@ -1,0 +1,27 @@
+"""Regression: opening a genotypes-only dataset without a reference must
+default to the 'variants' view (RaggedVariants), not crash trying to build
+haplotypes. See docs/superpowers/specs/2026-06-07-open-variants-no-reference-design.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import genvarloader as gvl
+
+
+@pytest.mark.parametrize(
+    "fixture_name", ["phased_vcf_gvl", "phased_pgen_gvl", "phased_svar_gvl"]
+)
+def test_open_without_reference_defaults_to_variants(fixture_name, request):
+    path = request.getfixturevalue(fixture_name)
+    ds = gvl.Dataset.open(path)
+    assert ds.sequence_type == "variants"
+
+
+def test_open_without_reference_indexing_yields_variants(phased_vcf_gvl):
+    ds = gvl.Dataset.open(phased_vcf_gvl)
+    # List indices (no squeeze) return the batched sequence object directly;
+    # scalar indices would squeeze to an awkward Record, so use lists here.
+    out = ds[[0], [0]]
+    assert isinstance(out, gvl.RaggedVariants)


### PR DESCRIPTION
## Summary
- `Dataset.open` on a genotypes-only dataset with no reference crashed in `OpenRequest._initial_seqs_kind`, which always picked `"haplotypes"` and then failed in `Haps.to_kind(RaggedSeqs)` with `ValueError: Cannot return RaggedSeqs: no reference genome was provided.`
- Make the default reference-aware: a `Haps` with no reference now defaults to `"variants"` (the only sequence view `Haps.to_kind` permits without a reference), so the dataset resolves to `RaggedDataset[RaggedVariants, ...]`. Datasets that *do* have a reference still default to `"haplotypes"`/`"reference"` as before.
- Adds `tests/unit/dataset/test_open_no_reference.py`: parametrized regression across all three variant sources (VCF/PGEN/SVAR) asserting `sequence_type == "variants"`, plus an end-to-end indexing test asserting a `RaggedVariants` is returned.

## Test Plan
- [x] `pixi run -e dev pytest tests/unit/dataset/test_open_no_reference.py -v` — 4 passed
- [x] `pixi run -e dev pytest tests/unit/dataset -q` — 136 passed, 0 failures (after `gen`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)