### PR TITLE
docs(to_dataloader): document buffered modes and narrow mode type

### DIFF
--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -1450,7 +1450,7 @@ class Dataset:
         pin_memory_device: str = "",
         return_indices: bool = False,
         transform: Callable | None = None,
-        mode: str | None = None,
+        mode: Literal["buffered", "double_buffered"] | None = None,
         buffer_bytes: int = 2 * 1024**3,
         copy: bool = True,
         heartbeat_seconds: float = 60.0,
@@ -1510,6 +1510,20 @@ class Dataset:
             .. note::
                 Depending on how transforms are implemented, they can easily introduce a dataloading bottleneck. If you find
                 dataloading is slow, it's often a good idea to try disabling your transform to see if it's impacting throughput.
+        mode
+            Dataloading strategy. :code:`None` (default) uses the standard PyTorch :class:`DataLoader <torch.utils.data.DataLoader>`
+            over a map-style dataset. :code:`"buffered"` and :code:`"double_buffered"` use a prefetching producer that fills an
+            in-memory buffer ahead of consumption to hide read latency; both are incompatible with :code:`num_workers > 0` since
+            the loader is itself the concurrency strategy. :code:`"double_buffered"` serializes chunks into two fixed-size
+            shared-memory slots, allowing a producer thread to fill one slot while the consumer drains the other.
+        buffer_bytes
+            Total byte budget for the prefetch buffer when :code:`mode` is :code:`"buffered"` or :code:`"double_buffered"`.
+            For :code:`"double_buffered"` this is split across two shared-memory slots (:code:`buffer_bytes / 2` each). Defaults to 2 GiB.
+        copy
+            Only used when :code:`mode="double_buffered"`. If :code:`True` (default), each batch owns its data. If :code:`False`,
+            batches are zero-copy views into shared memory and are only valid until the next batch is yielded.
+        heartbeat_seconds
+            Only used when :code:`mode="double_buffered"`. Seconds to wait per slot before checking that the producer is still alive.
         """
         if mode is not None:
             # Buffered modes operate directly on the Dataset, not on a TorchDataset wrapper,

--- a/python/genvarloader/_torch.py
+++ b/python/genvarloader/_torch.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import awkward as ak
 import numpy as np
@@ -109,7 +109,7 @@ def get_dataloader(
     prefetch_factor: int | None = None,
     persistent_workers: bool = False,
     pin_memory_device: str = "",
-    mode: str | None = None,
+    mode: Literal["buffered", "double_buffered"] | None = None,
     buffer_bytes: int = 2 * 1024**3,
     copy: bool = True,
     heartbeat_seconds: float = 60.0,


### PR DESCRIPTION
## Summary
- Document the `mode`, `buffer_bytes`, `copy`, and `heartbeat_seconds` parameters on `Dataset.to_dataloader` (previously undocumented).
- Narrow `mode` from `str | None` to `Literal["buffered", "double_buffered"] | None` on both `Dataset.to_dataloader` and the backing `get_dataloader`.

## Notes
- `RefDataset.to_dataloader` (`_reference.py`) was intentionally left untouched — it does not expose buffered modes (no `_output_bytes_per_instance`), so there is nothing buffered-mode to document there.

## Testing
- `pixi run -e dev typecheck` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)