### PR TITLE
docs: spec + plan for open-without-reference defaults to variants

### DIFF
--- a/docs/superpowers/plans/2026-06-07-open-variants-no-reference.md
+++ b/docs/superpowers/plans/2026-06-07-open-variants-no-reference.md
@@ -1,0 +1,158 @@
+# `Dataset.open` Without Reference Defaults to Variants — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `gvl.Dataset.open(path)` on a genotypes-only dataset with no reference resolve to a working `RaggedDataset[RaggedVariants, ...]` instead of raising `ValueError: Cannot return RaggedSeqs: no reference genome was provided.`
+
+**Architecture:** The single decision point for the default sequence view is `OpenRequest._initial_seqs_kind` in `python/genvarloader/_dataset/_open.py`. It currently returns `"haplotypes"` for any `Haps` storage. We make it reference-aware: a `Haps` with no reference defaults to `"variants"` (the only sequence view `Haps.to_kind` permits without a reference). `_build_reconstructor` and `Haps.to_kind` stay unchanged — they are already correct; only the chosen default was impossible.
+
+**Tech Stack:** Python, pytest, pixi (`pixi run -e dev`), maturin (Rust extension auto-built on test run).
+
+---
+
+## Background (read before starting)
+
+The crash, confirmed by repro:
+
+```python
+import genvarloader as gvl
+gvl.Dataset.open("tests/data/phased_dataset.vcf.gvl")
+# ValueError: Cannot return RaggedSeqs: no reference genome was provided.
+```
+
+Chain of events:
+- `OpenRequest._initial_seqs_kind` (`_open.py:180-186`) returns `"haplotypes"` for any `Haps`.
+- `OpenRequest.resolve` (`_open.py:76`) calls `_build_reconstructor(seqs, tracks, "haplotypes")`.
+- `_build_reconstructor` (`_reconstruct.py:269-279`) calls `seqs.to_kind(RaggedSeqs)`.
+- `Haps.to_kind` (`_haps.py:495-500`) raises because `kind != RaggedVariants and self.reference is None`.
+
+The fix flips the default to `"variants"` when the `Haps` has no reference. `RaggedVariants` is the only kind `to_kind` allows without a reference, so this is the unique correct default. `with_seqs("haplotypes" | "annotated" | "reference")` already validates reference presence later and raises a clear error if missing, so nothing downstream regresses.
+
+**Test fixtures** live in `tests/conftest.py` (session-scoped, available to all subdirectories):
+- `phased_vcf_gvl`, `phased_pgen_gvl`, `phased_svar_gvl` — each yields a `Path` to a genotypes-only, reference-less gvl dataset (one per variant source). These are the exact datasets that trigger the bug.
+
+**Return-shape contract:** For a seqs-only dataset with no active tracks, `RaggedDataset.__getitem__` returns the sequence object directly (the `RaggedDataset[RSEQ, None]` overload returns `RSEQ`), so `ds[region_idx, sample_idx]` yields a `RaggedVariants` — not a tuple. The phased fixtures have no tracks.
+
+---
+
+## File Structure
+
+- **Modify:** `python/genvarloader/_dataset/_open.py` — `_initial_seqs_kind` (lines 179-186). One logic change.
+- **Create:** `tests/unit/dataset/test_open_no_reference.py` — regression tests covering all three variant sources plus an end-to-end indexing assertion.
+
+---
+
+## Task 1: Genotypes-only dataset opens as variants and indexes to RaggedVariants
+
+**Files:**
+- Create: `tests/unit/dataset/test_open_no_reference.py`
+- Modify: `python/genvarloader/_dataset/_open.py:179-186`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/dataset/test_open_no_reference.py` with exactly this content:
+
+```python
+"""Regression: opening a genotypes-only dataset without a reference must
+default to the 'variants' view (RaggedVariants), not crash trying to build
+haplotypes. See docs/superpowers/specs/2026-06-07-open-variants-no-reference-design.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import genvarloader as gvl
+
+
+@pytest.mark.parametrize(
+    "fixture_name", ["phased_vcf_gvl", "phased_pgen_gvl", "phased_svar_gvl"]
+)
+def test_open_without_reference_defaults_to_variants(fixture_name, request):
+    path = request.getfixturevalue(fixture_name)
+    ds = gvl.Dataset.open(path)
+    assert ds.sequence_type == "variants"
+
+
+def test_open_without_reference_indexing_yields_variants(phased_vcf_gvl):
+    ds = gvl.Dataset.open(phased_vcf_gvl)
+    out = ds[0, 0]
+    assert isinstance(out, gvl.RaggedVariants)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_open_no_reference.py -v`
+
+Expected: all cases FAIL with `ValueError: Cannot return RaggedSeqs: no reference genome was provided.` (raised from `Haps.to_kind` during `Dataset.open`).
+
+- [ ] **Step 3: Apply the fix**
+
+In `python/genvarloader/_dataset/_open.py`, replace the `_initial_seqs_kind` method (lines 179-186):
+
+```python
+    @staticmethod
+    def _initial_seqs_kind(seqs: Haps | Ref | None) -> SeqsKind:
+        # Default view kind for each storage shape.
+        if isinstance(seqs, Haps):
+            return "haplotypes"
+        if isinstance(seqs, Ref):
+            return "reference"
+        return None
+```
+
+with:
+
+```python
+    @staticmethod
+    def _initial_seqs_kind(seqs: Haps | Ref | None) -> SeqsKind:
+        # Default view kind for each storage shape.
+        if isinstance(seqs, Haps):
+            # Without a reference we can't reconstruct haplotypes; the only
+            # sequence view Haps.to_kind allows is RaggedVariants.
+            return "haplotypes" if seqs.reference is not None else "variants"
+        if isinstance(seqs, Ref):
+            return "reference"
+        return None
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_open_no_reference.py -v`
+
+Expected: all 4 cases PASS.
+
+- [ ] **Step 5: Run the broader dataset suite to confirm no regression**
+
+Run: `pixi run -e dev pytest tests/unit/dataset tests/dataset -q`
+
+Expected: PASS (no new failures). This confirms datasets that *do* have a reference still default to `"haplotypes"`/`"reference"` as before.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_open.py tests/unit/dataset/test_open_no_reference.py
+rtk git commit -m "fix(open): default to variants when genotypes have no reference
+
+Dataset.open on a genotypes-only dataset with no reference crashed in
+_initial_seqs_kind, which always picked 'haplotypes' and then failed in
+Haps.to_kind(RaggedSeqs). Default to 'variants' when reference is None so
+the dataset resolves to RaggedDataset[RaggedVariants, ...].
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Fix in `_initial_seqs_kind` → Task 1 Step 3. ✓
+- `variants` is the unique correct default without a reference → covered; `Haps.to_kind` only permits `RaggedVariants` without a reference. ✓
+- Genotypes + tracks → `RaggedDataset[RaggedVariants, RaggedTracks]` with tracks active → no code change needed (the factory already builds `HapsTracks` for `seqs_kind="variants"`, a state reachable today via `with_seqs("variants")`); the phased fixtures have no tracks so the indexing test asserts the no-tracks shape (direct `RaggedVariants`). The combined state is exercised by existing `with_seqs("variants")` tests, so no new task is required.
+- All three fixtures (vcf/pgen/svar) + indexing → Task 1 Steps 1-2 (parametrized open across all three; indexing on vcf). ✓
+- TDD (failing test first) → Task 1 Steps 1-2 before Step 3. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/vague steps. Every code step shows full code. ✓
+
+**Type consistency:** `_initial_seqs_kind` signature and `SeqsKind` return type unchanged; `"variants"` is a valid member of `SeqsKind` (`_open.py:36`). `gvl.RaggedVariants` is exported (`__init__.py:45`). `ds.sequence_type` is a public property (`_impl.py:835`). ✓

--- a/docs/superpowers/specs/2026-06-07-open-variants-no-reference-design.md
+++ b/docs/superpowers/specs/2026-06-07-open-variants-no-reference-design.md
@@ -1,0 +1,107 @@
+# `Dataset.open` without a reference should default to variants
+
+**Date:** 2026-06-07
+**Status:** Approved (design)
+
+## Problem
+
+`gvl.Dataset.open(path)` on a dataset that has genotypes but no reference genome
+crashes during open:
+
+```python
+import genvarloader as gvl
+gvl.Dataset.open("tests/data/phased_dataset.vcf.gvl")
+# ValueError: Cannot return RaggedSeqs: no reference genome was provided.
+```
+
+A genotypes-only, no-reference dataset cannot reconstruct haplotypes or
+reference-overlaid sequences. The only sequence view it can serve is
+`RaggedVariants`. So `open` should resolve such a dataset to a working
+`RaggedDataset[RaggedVariants, ...]` rather than erroring.
+
+The bug is visible at open time and is internally contradictory: `_build_seqs`
+already logs a warning that the dataset "can only support `.with_seqs('variants')`",
+then `resolve()` immediately tries to build the haplotypes reconstructor anyway.
+
+## Root cause
+
+Two cooperating pieces in `python/genvarloader/_dataset/`:
+
+1. **`OpenRequest._initial_seqs_kind`** (`_open.py:180-186`) returns
+   `"haplotypes"` for *any* `Haps` storage, regardless of whether a reference
+   is present.
+2. **`OpenRequest.resolve`** (`_open.py:75-76`) then calls
+   `_build_reconstructor(seqs, tracks, "haplotypes")`, which calls
+   `seqs.to_kind(RaggedSeqs)`. `Haps.to_kind` (`_haps.py:495-500`) raises
+   `ValueError` for any non-`RaggedVariants` kind when `self.reference is None`.
+
+The reconstructor factory and `to_kind` are behaving correctly — the defect is
+that `open` picks an impossible default view kind.
+
+## Fix
+
+Make the default view kind reference-aware. This is a single decision point.
+
+In `python/genvarloader/_dataset/_open.py`, change `_initial_seqs_kind`:
+
+```python
+@staticmethod
+def _initial_seqs_kind(seqs: Haps | Ref | None) -> SeqsKind:
+    # Default view kind for each storage shape.
+    if isinstance(seqs, Haps):
+        # Without a reference we can't reconstruct haplotypes; the only
+        # sequence view available is RaggedVariants.
+        return "haplotypes" if seqs.reference is not None else "variants"
+    if isinstance(seqs, Ref):
+        return "reference"
+    return None
+```
+
+No other code changes. `_build_reconstructor` stays a pure mapper of
+explicit state → reconstructor class (correct layering). The `_build_seqs`
+warning text remains accurate.
+
+### Why this is sufficient
+
+- `seqs_kind == "variants"` routes through the `("haplotypes", "annotated",
+  "variants")` branch of `_build_reconstructor`, which calls
+  `seqs.to_kind(RaggedVariants)` — explicitly allowed without a reference.
+- With tracks present, the factory builds `HapsTracks(haps=Haps[RaggedVariants],
+  tracks)`. This is a state already reachable today via
+  `with_seqs("variants")`, so no new combined-state handling is needed.
+- `_check_valid_state` only restricts `variants` for `output_length ==
+  "variable"`; `open` uses `output_length == "ragged"`, so the default is valid.
+- Users can still call `.with_seqs("haplotypes" | "annotated" | "reference")`
+  later; those paths already validate reference presence and raise a clear
+  error if it's missing.
+
+## Behavior decisions
+
+- **Genotypes + tracks, no reference:** default to `variants` view with tracks
+  active (tracks keep their current auto-activation). Yields `RaggedVariants`
+  alongside the active tracks.
+
+## Testing (TDD)
+
+Write the failing test first, confirm it reproduces the `ValueError`, then apply
+the fix.
+
+Use the existing reference-less fixtures: `tests/data/phased_dataset.vcf.gvl`,
+`phased_dataset.pgen.gvl`, `phased_dataset.svar.gvl`.
+
+1. **Open without reference succeeds** — for each of the three fixtures,
+   `gvl.Dataset.open(fixture)` returns a dataset with `sequence_type ==
+   "variants"` and does not raise.
+2. **Indexing yields RaggedVariants** — `dataset[region_idx, sample_idx]`
+   returns `RaggedVariants` end-to-end (at least on the vcf fixture; the three
+   share a reconstruction path, so parametrizing open across all three plus one
+   indexing assertion is adequate).
+
+Place tests under `tests/unit/dataset/` following existing fixture conventions
+in that directory.
+
+## Out of scope
+
+- Changing `Haps.to_kind` validation or `_build_reconstructor` layering.
+- Any change to `with_seqs` / `with_settings` behavior.
+- Spliced/annotated output for variants (already correctly rejected).

--- a/docs/superpowers/specs/2026-06-07-open-variants-no-reference-design.md
+++ b/docs/superpowers/specs/2026-06-07-open-variants-no-reference-design.md
@@ -79,7 +79,12 @@ warning text remains accurate.
 
 - **Genotypes + tracks, no reference:** default to `variants` view with tracks
   active (tracks keep their current auto-activation). Yields `RaggedVariants`
-  alongside the active tracks.
+  alongside the active tracks, i.e. `RaggedDataset[RaggedVariants,
+  RaggedTracks]`. Tracks default to per-nucleotide `RaggedTracks`
+  (`Tracks.from_path` defaults `kind=RaggedTracks`), not `RaggedIntervals`;
+  `RaggedTracks` re-aligns to haplotype coordinates using variant indel lengths
+  from the genotypes, not the reference sequence, so it works without a
+  reference.
 
 ## Testing (TDD)
 


### PR DESCRIPTION
## Summary
Adds the design docs (spec + implementation plan) for the "open without `reference=` defaults to the variants view" feature. The feature code itself already shipped (#209); these are the trailing `docs/superpowers/` design artifacts that hadn't been pushed, added here for the record (consistent with how other features' specs/plans live in the repo).

- `docs/superpowers/specs/2026-06-07-open-variants-no-reference-design.md`
- `docs/superpowers/plans/2026-06-07-open-variants-no-reference.md`

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)