### PR TITLE
feat(flat): flat output mode (A0 + A) for issue #214

### DIFF
--- a/docs/superpowers/plans/2026-06-13-flat-output-mode-a0-a.md
+++ b/docs/superpowers/plans/2026-06-13-flat-output-mode-a0-a.md
@@ -1,0 +1,874 @@
+# Flat output mode (A0 + A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a flat-buffer output mode to gvl so `dataset.with_output_format("flat")[idx]` returns pure-numpy `(data, offsets, shape)` containers with zero awkward on the hot path, byte-identical (when re-wrapped) to today's output — for the seqs/haps/annotated-haps/reference outputs (A0) and the variants output (A).
+
+**Architecture:** A0 is a pure boundary change in `_dataset/_query.py`: the seqs/haps/annot/ref reconstructors already return `_Flat`/`_FlatAnnotatedHaps`, so flat mode skips the `to_ragged()` conversion (and the `output_length` pad/`to_fixed` massaging) at the return boundary. A introduces a new `_FlatVariants`/`_FlatAlleles` type and a numba reimplementation of the variant decode (`_get_variants_flat`) that produces those buffers directly from the sparse genotype + variant store with no awkward; a `flat` flag is threaded from the public `Dataset` through `QueryView` into the reconstructor so the variant path returns `_FlatVariants` in flat mode (ragged mode is left completely unchanged). The byte-identity equivalence test (`flat.to_ragged() == dataset[idx]`) is the correctness gate that also catches any reshape/squeeze/rc_neg interaction.
+
+**Tech Stack:** Python, numba (`@nb.njit`), numpy, awkward (only for `to_ragged()` rebuild + equivalence reference), seqpro `Ragged`, pytest, pixi.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-flat-output-mode-design.md`
+
+**Run tests with:** `pixi run -e dev pytest <path> -v` (generate test data once with `pixi run -e dev gen` if not already present).
+
+---
+
+## File Structure
+
+- **Create** `python/genvarloader/_dataset/_flat_variants.py` — `_FlatAlleles`, `_FlatVariants` dataclasses (with `to_ragged()`, `reshape`, `squeeze`, `reverse_masked`) + the numba gather kernels (`_gather_v_idxs`, `_gather_alleles`, `_compact_keep`) and the `get_variants_flat(...)` builder.
+- **Modify** `python/genvarloader/_flat.py` — nothing structural; `_FlatVariants` lives in its own module to avoid bloating `_flat.py`, but re-export `_FlatAlleles`/`_FlatVariants` here for a single import surface if convenient. (Optional; default: import from `_flat_variants`.)
+- **Modify** `python/genvarloader/_dataset/_haps.py` — add a `flat: bool = False` parameter to `Haps.__call__` / `Haps.get_haps_and_shifts`; when `flat` and `kind is RaggedVariants`, call the new `get_variants_flat`.
+- **Modify** `python/genvarloader/_dataset/_reconstruct.py` (and any other `Reconstructor` implementors — `Ref`, `Tracks`, `HapsTracks`) — add/accept `flat: bool = False` in `__call__` and thread it to the `Haps` sub-component; ignore elsewhere.
+- **Modify** `python/genvarloader/_dataset/_query.py` — add `flat_output: bool` to `QueryView`; thread `flat=view.flat_output` into the `view.recon(...)` calls; add `_FlatVariants` to `reverse_complement_ragged`; in `getitem`, when `flat_output`, skip the `output_length` massaging + `to_ragged()` and return the public flat wrappers.
+- **Modify** `python/genvarloader/_dataset/_impl.py` — add the `output_format` field (default `"ragged"`) to the `Dataset` frozen dataclass, the `with_output_format` method, and pass `flat_output` into `QueryView` in `__getitem__`.
+- **Modify** `python/genvarloader/__init__.py` — export `FlatRagged`, `FlatAnnotatedHaps`, `FlatVariants`, `FlatAlleles`.
+- **Create** `tests/dataset/test_flat_mode_equivalence.py` — the byte-identity gate.
+- **Create** `tests/unit/dataset/test_flat_variants_type.py` — unit tests for `_FlatVariants.to_ragged()` round-trip.
+- **Modify** `tests/dataset/test_no_awkward_in_hotpath.py` — add the flat-variants-mode no-awkward assertion.
+- **Modify** `skills/genvarloader/SKILL.md` — document `with_output_format` + flat types.
+
+---
+
+## Task 1: `_FlatAlleles` + `_FlatVariants` types with `to_ragged()`
+
+**Files:**
+- Create: `python/genvarloader/_dataset/_flat_variants.py`
+- Test: `tests/unit/dataset/test_flat_variants_type.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/dataset/test_flat_variants_type.py
+from __future__ import annotations
+
+import awkward as ak
+import numpy as np
+from seqpro.rag import Ragged
+
+from genvarloader import RaggedVariants
+from genvarloader._dataset._flat_variants import _FlatAlleles, _FlatVariants
+
+
+def _alleles(rows, group_off):
+    """rows: list[bytes] per variant; group_off: per-(b*p)-row variant boundaries."""
+    data = np.frombuffer(b"".join(rows), np.uint8).copy()
+    seq_off = np.concatenate([[0], np.cumsum([len(r) for r in rows])]).astype(np.int64)
+    return _FlatAlleles(
+        byte_data=data,
+        seq_offsets=seq_off,
+        var_offsets=np.asarray(group_off, np.int64),
+        shape=(len(group_off) - 1, None),
+    )
+
+
+def test_flat_variants_to_ragged_matches_handbuilt():
+    # b*p = 2 rows: row0 has 2 variants, row1 has 1 variant
+    group_off = [0, 2, 3]
+    alt = _alleles([b"ACG", b"T", b"GG"], group_off)
+    ref = _alleles([b"A", b"CC", b"T"], group_off)
+    start = _FlatAlleles  # placeholder to avoid unused import lint; replaced below
+    from genvarloader._flat import _Flat
+
+    start = _Flat.from_offsets(
+        np.array([1, 5, 9], np.int32), (2, None), np.asarray(group_off, np.int64)
+    )
+    fv = _FlatVariants(fields={"alt": alt, "start": start, "ref": ref})
+    rv = fv.to_ragged()
+
+    assert isinstance(rv, RaggedVariants)
+    assert ak.to_list(rv["alt"]) == [[b"ACG", b"T"], [b"GG"]]
+    assert ak.to_list(rv["ref"]) == [[b"A", b"CC"], [b"T"]]
+    assert ak.to_list(rv["start"]) == [[1, 5], [9]]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_flat_variants_type.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'genvarloader._dataset._flat_variants'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# python/genvarloader/_dataset/_flat_variants.py
+"""Flat-buffer analog of RaggedVariants: pure-numpy (data, offsets) per field,
+no awkward on the hot path. Converts to RaggedVariants only via to_ragged()."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numba as nb
+import numpy as np
+from numpy.typing import NDArray
+
+from .._flat import _Flat
+
+
+@dataclass(slots=True)
+class _FlatAlleles:
+    """Two-level flat bytestring for an alt/ref allele field, shape (b, p, ~v, ~l).
+
+    Layout matches genvarformer's `_bpvl`/`_decompose_bytestring` (inner-before-outer):
+    - byte_data:   uint8 contiguous allele bytes
+    - seq_offsets: per-variant byte boundaries, len n_variants + 1
+    - var_offsets: per-(b*p)-row variant boundaries, len b*p + 1
+    - shape:       outer fixed dims with exactly one None (the ragged variant axis)
+    """
+
+    byte_data: NDArray[np.uint8]
+    seq_offsets: NDArray[np.int64]
+    var_offsets: NDArray[np.int64]
+    shape: tuple[int | None, ...]
+
+    @property
+    def ploidy(self) -> int:
+        # shape is (b, p, None) for variants; ploidy is the last fixed dim.
+        fixed = [d for d in self.shape if d is not None]
+        return fixed[-1] if len(fixed) >= 2 else 1
+
+    def to_ragged(self):
+        from ._haps import _build_allele_layout
+
+        return _build_allele_layout(
+            np.ascontiguousarray(self.byte_data).view(np.uint8),
+            np.asarray(self.seq_offsets, np.int64),
+            np.asarray(self.var_offsets, np.int64),
+            self.ploidy,
+        )
+
+    def reverse_masked(self, mask: NDArray[np.bool_]) -> "_FlatAlleles":
+        """DNA reverse-complement the mask-selected (b*p) rows' alleles, in place.
+        ``mask`` is one entry per (b*p) row; broadcast across that row's variants."""
+        from .._ragged import _COMP, reverse_complement_masked
+        from seqpro.rag import Ragged
+
+        m = np.ascontiguousarray(mask, np.bool_).reshape(-1)
+        # per-allele mask: repeat each row's flag across its variant count
+        per_allele = np.repeat(m, np.diff(self.var_offsets))
+        view = Ragged.from_offsets(
+            self.byte_data.view("S1"),
+            (per_allele.size, None),
+            np.asarray(self.seq_offsets, np.int64),
+        )
+        reverse_complement_masked(view, per_allele)  # mutates byte_data in place
+        return self
+
+    def reshape(self, shape: tuple[int | None, ...]) -> "_FlatAlleles":
+        return _FlatAlleles(self.byte_data, self.seq_offsets, self.var_offsets, shape)
+
+
+@dataclass(slots=True)
+class _FlatVariants:
+    """Flat analog of RaggedVariants. `fields` maps field name -> _Flat (scalar
+    fields: start/ilen/dosage/info) or _FlatAlleles (alt/ref)."""
+
+    fields: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def shape(self) -> tuple[int | None, ...]:
+        return self.fields["start"].shape
+
+    def to_ragged(self):
+        from ._rag_variants import RaggedVariants
+
+        kw = {}
+        for name, f in self.fields.items():
+            kw[name] = f.to_ragged()
+        return RaggedVariants(**kw)
+
+    def reshape(self, shape) -> "_FlatVariants":
+        return _FlatVariants({k: v.reshape(shape) for k, v in self.fields.items()})
+
+    def squeeze(self, axis: int | None = None) -> "_FlatVariants":
+        return _FlatVariants(
+            {k: v.squeeze(axis) for k, v in self.fields.items()}
+        )
+
+    def reverse_masked(self, mask: NDArray[np.bool_]) -> "_FlatVariants":
+        # Only alt/ref alleles are reverse-complemented; scalar fields unchanged
+        # (matches RaggedVariants.rc_ which only touches alt/ref).
+        for name in ("alt", "ref"):
+            if name in self.fields:
+                self.fields[name] = self.fields[name].reverse_masked(mask)
+        return self
+```
+
+Note: `_Flat` already has `.reshape`/`.squeeze`/`.to_ragged`; `_FlatVariants.to_ragged` calls them for scalar fields. `start`/`ilen`/`info` `_Flat`s must carry shape `(b, p, None)` so `.to_ragged()` yields `(b, p, ~v)`. `_FlatVariants.squeeze` delegates to each field — `_Flat.squeeze(0)` drops the leading axis (matches `RaggedVariants.squeeze` → `self[0]`); verify in the equivalence test.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_flat_variants_type.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /root/GenVarLoader
+rtk git add python/genvarloader/_dataset/_flat_variants.py tests/unit/dataset/test_flat_variants_type.py
+rtk git commit -m "feat(flat): _FlatVariants/_FlatAlleles types with to_ragged()"
+```
+
+---
+
+## Task 2: Public exports (`FlatRagged`, `FlatAnnotatedHaps`, `FlatVariants`, `FlatAlleles`)
+
+**Files:**
+- Modify: `python/genvarloader/__init__.py:18-61`
+- Test: `tests/unit/dataset/test_flat_variants_type.py` (append)
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```python
+def test_public_flat_exports():
+    import genvarloader as gvl
+
+    assert gvl.FlatRagged is not None
+    assert gvl.FlatAnnotatedHaps is not None
+    assert gvl.FlatVariants is not None
+    assert gvl.FlatAlleles is not None
+    # aliases point at the existing internals
+    from genvarloader._flat import _Flat, _FlatAnnotatedHaps
+    from genvarloader._dataset._flat_variants import _FlatVariants, _FlatAlleles
+
+    assert gvl.FlatRagged is _Flat
+    assert gvl.FlatAnnotatedHaps is _FlatAnnotatedHaps
+    assert gvl.FlatVariants is _FlatVariants
+    assert gvl.FlatAlleles is _FlatAlleles
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_flat_variants_type.py::test_public_flat_exports -v`
+Expected: FAIL with `AttributeError: module 'genvarloader' has no attribute 'FlatRagged'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `python/genvarloader/__init__.py`, after the existing imports (around line 27) add:
+
+```python
+from ._flat import _Flat as FlatRagged
+from ._flat import _FlatAnnotatedHaps as FlatAnnotatedHaps
+from ._dataset._flat_variants import _FlatVariants as FlatVariants
+from ._dataset._flat_variants import _FlatAlleles as FlatAlleles
+```
+
+And add the four names to `__all__` (keep alphabetical ordering used in the file):
+
+```python
+    "FlatAlleles",
+    "FlatAnnotatedHaps",
+    "FlatRagged",
+    "FlatVariants",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_flat_variants_type.py::test_public_flat_exports -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add python/genvarloader/__init__.py tests/unit/dataset/test_flat_variants_type.py
+rtk git commit -m "feat(flat): export FlatRagged/FlatAnnotatedHaps/FlatVariants/FlatAlleles"
+```
+
+---
+
+## Task 3: `output_format` field + `with_output_format` + thread into `QueryView`
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_impl.py` (add field near line 653; add method near the other `with_*` methods ~line 485; modify `__getitem__` ~line 1588)
+- Modify: `python/genvarloader/_dataset/_query.py` (add `flat_output` to `QueryView` ~line 50)
+- Test: `tests/unit/dataset/test_with_methods.py` (append) or a new `tests/unit/dataset/test_output_format.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/dataset/test_output_format.py
+import pytest
+
+
+def test_with_output_format_sets_field(snap_dataset):
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    assert ds.output_format == "ragged"
+    flat = ds.with_output_format("flat")
+    assert flat.output_format == "flat"
+    # original is unchanged (frozen dataclass / replace semantics)
+    assert ds.output_format == "ragged"
+
+
+def test_with_output_format_rejects_bad_value(snap_dataset):
+    with pytest.raises(ValueError):
+        snap_dataset.with_output_format("nope")
+```
+
+Add a `conftest.py`-visible `snap_dataset` or import the fixture. The `snap_dataset` fixture lives in `tests/dataset/test_flat_getitem_snapshot.py`; move it to `tests/dataset/conftest.py` (or `tests/conftest.py`) so multiple test modules can use it. **Do this move as the first sub-step** (cut the `snap_dataset` fixture + its imports into `tests/dataset/conftest.py`, leave the rest of the snapshot test importing it implicitly via pytest fixture resolution).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_output_format.py -v`
+Expected: FAIL with `AttributeError: 'Dataset' object has no attribute 'output_format'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `_impl.py`, add the field to the `Dataset` frozen dataclass alongside `output_length` (after line 656):
+
+```python
+    output_format: Literal["ragged", "flat"] = "ragged"
+    """Container format for eager indexing. ``"ragged"`` (default) returns awkward-backed
+    seqpro ``Ragged`` / ``RaggedVariants``; ``"flat"`` returns pure-numpy ``FlatRagged`` /
+    ``FlatVariants`` with zero awkward on the hot path. See ``with_output_format``."""
+```
+
+> If the dataclass has other non-default fields declared *after* this point, give `output_format` no default and instead set it in `open()`/`replace` defaults. Check field ordering: dataclass fields with defaults cannot precede fields without. The simplest safe move is to add `output_format` as the LAST declared field with a default, after `_rng` (line 700). Place it there.
+
+Add the method near the other `with_*` methods (e.g. after `with_len`, ~line 483):
+
+```python
+    def with_output_format(self, fmt: Literal["ragged", "flat"]) -> "Dataset":
+        """Return a copy that yields ``fmt`` containers from eager indexing.
+
+        Parameters
+        ----------
+        fmt
+            ``"ragged"`` for awkward-backed ``Ragged``/``RaggedVariants`` (default),
+            or ``"flat"`` for pure-numpy ``FlatRagged``/``FlatVariants``.
+        """
+        if fmt not in ("ragged", "flat"):
+            raise ValueError(f"output_format must be 'ragged' or 'flat', got {fmt!r}.")
+        return replace(self, output_format=fmt)
+```
+
+In `__getitem__` (~line 1588) pass it into `QueryView`:
+
+```python
+        view = QueryView(
+            idxer=self._idxer,
+            sp_idxer=self._sp_idxer,
+            full_regions=self._full_regions,
+            rng=self._rng,
+            recon=self._recon,
+            output_length=self.output_length,
+            jitter=self.jitter,
+            deterministic=self.deterministic,
+            rc_neg=self.rc_neg,
+            flat_output=self.output_format == "flat",
+        )
+```
+
+In `_query.py`, add to the `QueryView` dataclass (after `rc_neg: bool`, ~line 53):
+
+```python
+    flat_output: bool = False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_output_format.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing suite to confirm no regression**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_getitem_snapshot.py -v`
+Expected: PASS (the fixture move didn't break it; behavior unchanged since `flat_output` is unused so far).
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_impl.py python/genvarloader/_dataset/_query.py tests/unit/dataset/test_output_format.py tests/dataset/conftest.py tests/dataset/test_flat_getitem_snapshot.py
+rtk git commit -m "feat(flat): output_format field + with_output_format + QueryView.flat_output"
+```
+
+---
+
+## Task 4: A0 — flat passthrough for non-variant outputs (boundary change)
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_query.py` — `getitem` (~lines 92-122)
+- Create: `tests/dataset/test_flat_mode_equivalence.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/dataset/test_flat_mode_equivalence.py
+"""flat-mode output, re-wrapped via .to_ragged(), must be byte-identical to ragged mode."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from seqpro.rag import Ragged
+
+from genvarloader._ragged import RaggedAnnotatedHaps
+
+IDX = [0, (np.array([0, 1, 2]),)]  # scalar-ish and a list index
+
+
+def _to_plain(obj):
+    """Normalize a ragged/annot/flat object into dict of ndarrays for comparison."""
+    if isinstance(obj, RaggedAnnotatedHaps):
+        return {
+            "haps": np.asarray(obj.haps.data), "haps_off": np.asarray(obj.haps.offsets),
+            "vidx": np.asarray(obj.var_idxs.data), "pos": np.asarray(obj.ref_coords.data),
+        }
+    if isinstance(obj, Ragged):
+        return {"data": np.asarray(obj.data), "off": np.asarray(obj.offsets)}
+    raise TypeError(type(obj))
+
+
+@pytest.mark.parametrize("seqs", ["haplotypes", "reference", "annotated"])
+@pytest.mark.parametrize("idx", IDX)
+def test_a0_flat_to_ragged_matches_ragged(snap_dataset, seqs, idx):
+    ds = snap_dataset.with_seqs(seqs).with_tracks(False)
+    ragged = ds[idx]
+    flat = ds.with_output_format("flat")[idx]
+    rewrapped = flat.to_ragged()
+    r, f = _to_plain(ragged), _to_plain(rewrapped)
+    assert r.keys() == f.keys()
+    for k in r:
+        np.testing.assert_array_equal(r[k], f[k], err_msg=f"field {k}")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_mode_equivalence.py -v`
+Expected: FAIL — in flat mode the boundary still calls `to_ragged()`, so `flat` is already a `Ragged` and `.to_ragged()` raises `AttributeError`, OR (after we wire it) the wrapper type lacks `.to_ragged`. Confirm it errors before the fix.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `_query.py` `getitem`, gate the `output_length` massaging and the `to_ragged()` conversion on `flat_output`. Replace the block at lines ~92-110 with:
+
+```python
+    if not view.flat_output:
+        if view.output_length == "variable":
+            recon = tuple(
+                r if isinstance(r, (RaggedVariants, RaggedIntervals)) else pad(r)
+                for r in recon
+            )
+        elif isinstance(view.output_length, int):
+            recon = tuple(
+                r
+                if isinstance(r, (RaggedVariants, RaggedIntervals))
+                else r.to_fixed(view.output_length)
+                for r in recon
+            )
+        # Convert any still-flat elements to their public Ragged types before
+        # reshape/squeeze apply the existing logic.
+        recon = tuple(
+            o.to_ragged() if isinstance(o, (_Flat, _FlatAnnotatedHaps)) else o
+            for o in recon
+        )
+    # flat_output: leave _Flat / _FlatAnnotatedHaps (and, after Task 5,
+    # _FlatVariants) unconverted. reshape/squeeze below still apply via their
+    # flat methods; the consumer densifies via .to_fixed/.to_padded if desired.
+```
+
+The subsequent `out_reshape` (line ~112) and `squeeze` (line ~115) blocks already call `.reshape`/`.squeeze`, which `_Flat`/`_FlatAnnotatedHaps` implement, so they work unchanged in flat mode.
+
+`rc_neg` (in `_getitem_unspliced`, lines 158-160) already runs `reverse_complement_ragged` on the `_Flat`/`_FlatAnnotatedHaps` recon (see the overloads at `_query.py:322-344`), so negative-strand handling is already correct for A0.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_mode_equivalence.py -v`
+Expected: PASS for all `seqs` in `{haplotypes, reference, annotated}`.
+
+- [ ] **Step 5: Confirm ragged path is untouched**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_getitem_snapshot.py -v`
+Expected: PASS (byte-identical snapshots unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_query.py tests/dataset/test_flat_mode_equivalence.py
+rtk git commit -m "feat(flat): A0 flat passthrough for seqs/haps/annot/reference outputs"
+```
+
+---
+
+## Task 5: A — flat variant decode (`get_variants_flat`) + thread `flat` flag
+
+This is the core task. It has several sub-steps; commit once at the end.
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_flat_variants.py` (add kernels + `get_variants_flat`)
+- Modify: `python/genvarloader/_dataset/_haps.py` (`__call__` / `get_haps_and_shifts` gain `flat: bool = False`)
+- Modify: `python/genvarloader/_dataset/_reconstruct.py` + other `Reconstructor` impls (thread `flat`)
+- Modify: `python/genvarloader/_dataset/_query.py` (pass `flat=view.flat_output` to `view.recon(...)`; add `_FlatVariants` to `reverse_complement_ragged`; allow `_FlatVariants` to skip pad/to_ragged in flat mode)
+- Test: `tests/dataset/test_flat_mode_equivalence.py` (extend with variants cases)
+
+- [ ] **Step 1: Write the failing test (extend)**
+
+```python
+# append to tests/dataset/test_flat_mode_equivalence.py
+import awkward as ak
+from genvarloader import RaggedVariants
+
+
+def _rv_to_lists(rv: RaggedVariants) -> dict:
+    out = {"alt": ak.to_list(rv["alt"]), "start": ak.to_list(rv["start"])}
+    for f in ("ref", "ilen", "dosage"):
+        if f in rv.fields:
+            out[f] = ak.to_list(rv[f])
+    return out
+
+
+@pytest.mark.parametrize("idx", IDX)
+def test_a_flat_variants_to_ragged_matches_ragged(snap_dataset, idx):
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    ragged = ds[idx]                                  # RaggedVariants (current path)
+    flat = ds.with_output_format("flat")[idx]         # _FlatVariants
+    rewrapped = flat.to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+
+
+def test_a_flat_variants_empty_region_and_ploidy(snap_dataset):
+    # exercise an index range likely to include empty variant groups; the
+    # equivalence must still hold element-for-element.
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    idx = (np.arange(min(6, snap_dataset.shape[0])),)
+    ragged = ds[idx]
+    rewrapped = ds.with_output_format("flat")[idx].to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+```
+
+> If the dataset supports AF / exonic filters, add a parametrization that applies `with_settings(min_af=...)` / the exonic filter and re-asserts equivalence. Mirror whatever the existing variant tests use to enable those (search `tests/integration/dataset/test_query_filters.py`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_mode_equivalence.py -k variants -v`
+Expected: FAIL — flat mode still returns a `RaggedVariants` from the reconstructor (no `flat` plumbing yet), so `.to_ragged()` errors, or the variant path isn't flat.
+
+- [ ] **Step 3a: Add the numba gather kernels + builder to `_flat_variants.py`**
+
+```python
+# add to python/genvarloader/_dataset/_flat_variants.py
+
+@nb.njit(nogil=True, cache=True)
+def _gather_v_idxs(geno_offset_idx, geno_offsets, geno_v_idxs):
+    """Concatenate the per-(b*p)-row sparse variant-index slices into one flat
+    buffer + per-row offsets. Replaces `genotypes[r, s].to_packed()`."""
+    n_rows = geno_offset_idx.shape[0]
+    out_offsets = np.empty(n_rows + 1, np.int64)
+    out_offsets[0] = 0
+    for i in range(n_rows):
+        goi = geno_offset_idx[i]
+        out_offsets[i + 1] = out_offsets[i] + (geno_offsets[goi + 1] - geno_offsets[goi])
+    total = out_offsets[n_rows]
+    v_idxs = np.empty(total, geno_v_idxs.dtype)
+    dst = 0
+    for i in range(n_rows):
+        goi = geno_offset_idx[i]
+        s = geno_offsets[goi]
+        e = geno_offsets[goi + 1]
+        for k in range(s, e):
+            v_idxs[dst] = geno_v_idxs[k]
+            dst += 1
+    return v_idxs, out_offsets
+
+
+@nb.njit(nogil=True, cache=True)
+def _gather_alleles(v_idxs, allele_bytes, allele_offsets):
+    """Gather selected variants' allele bytes into a contiguous buffer + per-variant
+    byte offsets. Replaces `variants.<kind>[v_idxs].to_packed()`."""
+    n = v_idxs.shape[0]
+    seq_offsets = np.empty(n + 1, np.int64)
+    seq_offsets[0] = 0
+    for i in range(n):
+        v = v_idxs[i]
+        seq_offsets[i + 1] = seq_offsets[i] + (allele_offsets[v + 1] - allele_offsets[v])
+    data = np.empty(seq_offsets[n], np.uint8)
+    dst = 0
+    for i in range(n):
+        v = v_idxs[i]
+        s = allele_offsets[v]
+        e = allele_offsets[v + 1]
+        for k in range(s, e):
+            data[dst] = allele_bytes[k]
+            dst += 1
+    return data, seq_offsets
+
+
+@nb.njit(nogil=True, cache=True)
+def _compact_keep(v_idxs, row_offsets, keep):
+    """Drop masked variants and recompute per-row offsets. `keep` is per-variant
+    (aligned to v_idxs)."""
+    n_rows = row_offsets.shape[0] - 1
+    new_offsets = np.empty(n_rows + 1, np.int64)
+    new_offsets[0] = 0
+    n_keep = 0
+    for i in range(n_rows):
+        for j in range(row_offsets[i], row_offsets[i + 1]):
+            if keep[j]:
+                n_keep += 1
+        new_offsets[i + 1] = n_keep
+    new_v = np.empty(n_keep, v_idxs.dtype)
+    dst = 0
+    for j in range(v_idxs.shape[0]):
+        if keep[j]:
+            new_v[dst] = v_idxs[j]
+            dst += 1
+    return new_v, new_offsets
+
+
+def get_variants_flat(haps, idx) -> "_FlatVariants":
+    """Flat (no-awkward) reimplementation of Haps._get_variants. Mirrors the field
+    set and filter semantics of _get_variants in _haps.py.
+
+    `haps` is the Haps reconstructor (provides .genotypes, .variants, .dosages,
+    .var_fields, .min_af, .max_af). `idx` is the flat (region*sample) index array.
+    """
+    from .._flat import _Flat
+    from ._haps import Haps  # for _get_geno_offset_idx (static method)
+
+    genotypes = haps.genotypes
+    ploidy = int(genotypes.shape[-2])
+    geno_offset_idx = Haps._get_geno_offset_idx(idx, genotypes)  # (b, p)
+    goi_flat = np.ascontiguousarray(geno_offset_idx).reshape(-1)
+
+    v_idxs, row_offsets = _gather_v_idxs(
+        goi_flat,
+        np.asarray(genotypes.offsets),
+        np.asarray(genotypes.data),
+    )
+
+    # ---- filters (match _haps._get_variants) ----
+    if haps.min_af is not None or haps.max_af is not None:
+        afs = haps.variants.info["AF"][v_idxs]
+        keep = np.ones(v_idxs.shape[0], np.bool_)
+        if haps.min_af is not None:
+            keep &= afs >= haps.min_af
+        if haps.max_af is not None:
+            keep &= afs <= haps.max_af
+        v_idxs, row_offsets = _compact_keep(v_idxs, row_offsets, keep)
+    # NOTE: exonic filter (haps.filter == "exonic") is applied UPSTREAM via
+    # req.keep/req.keep_offsets in get_haps_and_shifts. For the variants kind the
+    # current code path passes keep/keep_offsets into _get_variants only in
+    # get_haps_and_shifts (not the bare __call__). Replicate: if keep is supplied,
+    # compact with it here. See Step 3b for how keep is threaded.
+
+    n_rows = row_offsets.shape[0]                       # b*p + 1
+    b = goi_flat.shape[0] // ploidy
+    shape = (b, ploidy, None)
+
+    def _scalar(arr_full):
+        data = np.ascontiguousarray(arr_full[v_idxs])
+        return _Flat.from_offsets(data, shape, row_offsets)
+
+    fields: dict = {}
+    # alt is required
+    alt_bytes, alt_seq_off = _gather_alleles(
+        v_idxs,
+        np.asarray(haps.variants.alt.data).view(np.uint8),
+        np.asarray(haps.variants.alt.offsets),
+    )
+    fields["alt"] = _FlatAlleles(alt_bytes, alt_seq_off, row_offsets, shape)
+    fields["start"] = _scalar(np.asarray(haps.variants.start))
+
+    if "ref" in haps.var_fields:
+        ref_bytes, ref_seq_off = _gather_alleles(
+            v_idxs,
+            np.asarray(haps.variants.ref.data).view(np.uint8),
+            np.asarray(haps.variants.ref.offsets),
+        )
+        fields["ref"] = _FlatAlleles(ref_bytes, ref_seq_off, row_offsets, shape)
+    if "ilen" in haps.var_fields:
+        fields["ilen"] = _scalar(np.asarray(haps.variants.ilen))
+
+    if haps.dosages is not None and "dosage" in haps.var_fields:
+        # dosage is parallel to genotypes (gathered by the same offset ranges, not v_idxs)
+        dos, _ = _gather_v_idxs(
+            goi_flat, np.asarray(genotypes.offsets), np.asarray(haps.dosages.data)
+        )
+        # if AF/exonic filtered, dosage must be compacted with the same keep mask
+        # — keep dosage gather BEFORE compaction OR carry keep; simplest: gather
+        # dosage parallel to the UNfiltered v_idxs then apply the same _compact_keep.
+        fields["dosage"] = _Flat.from_offsets(np.ascontiguousarray(dos), shape, row_offsets)
+
+    # remaining info fields
+    for k in haps.var_fields:
+        if k in ("alt", "start", "ref", "ilen", "dosage"):
+            continue
+        fields[k] = _scalar(np.asarray(haps.variants.info[k]))
+
+    return _FlatVariants(fields)
+```
+
+> **Dosage + filter ordering caveat:** the snippet gathers dosage AFTER computing the
+> (possibly filtered) `row_offsets`, which is wrong if a filter compacted `v_idxs`.
+> Fix during implementation: capture the UNfiltered `row_offsets` and the `keep` mask,
+> gather dosage against the unfiltered offsets, then `_compact_keep` dosage with the same
+> mask. The equivalence test with `min_af` set is the gate that forces this correct.
+
+- [ ] **Step 3b: Thread `flat` through `Haps` and the reconstructors**
+
+In `_haps.py` `Haps.__call__` (line 502), add `flat: bool = False`:
+
+```python
+    def __call__(self, idx, r_idx, regions, output_length, jitter, rng, deterministic,
+                 splice_plan=None, flat: bool = False):
+        if issubclass(self.kind, RaggedVariants):
+            if splice_plan is not None:
+                raise NotImplementedError("Spliced output is not supported for RaggedVariants.")
+            if flat:
+                from ._flat_variants import get_variants_flat
+                return cast(_H, get_variants_flat(self, idx))
+            ragv = self._get_variants(idx=idx, regions=None, shifts=None)
+            return cast(_H, ragv)
+        else:
+            haps, *_ = self.get_haps_and_shifts(idx=idx, regions=regions,
+                output_length=output_length, rng=rng, deterministic=deterministic,
+                splice_plan=splice_plan)
+            return haps
+```
+
+(For exonic filter parity, also branch in `get_haps_and_shifts` where `_get_variants` is called with `keep`/`keep_offsets`: when `flat`, call `get_variants_flat(self, idx, keep=req.keep, keep_offsets=req.keep_offsets)` and add those optional params to `get_variants_flat` applying `_compact_keep`. Only needed if the variants-kind path flows through `get_haps_and_shifts` — verify which call site the variants output uses; the bare `__call__` path is the primary one.)
+
+Add `flat: bool = False` to the `Reconstructor` protocol `__call__` and to each implementor (`Ref`, `Tracks`, `HapsTracks`, etc.) in `_reconstruct.py`. Non-variant reconstructors accept and ignore it (they already return `_Flat`); `HapsTracks` forwards `flat` to its `Haps` sub-call.
+
+In `_query.py` `_getitem_unspliced` (line 145) and `_getitem_spliced`, pass `flat=view.flat_output`:
+
+```python
+    recon = view.recon(
+        idx=ds_idx, r_idx=r_idx, regions=regions, output_length=view.output_length,
+        jitter=view.jitter, rng=view.rng, deterministic=view.deterministic,
+        flat=view.flat_output,
+    )
+```
+
+- [ ] **Step 3c: Teach `_query.py` to carry `_FlatVariants` through rc / boundary**
+
+In `reverse_complement_ragged` (line 335), add a branch before `RaggedVariants`:
+
+```python
+    from ._flat_variants import _FlatVariants
+    if isinstance(rag, _FlatVariants):
+        return rag.reverse_masked(to_rc)
+```
+
+Add the overload signature too. In `getitem`, the flat branch (Task 4) already leaves non-`(_Flat, _FlatAnnotatedHaps)` objects alone — but `_FlatVariants` must also bypass `to_ragged()` in ragged mode? No: in **ragged** mode the variant recon returns `RaggedVariants` (flat=False), so nothing changes. In **flat** mode the recon returns `_FlatVariants` and the `if not view.flat_output:` guard skips conversion — so `_FlatVariants` flows straight out. `reshape`/`squeeze` apply via `_FlatVariants` methods. Confirm `squeeze` matches `RaggedVariants.squeeze` (→ `self[0]`): `_FlatVariants.squeeze(0)` delegates to `_Flat.squeeze(0)` / `_FlatAlleles` (add a `squeeze` to `_FlatAlleles` that drops the leading fixed axis). The equivalence test on a scalar `idx` (which triggers squeeze) is the gate.
+
+- [ ] **Step 3d: Add `squeeze` to `_FlatAlleles`**
+
+```python
+    def squeeze(self, axis: int | None = None) -> "_FlatAlleles":
+        fixed = [d for d in self.shape if d is not None]
+        if axis is None:
+            fixed = [d for d in fixed if d != 1]
+        else:
+            del fixed[axis]
+        return _FlatAlleles(self.byte_data, self.seq_offsets, self.var_offsets,
+                            (*fixed, None))
+```
+
+- [ ] **Step 4: Run the variant equivalence tests**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_mode_equivalence.py -v`
+Expected: PASS for all cases (haps/ref/annot from Task 4 + variants, empty regions, ploidy, and any AF/exonic parametrization).
+
+- [ ] **Step 5: Confirm ragged path untouched + full suite**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_getitem_snapshot.py tests/dataset/test_flat_variants.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_flat_variants.py python/genvarloader/_dataset/_haps.py python/genvarloader/_dataset/_reconstruct.py python/genvarloader/_dataset/_query.py tests/dataset/test_flat_mode_equivalence.py
+rtk git commit -m "feat(flat): A flat variant decode (get_variants_flat) with no awkward"
+```
+
+---
+
+## Task 6: No-awkward-in-hot-path guard for flat variants mode
+
+**Files:**
+- Modify: `tests/dataset/test_no_awkward_in_hotpath.py`
+
+- [ ] **Step 1: Inspect the existing guard mechanism**
+
+Run: `pixi run -e dev pytest tests/dataset/test_no_awkward_in_hotpath.py -v` and read the file to learn how it detects awkward calls (it likely patches `awkward.highlevel.Array.__getitem__` or uses a profiler/import guard).
+
+- [ ] **Step 2: Write the failing test (add a case)**
+
+Add a test that runs `ds.with_seqs("variants").with_tracks(False).with_output_format("flat")[idx]` under the same awkward-detection harness the file already uses, asserting **zero** `awkward.highlevel.__getitem__` calls during the decode. Reuse the existing fixture and detection helper — do not invent a new mechanism. Example shape (adapt to the file's actual helper name):
+
+```python
+def test_flat_variants_decode_has_no_awkward(snap_dataset, awkward_getitem_counter):
+    ds = snap_dataset.with_seqs("variants").with_tracks(False).with_output_format("flat")
+    with awkward_getitem_counter() as count:
+        _ = ds[(np.arange(4),)]
+    assert count.value == 0, f"awkward.__getitem__ called {count.value}x in flat variant decode"
+```
+
+- [ ] **Step 3: Run to verify it fails (or passes)**
+
+Run: `pixi run -e dev pytest tests/dataset/test_no_awkward_in_hotpath.py -k flat -v`
+Expected: PASS if `get_variants_flat` is genuinely awkward-free; FAIL pinpoints a residual awkward call (e.g. `genotypes.offsets`/`.data` returning an awkward-backed array — convert with `np.asarray` as the kernel wrappers already do). Fix any residual until it passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add tests/dataset/test_no_awkward_in_hotpath.py
+rtk git commit -m "test(flat): assert flat variant decode runs zero awkward getitem"
+```
+
+---
+
+## Task 7: Update the genvarloader skill + docs
+
+**Files:**
+- Modify: `skills/genvarloader/SKILL.md`
+
+- [ ] **Step 1: Document the new API**
+
+Add to the skill:
+- `Dataset.with_output_format("ragged" | "flat")` — what it does, default `"ragged"`, that flat mode returns `FlatRagged`/`FlatVariants`/`FlatAnnotatedHaps`/`FlatAlleles` with `.to_ragged()`/`.to_fixed()`/`.to_padded()` escape hatches and zero awkward on the hot path.
+- The new public types in the symbol list / "Where to look next" table.
+- A one-line note: flat offsets are int64; cast to int32 for torch nested tensors.
+
+- [ ] **Step 2: Verify the doc builds (if applicable) and commit**
+
+Run: `pixi run -e docs doc` (only if docs reference the skill / API; otherwise skip).
+
+```bash
+rtk git add skills/genvarloader/SKILL.md
+rtk git commit -m "docs(skill): document with_output_format + flat output types"
+```
+
+---
+
+## Task 8 (cross-repo, genvarformer): thin-wrapper validation
+
+> This task lives in the **genvarformer** repo (`/root/genvarformer`), not gvl. It validates the gvl change end-to-end and is tracked as the consumer half of issue #214 §8. Do it after Tasks 1-7 land and gvl is installed/linked into the genvarformer env. It gets its own commit/PR in that repo.
+
+**Files (genvarformer):**
+- Modify: `src/genvarformer/data/sources/_helpers.py` (`rag_to_nested`), `src/genvarformer/data/sources/tokens.py` (`RefSeq._call_one_to_many`, `Variants._fetch` step 1)
+
+- [ ] **Step 1:** Switch the gvl dataset construction in genvarformer to `.with_output_format("flat")` for the sources that immediately tensorize.
+- [ ] **Step 2:** In `rag_to_nested` / `RefSeq`, consume `FlatRagged` directly → `Nested` (`torch.from_numpy(flat.data)`, `torch.from_numpy(flat.offsets.astype(np.int32))`), dropping the `np.asarray(rag.data)` round-trip.
+- [ ] **Step 3:** In `Variants._fetch`, take `FlatVariants` and feed its buffers into PR #19's merge/sort/dummy kernels without the `_decompose_bytestring` re-boxing (inputs are already flat).
+- [ ] **Step 4:** Run genvarformer's existing batch-equality guardrail; assert outputs unchanged.
+- [ ] **Step 5:** Re-profile the production data path; confirm `awkward.highlevel.__getitem__` is gone from the top cumulative functions and member-seqs/s improves.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2 goal (flat mode, byte-identical) → Tasks 3-5 + equivalence test.
+- §3 public API (`with_output_format`, `FlatRagged`/`FlatAnnotatedHaps`/`FlatVariants`/`FlatAlleles`) → Tasks 1-3.
+- §4 boundary change → Tasks 3-5.
+- §5 A flat variant decode (v_idx gather, scalar fields, allele gather, AF/exonic filters, dosage parallel-gather) → Task 5.
+- §6 A0 passthrough (incl. deferred tracks/intervals — left ragged, not in scope) → Task 4. *(Tracks/intervals intentionally not flattened; documented as deferred in the spec.)*
+- §7 equivalence + no-awkward gates → Tasks 4, 5, 6.
+- §8 genvarformer thinning → Task 8.
+- Skill update mandated by CLAUDE.md → Task 7.
+
+**Placeholder scan:** The dosage/filter ordering and the exonic-keep threading are flagged as explicit implementation caveats with the equivalence test (`min_af` parametrization) as the forcing gate — not hand-waved; the fix is described. The no-awkward harness reuses the existing file's mechanism (Task 6 Step 1 inspects it first) rather than inventing one.
+
+**Type consistency:** `_FlatVariants(fields=dict)`, `_FlatAlleles(byte_data, seq_offsets, var_offsets, shape)`, `get_variants_flat(haps, idx)`, `_gather_v_idxs`/`_gather_alleles`/`_compact_keep`, `with_output_format`, `QueryView.flat_output`, `Haps.__call__(..., flat=False)` are used consistently across tasks. `to_ragged()` is the conversion method on every flat type.
+
+**Known verification points (forced by tests, not left open):** scalar-idx `squeeze` parity (`_FlatVariants.squeeze`/`_FlatAlleles.squeeze`), `rc_neg` on negative-strand variants (snapshot fixture has `rc_neg=True`), empty variant groups, multi-ploidy, AF/exonic filters.

--- a/docs/superpowers/specs/2026-06-13-flat-output-mode-design.md
+++ b/docs/superpowers/specs/2026-06-13-flat-output-mode-design.md
@@ -1,0 +1,222 @@
+# Flat output mode — design (A0 + A)
+
+**Date:** 2026-06-13
+**Repo:** `mcvickerlab/GenVarLoader` (gvl)
+**Driven by:** gvl issue #214 (super-batch / flat-buffer output mode), genvarformer PR #19
+(numba tokenizer hot-path), `gvf-germ-som` trans gene-regulation training run.
+**Status:** approved design; ready for `writing-plans`.
+
+Related prior gvl designs: `2026-05-31-flat-buffer-getitem-pipeline-design.md`,
+`2026-06-01-flat-buffer-getitem-followups-design.md`,
+`2026-06-07-ragged-variants-pack-lazy-views-design.md`.
+
+---
+
+## 0. Problem (why this exists)
+
+A genvarformer training loop indexes a gvl dataset with a list of flat `(region, sample)`
+indices (`dataset[flat_idx]`). In a CPU profile of the production data path the decode is
+**97 % of wall (~1017 ms/batch)** and **`awkward.highlevel.__getitem__` alone is 62 % of
+wall**. The GPU sits idle waiting on it (see issue #214 for the full profile).
+
+gvl already reconstructs into pure-numpy flat `(data, offsets, shape)` buffers internally
+(`_Flat`, numba kernels) and only wraps them in awkward `Ragged` / `RaggedVariants` at the
+public boundary (`_dataset/_query.py:107`, `o.to_ragged()`). The consumer then does a
+*second* awkward pass before dropping back to numpy for torch. The awkward round-trip
+across the boundary — and for the **variants** output, gvl's own awkward indexing inside
+`_get_variants` — is the cost.
+
+---
+
+## 1. Decomposition of issue #214 (umbrella)
+
+This spec implements **A0 + A**. The remaining sub-projects each get their own
+spec → plan cycle.
+
+| ID | Sub-project | Depends on | Notes |
+|----|-------------|-----------|-------|
+| **A0** | Flat passthrough for non-variant outputs (seqs / haps / annotated-haps / reference) | — | Trivial: `_Flat` already exists; stop calling `to_ragged()`. |
+| **A** | Flat **variant** decode kernel — numba reimplementation of `_get_variants` over sparse genotypes, no awkward | A0 (shared boundary/API) | The real foundation; removes gvl's internal 62 % awkward in the variants path. |
+| **B** | Absorb variant assembly into gvl: phased+unphased ploidy merge, within-group sort, dummy-variant / empty-region padding | A | Much of this already exists as gvf PR #19 `_ragged_numba.py` kernels to upstream + generalize. |
+| **C** | Flank fetch + tokenization in gvl: sample-invariant reference dedup, `seqpro.tokenize` via a **caller-supplied byte→int LUT**, flat int-token output | A | Moves `seqpro.tokenize` (3.55 s) down; dedups per unique region. |
+| **D** | Window allele output mode: `ref_window = flank5·ref·flank3`, `alt_window = flank5·alt·flank3` as flat token buffers | C | Single contiguous reference read for `ref_window`; assembly for `alt_window`; dummy = all-`N` window. |
+| **E** | `double_buffered` transport composition + `__getitems__` super-batch entry | A | Transport already decomposes `RaggedVariants` to flat buffers in `_shm_layout.py` (kind=2); largely "don't re-wrap on read" + relax file-backed / splice / `insertion_fill` constraints. |
+
+**Decision (boundary):** tokenization lives in gvl *optionally*, driven by a caller-supplied
+byte→int LUT (sub-project C). So B/C/D are genuinely gvl features, and `seqpro.tokenize`
+moves down with dedup applied.
+
+**Recommended order:** A0 → **A** → (B, C — independent, both need A) → D (needs C).
+E needs only A's payload shape but delivers most once B/C shrink the payload, so sequence it
+after B/C unless the training run needs prefetch overlap sooner.
+
+Each gvl sub-project lands with the matching **genvarformer consumer thinning** (strip awkward
+from `_fetch`, `_read_flank_seq`, `_add_dummy_variant`, `rag_to_nested`), validated against
+genvarformer's existing batch-equality guardrail.
+
+---
+
+## 2. Goal (this spec: A0 + A)
+
+`dataset.with_output_format("flat")[idx]` returns pure-numpy `(data, offsets, shape)`
+containers with **zero awkward on the hot path**, **byte-identical when re-wrapped** to
+today's output, for the seqs / haps / annotated-haps / reference outputs (A0) and the
+variants output (A).
+
+---
+
+## 3. Public API
+
+- **`Dataset.with_output_format(fmt: Literal["ragged", "flat"]) -> Dataset`** — returns a
+  frozen-dataclass copy with a new `output_format` field (default `"ragged"`), mirroring the
+  existing `with_*` lazy-view methods. Threads into `QueryView` as a `flat_output` flag.
+  Orthogonal to `output_length` and to subsetting; composes with them. The `__getitems__`
+  plural / super-batch entry is **deferred to E** — `with_output_format` is independent of it.
+
+- **New public types** (added to `genvarloader/__init__.py` `__all__`). Promote the existing
+  internals to documented public names; keep the underscored aliases so no internal call site
+  breaks:
+  - **`FlatRagged`** (= `_Flat`): `.data`, `.offsets`, `.shape`, `.to_ragged()`,
+    `.to_fixed(length)`, `.to_padded(pad)`, `.reshape`, `.squeeze`.
+  - **`FlatAnnotatedHaps`** (= `_FlatAnnotatedHaps`): `.haps`, `.var_idxs`, `.ref_coords`,
+    plus `.to_ragged()` / `.to_fixed()` / `.to_padded()`.
+  - **`FlatVariants`** (new): mirrors `RaggedVariants` field-for-field —
+    `start` / `ilen` / `dosage` / `info[...]` as `FlatRagged`; `alt` / `ref` as
+    **`FlatAlleles`**. Implements `.to_ragged() -> RaggedVariants`, plus `reshape` / `squeeze`
+    delegating to each field.
+  - **`FlatAlleles`** (new): two-level flat bytestring — `byte_data: uint8`, `seq_offsets`
+    (per-variant byte offsets), `var_offsets` (per-`(instance, ploid)` variant offsets),
+    `shape` carrying ploidy. Layout matches genvarformer's `_bpvl` / `_decompose_bytestring`
+    exactly (inner-before-outer offsets).
+
+- **Skill update:** `skills/genvarloader/SKILL.md` must document the new `with_output_format`
+  method, the flat output mode, and the new public types (CLAUDE.md mandates this for any
+  public-API change).
+
+---
+
+## 4. Boundary change (`_dataset/_query.py`)
+
+Today `getitem` (line ~107) unconditionally maps `_Flat` / `_FlatAnnotatedHaps → to_ragged()`,
+after the `output_length` pad / `to_fixed` massaging (lines ~92–103).
+
+In **flat mode** (`view.flat_output`):
+- **Skip** `to_ragged()` and **skip** the `output_length` pad / `to_fixed` massaging — return
+  the flat wrappers raw. The consumer densifies via `.to_fixed` / `.to_padded` when it wants
+  dense output. (Flat mode is orthogonal to `output_length`; the buffers are valid regardless,
+  and densification is the consumer's choice.)
+- **`reshape` / `squeeze`** (lines ~112–117) still apply. `FlatRagged` already has both;
+  `FlatVariants` / `FlatAlleles` gain `reshape` / `squeeze` delegating to each field.
+- **`rc_neg`** (negative-strand reverse-complement, lines ~158–160) routes through
+  `_Flat.reverse_masked(comp=_COMP)` (already implemented) instead of
+  `reverse_complement_ragged`.
+
+**Edge to verify (not blocking):** reverse-complement semantics for the **variants** record
+output (`FlatVariants`) — confirm whether variant records are reverse-complemented at all in
+the current ragged path, and match that behaviour exactly.
+
+---
+
+## 5. A — flat variant decode (replaces awkward `_get_variants`)
+
+Numba over the sparse buffers already in hand: `geno_offset_idx`
+(from `_get_geno_offset_idx`, computed via `ravel_multi_index`), `genotypes.offsets`,
+`genotypes.data` (the v_idxs store), `variants.start`, `variants.ilen`, `variants.alt`,
+`variants.ref`, `variants.info[...]`, `dosages`. This reuses the exact pattern
+`reconstruct_haplotypes_from_sparse` already uses (it consumes `geno_offset_idx` +
+`geno_offsets` + `geno_v_idxs` in numba with no awkward) — A emits the variant *fields*
+instead of reconstructed sequences.
+
+1. **Gather selected v_idxs** — numba over `geno_offset_idx` → flat `v_idxs` buffer +
+   per-`(instance, ploid)` output offsets `(b*p + 1)`. Replaces
+   `self.genotypes[r, s].to_packed()`.
+2. **Scalar fields** (`start`, `ilen`, `info[...]`) — dense fancy-index `arr[v_idxs]` →
+   `FlatRagged.from_offsets(data, shape, offsets)`. **`dosage`** is parallel to genotypes
+   (not gathered via `v_idxs`); gather its payload by the same genotype offset ranges,
+   matching today's `self.dosages[r, s]`.
+3. **Alleles** (`alt`, `ref`) — segmented numba gather. Preallocate exact bytes with the
+   `_allele_bytes_sum` approach (already computes per-instance totals without touching
+   payload), copy each selected variant's allele bytes into a flat buffer, and build the
+   two-level offsets → `FlatAlleles`. Replaces `getattr(self.variants, kind)[v_idxs]` +
+   `.to_packed()` + `_build_allele_layout`.
+4. **Filters** —
+   - `min_af` / `max_af`: compute `info["AF"][v_idxs]`, build the keep mask, compact `v_idxs`
+     and recompute offsets in numba. Replaces the awkward `genos[_keep]` /
+     `ak.to_regular(...)` path.
+   - `exonic`: `choose_exonic_variants` is already numba and yields `keep` / `keep_offsets`;
+     apply as a flat compaction.
+5. **Assemble** `FlatVariants(**fields)`. In ragged mode the boundary calls
+   `.to_ragged()` → an element-identical `RaggedVariants`.
+
+---
+
+## 6. A0 — flat passthrough (non-variant outputs)
+
+The seqs / haps / annotated-haps / reference reconstructors already return `_Flat` /
+`_FlatAnnotatedHaps`. A0 is the boundary returning them public-wrapped (`FlatRagged` /
+`FlatAnnotatedHaps`) instead of `to_ragged()`, with `reshape` / `squeeze` / `rc_neg`
+preserved via the existing `_Flat` methods.
+
+**Deferred:** tracks / intervals (`RaggedIntervals`) — `_call_intervals` is its own awkward
+path and not yet a `_Flat`. Out of A0 scope; handled in B or E.
+
+---
+
+## 7. Equivalence & acceptance (primary gate)
+
+1. **Byte-identity.** `FlatVariants.to_ragged()` rebuilds `RaggedVariants` via gvl's existing
+   `_build_allele_layout` (same boxing as gvf's `_bpv` / `_bpvl`). Across an index matrix —
+   scalar, list, 2-D `(region, sample)`, empty regions, AF-filtered, exonic-filtered,
+   multi-ploidy — assert `flat.to_ragged()` is **element-identical** to the current
+   `dataset[idx]`. Extend `tests/dataset/test_flat_getitem_snapshot.py` and
+   `tests/dataset/test_flat_variants.py`.
+2. **No awkward on the hot path.** A test / micro-bench asserts `awkward.highlevel.__getitem__`
+   is absent from the variant-decode call stack in flat mode.
+3. **Consumer parity.** genvarformer's existing batch-equality guardrail passes with the thin
+   wrapper (§8) swapped in.
+
+---
+
+## 8. genvarformer consumer thinning (validation, separate repo)
+
+Lands alongside this gvl change to prove the win and exercise the API:
+- `RefSeq._call_one_to_many` + `rag_to_nested` (`_helpers.py`): consume `FlatRagged` directly →
+  `Nested` (`torch.from_numpy(data)`, offsets cast to int32), dropping the
+  `np.asarray(rag.data)` round-trip.
+- `Variants._fetch` step 1: receives `FlatVariants` — PR #19's `_decompose_bytestring` boxing
+  on the *inputs* disappears (already flat). The merge / sort / dummy kernels stay in gvf for
+  now (that is sub-project B) but now take flat inputs.
+- Validate against the existing batch-equality guardrail.
+
+---
+
+## 9. Error handling & constraints
+
+- `with_output_format("flat")` composes with `subset_to` and `output_length`. Combinations
+  already unsupported in the ragged path (e.g. spliced + variants) keep raising the same
+  errors.
+- Flat types are views into freshly allocated buffers — safe to wrap with `torch.from_numpy`
+  without a copy. Offsets are int64; consumers wanting torch `Nested` cast to int32. Document
+  this.
+- Promoting `_Flat` etc. to public names must keep the underscored aliases working so no
+  internal call site breaks.
+
+---
+
+## 10. Testing strategy
+
+- gvl: extend the flat snapshot / equality tests with a `flat`-mode parametrization across the
+  index matrix in §7; add the awkward-absence guard.
+- Run the existing suite (`pixi run -e dev test`) to confirm no regression in the ragged path.
+- genvarformer: run the batch-equality guardrail with the thin wrapper.
+
+---
+
+## 11. Scope boundary
+
+**In scope:** A0 (seqs / haps / annotated-haps / reference) + A (variants) flat decode; the
+public types; `with_output_format`; byte-identity + awkward-absence tests; the genvarformer
+thin-wrapper validation.
+
+**Out of scope (own specs):** B (assembly absorb), C (flank + tokenize), D (windows),
+E (`double_buffered` + `__getitems__` super-batch entry), and the tracks / intervals flat path.

--- a/python/genvarloader/__init__.py
+++ b/python/genvarloader/__init__.py
@@ -6,6 +6,8 @@ from seqpro.rag import Ragged
 
 from . import data_registry
 from ._bigwig import BigWigs
+from ._dataset._flat_variants import _FlatAlleles as FlatAlleles
+from ._dataset._flat_variants import _FlatVariants as FlatVariants
 from ._dataset._impl import ArrayDataset, Dataset, RaggedDataset
 from ._dataset._insertion_fill import (
     Constant,
@@ -19,8 +21,6 @@ from ._dataset._rag_variants import RaggedVariants
 from ._dataset._reference import RefDataset, Reference
 from ._dataset._svar_link import migrate_svar_link
 from ._dataset._write import get_splice_bed, write
-from ._dataset._flat_variants import _FlatAlleles as FlatAlleles
-from ._dataset._flat_variants import _FlatVariants as FlatVariants
 from ._dummy import get_dummy_dataset
 from ._flat import _Flat as FlatRagged
 from ._flat import _FlatAnnotatedHaps as FlatAnnotatedHaps
@@ -39,11 +39,11 @@ __all__ = [
     "Constant",
     "Dataset",
     "DatasetWithSites",
+    "FlankSample",
     "FlatAlleles",
     "FlatAnnotatedHaps",
     "FlatRagged",
     "FlatVariants",
-    "FlankSample",
     "InsertionFill",
     "Interpolate",
     "Ragged",

--- a/python/genvarloader/__init__.py
+++ b/python/genvarloader/__init__.py
@@ -19,7 +19,11 @@ from ._dataset._rag_variants import RaggedVariants
 from ._dataset._reference import RefDataset, Reference
 from ._dataset._svar_link import migrate_svar_link
 from ._dataset._write import get_splice_bed, write
+from ._dataset._flat_variants import _FlatAlleles as FlatAlleles
+from ._dataset._flat_variants import _FlatVariants as FlatVariants
 from ._dummy import get_dummy_dataset
+from ._flat import _Flat as FlatRagged
+from ._flat import _FlatAnnotatedHaps as FlatAnnotatedHaps
 from ._ragged import RaggedAnnotatedHaps, RaggedIntervals
 from ._table import Table
 from ._torch import to_nested_tensor
@@ -35,6 +39,10 @@ __all__ = [
     "Constant",
     "Dataset",
     "DatasetWithSites",
+    "FlatAlleles",
+    "FlatAnnotatedHaps",
+    "FlatRagged",
+    "FlatVariants",
     "FlankSample",
     "InsertionFill",
     "Interpolate",

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -1,0 +1,103 @@
+"""Flat-buffer analog of RaggedVariants: pure-numpy (data, offsets) per field,
+no awkward on the hot path. Converts to RaggedVariants only via to_ragged()."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .._flat import _Flat
+
+
+@dataclass(slots=True)
+class _FlatAlleles:
+    """Two-level flat bytestring for an alt/ref allele field, shape (b, p, ~v, ~l).
+
+    Layout matches _build_allele_layout (inner-before-outer):
+    - byte_data:   uint8 contiguous allele bytes
+    - seq_offsets: per-variant byte boundaries (allele_offsets), len n_variants + 1
+    - var_offsets: per-(b*p)-row variant boundaries (group_offsets), len b*p + 1
+    - shape:       outer fixed dims with exactly one None (the ragged variant axis)
+    """
+
+    byte_data: NDArray[np.uint8]
+    seq_offsets: NDArray[np.int64]
+    var_offsets: NDArray[np.int64]
+    shape: tuple[int | None, ...]
+
+    @property
+    def ploidy(self) -> int:
+        # shape is (b, p, None) for variants; ploidy is the last fixed dim.
+        # For a flat (2, None) shape (b*p flattened), ploidy defaults to 1.
+        fixed = [d for d in self.shape if d is not None]
+        return fixed[-1] if len(fixed) >= 2 else 1
+
+    def to_ragged(self):
+        from ._haps import _build_allele_layout
+
+        return _build_allele_layout(
+            np.ascontiguousarray(self.byte_data, np.uint8),
+            np.asarray(self.seq_offsets, np.int64),
+            np.asarray(self.var_offsets, np.int64),
+            self.ploidy,
+        )
+
+    def reverse_masked(self, mask: NDArray[np.bool_]) -> "_FlatAlleles":
+        """DNA reverse-complement the mask-selected (b*p) rows' alleles, in place.
+        ``mask`` is one entry per (b*p) row; broadcast across that row's variants."""
+        from seqpro.rag import Ragged
+
+        from .._ragged import reverse_complement_masked
+
+        m = np.ascontiguousarray(mask, np.bool_).reshape(-1)
+        # per-allele mask: repeat each row's flag across its variant count
+        per_allele = np.repeat(m, np.diff(self.var_offsets))
+        view = Ragged.from_offsets(
+            self.byte_data.view("S1"),
+            (per_allele.size, None),
+            np.asarray(self.seq_offsets, np.int64),
+        )
+        reverse_complement_masked(view, per_allele)  # mutates byte_data in place
+        return self
+
+    def reshape(self, shape: tuple[int | None, ...]) -> "_FlatAlleles":
+        return _FlatAlleles(self.byte_data, self.seq_offsets, self.var_offsets, shape)
+
+
+@dataclass(slots=True)
+class _FlatVariants:
+    """Flat analog of RaggedVariants. `fields` maps field name -> _Flat (scalar
+    fields: start/ilen/dosage/info) or _FlatAlleles (alt/ref)."""
+
+    fields: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def shape(self) -> tuple[int | None, ...]:
+        return self.fields["start"].shape
+
+    def to_ragged(self):
+        from ._rag_variants import RaggedVariants
+
+        kw = {}
+        for name, f in self.fields.items():
+            kw[name] = f.to_ragged()
+        return RaggedVariants(**kw)
+
+    def reshape(self, shape) -> "_FlatVariants":
+        return _FlatVariants({k: v.reshape(shape) for k, v in self.fields.items()})
+
+    def squeeze(self, axis: int | None = None) -> "_FlatVariants":
+        return _FlatVariants(
+            {k: v.squeeze(axis) for k, v in self.fields.items()}
+        )
+
+    def reverse_masked(self, mask: NDArray[np.bool_]) -> "_FlatVariants":
+        # Only alt/ref alleles are reverse-complemented; scalar fields unchanged
+        # (matches RaggedVariants.rc_ which only touches alt/ref).
+        for name in ("alt", "ref"):
+            if name in self.fields:
+                self.fields[name] = self.fields[name].reverse_masked(mask)
+        return self

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -4,10 +4,14 @@ no awkward on the hot path. Converts to RaggedVariants only via to_ragged()."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+import numba as nb
 import numpy as np
 from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from ._haps import Haps
 
 
 
@@ -35,25 +39,52 @@ class _FlatAlleles:
         return fixed[-1] if len(fixed) >= 2 else 1
 
     def to_ragged(self):
+        from awkward.contents import RegularArray
+
         from ._haps import _build_allele_layout
 
-        return _build_allele_layout(
+        # Build the canonical (outer_p, p, ~v, ~l) layout where the innermost
+        # RegularArray groups the b*p rows by ploidy.
+        arr = _build_allele_layout(
             np.ascontiguousarray(self.byte_data, np.uint8),
             np.asarray(self.seq_offsets, np.int64),
             np.asarray(self.var_offsets, np.int64),
             self.ploidy,
         )
+        # If there are additional leading fixed dims (e.g. (6, 3, 2)), rebuild the
+        # regular-axis stack so the outer shape matches self.shape exactly. Mirrors
+        # RaggedVariants.reshape: strip all RegularArrays down to the variant-row
+        # node, then wrap by reversed(shape[1:]) (= every fixed dim except the
+        # leading one, which is implied by the remaining group count).
+        fixed = [d for d in self.shape if d is not None]
+        if len(fixed) > 2:
+            import awkward as ak
+
+            node = arr.layout
+            while isinstance(node, RegularArray):
+                node = node.content
+            for len_ in reversed(fixed[1:]):
+                node = RegularArray(node, len_)
+            arr = ak.Array(node)
+        return arr
 
     def reverse_masked(self, mask: NDArray[np.bool_]) -> "_FlatAlleles":
-        """DNA reverse-complement the mask-selected (b*p) rows' alleles, in place.
-        ``mask`` is one entry per (b*p) row; broadcast across that row's variants."""
+        """DNA reverse-complement the mask-selected rows' alleles, in place.
+
+        ``mask`` is one entry per region (length ``b``); it is broadcast across
+        ploidy then across each (b*p) row's variant count, exactly matching
+        ``RaggedVariants.rc_`` (``np.repeat(to_rc, ploidy)`` then
+        ``np.repeat(per_bp, np.diff(group_off))``).
+        """
         from seqpro.rag import Ragged
 
         from .._ragged import reverse_complement_masked
 
         m = np.ascontiguousarray(mask, np.bool_).reshape(-1)
+        # per-(b*p) mask: broadcast each region's flag across ploidy
+        per_bp = np.repeat(m, self.ploidy)
         # per-allele mask: repeat each row's flag across its variant count
-        per_allele = np.repeat(m, np.diff(self.var_offsets))
+        per_allele = np.repeat(per_bp, np.diff(self.var_offsets))
         view = Ragged.from_offsets(
             self.byte_data.view("S1"),
             (per_allele.size, None),
@@ -109,3 +140,163 @@ class _FlatVariants:
             if name in self.fields:
                 self.fields[name] = self.fields[name].reverse_masked(mask)
         return self
+
+
+@nb.njit(nogil=True, cache=True)
+def _gather_v_idxs(geno_offset_idx, geno_offsets, geno_v_idxs):  # pragma: no cover - njit
+    n_rows = geno_offset_idx.shape[0]
+    out_offsets = np.empty(n_rows + 1, np.int64)
+    out_offsets[0] = 0
+    for i in range(n_rows):
+        goi = geno_offset_idx[i]
+        out_offsets[i + 1] = out_offsets[i] + (geno_offsets[goi + 1] - geno_offsets[goi])
+    total = out_offsets[n_rows]
+    v_idxs = np.empty(total, geno_v_idxs.dtype)
+    dst = 0
+    for i in range(n_rows):
+        goi = geno_offset_idx[i]
+        s = geno_offsets[goi]
+        e = geno_offsets[goi + 1]
+        for k in range(s, e):
+            v_idxs[dst] = geno_v_idxs[k]
+            dst += 1
+    return v_idxs, out_offsets
+
+
+@nb.njit(nogil=True, cache=True)
+def _gather_alleles(v_idxs, allele_bytes, allele_offsets):  # pragma: no cover - njit
+    n = v_idxs.shape[0]
+    seq_offsets = np.empty(n + 1, np.int64)
+    seq_offsets[0] = 0
+    for i in range(n):
+        v = v_idxs[i]
+        seq_offsets[i + 1] = seq_offsets[i] + (allele_offsets[v + 1] - allele_offsets[v])
+    data = np.empty(seq_offsets[n], np.uint8)
+    dst = 0
+    for i in range(n):
+        v = v_idxs[i]
+        s = allele_offsets[v]
+        e = allele_offsets[v + 1]
+        for k in range(s, e):
+            data[dst] = allele_bytes[k]
+            dst += 1
+    return data, seq_offsets
+
+
+@nb.njit(nogil=True, cache=True)
+def _compact_keep(v_idxs, row_offsets, keep):  # pragma: no cover - njit
+    n_rows = row_offsets.shape[0] - 1
+    new_offsets = np.empty(n_rows + 1, np.int64)
+    new_offsets[0] = 0
+    n_keep = 0
+    for i in range(n_rows):
+        for j in range(row_offsets[i], row_offsets[i + 1]):
+            if keep[j]:
+                n_keep += 1
+        new_offsets[i + 1] = n_keep
+    new_v = np.empty(n_keep, v_idxs.dtype)
+    dst = 0
+    for j in range(v_idxs.shape[0]):
+        if keep[j]:
+            new_v[dst] = v_idxs[j]
+            dst += 1
+    return new_v, new_offsets
+
+
+def get_variants_flat(haps: "Haps", idx: NDArray[np.integer]) -> _FlatVariants:
+    """Flat-buffer analog of :meth:`Haps._get_variants`: builds a
+    :class:`_FlatVariants` with no awkward on the hot path. Re-wrapping the
+    result via :meth:`_FlatVariants.to_ragged` is byte-identical to the awkward
+    :class:`RaggedVariants` produced by ``_get_variants``.
+
+    Replicates ONLY AF filtering (min_af/max_af); exonic filtering is not
+    threaded into the variants output (its ``keep``/``keep_offsets`` params are
+    dead in ``_get_variants``).
+    """
+    from .._flat import _Flat
+
+    genotypes = haps.genotypes
+    ploidy = genotypes.shape[-2]
+    b = len(idx)
+
+    # (b, ploidy) indices into the sparse-genotype offsets. Flatten C-order to
+    # (b*ploidy,) so per-row slicing reproduces genotypes[r,s].to_packed() order.
+    geno_offset_idx = haps._get_geno_offset_idx(idx, genotypes).reshape(-1)
+    geno_offset_idx = np.ascontiguousarray(geno_offset_idx, np.intp)
+
+    geno_offsets = np.asarray(genotypes.offsets, np.int64)
+    geno_v_idxs = np.asarray(genotypes.data)
+
+    # v_idxs: gathered per (b*ploidy) row; row_offsets length b*ploidy + 1.
+    v_idxs, row_offsets = _gather_v_idxs(geno_offset_idx, geno_offsets, geno_v_idxs)
+
+    # Unfiltered offsets needed for dosage parallel-gather + compaction.
+    unfiltered_row_offsets = row_offsets
+
+    # AF filtering (mirrors _get_variants). Computed before gathering dosage so we
+    # can compact dosage with the SAME keep mask + UNFILTERED offsets.
+    keep = None
+    if haps.min_af is not None or haps.max_af is not None:
+        geno_afs = np.asarray(haps.variants.info["AF"])[v_idxs]
+        keep = np.full(len(v_idxs), True, np.bool_)
+        if haps.min_af is not None:
+            keep &= geno_afs >= haps.min_af
+        if haps.max_af is not None:
+            keep &= geno_afs <= haps.max_af
+
+    # Dosage: parallel to genotypes (one value per variant, gathered by the SAME
+    # genotype offset ranges). Gather against UNFILTERED offsets first.
+    dosage_data = None
+    if haps.dosages is not None and "dosage" in haps.var_fields:
+        dos_offsets = np.asarray(haps.dosages.offsets, np.int64)
+        dos_all = np.asarray(haps.dosages.data)
+        dosage_data, dos_row_offsets = _gather_v_idxs(
+            geno_offset_idx, dos_offsets, dos_all
+        )
+        # dos_row_offsets == unfiltered_row_offsets by construction (genotypes and
+        # dosages share offset structure).
+
+    # Apply AF compaction to v_idxs / row_offsets / dosage.
+    if keep is not None:
+        v_idxs, row_offsets = _compact_keep(v_idxs, unfiltered_row_offsets, keep)
+        if dosage_data is not None:
+            dosage_data, _ = _compact_keep(dosage_data, unfiltered_row_offsets, keep)
+
+    shape: tuple[int | None, ...] = (b, ploidy, None)
+
+    fields: dict[str, Any] = {}
+
+    # alt: ALWAYS (required)
+    alt_bytes = np.asarray(haps.variants.alt.data).view(np.uint8)
+    alt_off = np.asarray(haps.variants.alt.offsets, np.int64)
+    alt_data, alt_seq_off = _gather_alleles(v_idxs, alt_bytes, alt_off)
+    fields["alt"] = _FlatAlleles(alt_data, alt_seq_off, row_offsets, shape)
+
+    # start: ALWAYS (added unconditionally by _get_variants)
+    start_data = np.asarray(haps.variants.start)[v_idxs]
+    fields["start"] = _Flat.from_offsets(start_data, shape, row_offsets)
+
+    # ref: if "ref" in var_fields
+    if "ref" in haps.var_fields:
+        ref_bytes = np.asarray(haps.variants.ref.data).view(np.uint8)
+        ref_off = np.asarray(haps.variants.ref.offsets, np.int64)
+        ref_data, ref_seq_off = _gather_alleles(v_idxs, ref_bytes, ref_off)
+        fields["ref"] = _FlatAlleles(ref_data, ref_seq_off, row_offsets, shape)
+
+    # ilen: if "ilen" in var_fields
+    if "ilen" in haps.var_fields:
+        ilen_data = np.asarray(haps.variants.ilen)[v_idxs]
+        fields["ilen"] = _Flat.from_offsets(ilen_data, shape, row_offsets)
+
+    # dosage: if dosages present and requested
+    if dosage_data is not None:
+        fields["dosage"] = _Flat.from_offsets(dosage_data, shape, row_offsets)
+
+    # other info fields
+    for k in haps.var_fields:
+        if k in {"alt", "start", "ref", "ilen", "dosage"}:
+            continue
+        info_data = np.asarray(haps.variants.info[k])[v_idxs]
+        fields[k] = _Flat.from_offsets(info_data, shape, row_offsets)
+
+    return _FlatVariants(fields)

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -9,7 +9,6 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
-from .._flat import _Flat
 
 
 @dataclass(slots=True)
@@ -65,6 +64,15 @@ class _FlatAlleles:
 
     def reshape(self, shape: tuple[int | None, ...]) -> "_FlatAlleles":
         return _FlatAlleles(self.byte_data, self.seq_offsets, self.var_offsets, shape)
+
+    def squeeze(self, axis: int | None = None) -> "_FlatAlleles":
+        fixed = [d for d in self.shape if d is not None]
+        if axis is None:
+            fixed = [d for d in fixed if d != 1]
+        else:
+            del fixed[axis]
+        return _FlatAlleles(self.byte_data, self.seq_offsets, self.var_offsets,
+                            (*fixed, None))
 
 
 @dataclass(slots=True)

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from ._haps import Haps
 
 
-
 @dataclass(slots=True)
 class _FlatAlleles:
     """Two-level flat bytestring for an alt/ref allele field, shape (b, p, ~v, ~l).
@@ -112,8 +111,9 @@ class _FlatAlleles:
             fixed = [d for d in fixed if d != 1]
         else:
             del fixed[axis]
-        return _FlatAlleles(self.byte_data, self.seq_offsets, self.var_offsets,
-                            (*fixed, None))
+        return _FlatAlleles(
+            self.byte_data, self.seq_offsets, self.var_offsets, (*fixed, None)
+        )
 
 
 @dataclass(slots=True)
@@ -139,9 +139,7 @@ class _FlatVariants:
         return _FlatVariants({k: v.reshape(shape) for k, v in self.fields.items()})
 
     def squeeze(self, axis: int | None = None) -> "_FlatVariants":
-        return _FlatVariants(
-            {k: v.squeeze(axis) for k, v in self.fields.items()}
-        )
+        return _FlatVariants({k: v.squeeze(axis) for k, v in self.fields.items()})
 
     def reverse_masked(self, mask: NDArray[np.bool_]) -> "_FlatVariants":
         # Only alt/ref alleles are reverse-complemented; scalar fields unchanged
@@ -153,7 +151,9 @@ class _FlatVariants:
 
 
 @nb.njit(nogil=True, cache=True)
-def _gather_v_idxs(geno_offset_idx, geno_offsets, geno_v_idxs):  # pragma: no cover - njit
+def _gather_v_idxs(
+    geno_offset_idx, geno_offsets, geno_v_idxs
+):  # pragma: no cover - njit
     """Gather per-row variant indices: for each row's offset slice into the
     sparse arrays, copy its values out into flat ``(data, offsets)``."""
     n_rows = geno_offset_idx.shape[0]
@@ -161,7 +161,9 @@ def _gather_v_idxs(geno_offset_idx, geno_offsets, geno_v_idxs):  # pragma: no co
     out_offsets[0] = 0
     for i in range(n_rows):
         goi = geno_offset_idx[i]
-        out_offsets[i + 1] = out_offsets[i] + (geno_offsets[goi + 1] - geno_offsets[goi])
+        out_offsets[i + 1] = out_offsets[i] + (
+            geno_offsets[goi + 1] - geno_offsets[goi]
+        )
     total = out_offsets[n_rows]
     v_idxs = np.empty(total, geno_v_idxs.dtype)
     dst = 0
@@ -184,7 +186,9 @@ def _gather_alleles(v_idxs, allele_bytes, allele_offsets):  # pragma: no cover -
     seq_offsets[0] = 0
     for i in range(n):
         v = v_idxs[i]
-        seq_offsets[i + 1] = seq_offsets[i] + (allele_offsets[v + 1] - allele_offsets[v])
+        seq_offsets[i + 1] = seq_offsets[i] + (
+            allele_offsets[v + 1] - allele_offsets[v]
+        )
     data = np.empty(seq_offsets[n], np.uint8)
     dst = 0
     for i in range(n):

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -39,34 +39,37 @@ class _FlatAlleles:
         return fixed[-1] if len(fixed) >= 2 else 1
 
     def to_ragged(self):
-        from awkward.contents import RegularArray
+        import awkward as ak
+        from awkward.contents import ListOffsetArray, NumpyArray, RegularArray
+        from awkward.index import Index
 
-        from ._haps import _build_allele_layout
-
-        # Build the canonical (outer_p, p, ~v, ~l) layout where the innermost
-        # RegularArray groups the b*p rows by ploidy.
-        arr = _build_allele_layout(
+        # Build the ragged variant-row node (leaf -> bytestring -> variant-row
+        # ListOffsetArray) giving (n_groups, ~v, ~l) where n_groups =
+        # len(var_offsets) - 1. This mirrors the inner part of
+        # _build_allele_layout but WITHOUT the ploidy RegularArray wrap.
+        leaf = NumpyArray(
             np.ascontiguousarray(self.byte_data, np.uint8),
-            np.asarray(self.seq_offsets, np.int64),
-            np.asarray(self.var_offsets, np.int64),
-            self.ploidy,
+            parameters={"__array__": "byte"},
         )
-        # If there are additional leading fixed dims (e.g. (6, 3, 2)), rebuild the
-        # regular-axis stack so the outer shape matches self.shape exactly. Mirrors
-        # RaggedVariants.reshape: strip all RegularArrays down to the variant-row
-        # node, then wrap by reversed(shape[1:]) (= every fixed dim except the
-        # leading one, which is implied by the remaining group count).
+        l_content = ListOffsetArray(
+            Index(np.asarray(self.seq_offsets, np.int64)),
+            leaf,
+            parameters={"__array__": "bytestring"},
+        )
+        vl_content = ListOffsetArray(
+            Index(np.asarray(self.var_offsets, np.int64)), l_content
+        )
+        # Wrap with RegularArrays for the INNER fixed dims (everything except the
+        # outermost, which is implied by the remaining group count). Shape-driven:
+        # this makes to_ragged() agnostic to ploidy after a scalar-scalar squeeze.
+        #   fixed=[b,p]   -> reversed([p])   -> RegularArray(vl,p) -> (b,p,~v,~l)
+        #   fixed=[p]     -> reversed([])    -> no wrap            -> (p,~v,~l)
+        #   fixed=[b,s,p] -> reversed([s,p]) -> nested             -> (b,s,p,~v,~l)
+        node = vl_content
         fixed = [d for d in self.shape if d is not None]
-        if len(fixed) > 2:
-            import awkward as ak
-
-            node = arr.layout
-            while isinstance(node, RegularArray):
-                node = node.content
-            for len_ in reversed(fixed[1:]):
-                node = RegularArray(node, len_)
-            arr = ak.Array(node)
-        return arr
+        for size in reversed(fixed[1:]):
+            node = RegularArray(node, size)
+        return ak.Array(node)
 
     def reverse_masked(self, mask: NDArray[np.bool_]) -> "_FlatAlleles":
         """DNA reverse-complement the mask-selected rows' alleles, in place.

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -93,8 +93,15 @@ class _FlatAlleles:
         reverse_complement_masked(view, per_allele)  # mutates byte_data in place
         return self
 
-    def reshape(self, shape: tuple[int | None, ...]) -> "_FlatAlleles":
-        return _FlatAlleles(self.byte_data, self.seq_offsets, self.var_offsets, shape)
+    def reshape(self, shape: int | tuple[int, ...]) -> "_FlatAlleles":
+        # Mirror _Flat.reshape: accept outer dims and APPEND our own ragged None.
+        if isinstance(shape, int):
+            shape = (shape,)
+        shape = tuple(shape)
+        if shape and shape[-1] is None:  # be defensive: strip a trailing None
+            shape = shape[:-1]
+        new = shape + (None,)
+        return _FlatAlleles(self.byte_data, self.seq_offsets, self.var_offsets, new)
 
     def squeeze(self, axis: int | None = None) -> "_FlatAlleles":
         fixed = [d for d in self.shape if d is not None]
@@ -144,6 +151,8 @@ class _FlatVariants:
 
 @nb.njit(nogil=True, cache=True)
 def _gather_v_idxs(geno_offset_idx, geno_offsets, geno_v_idxs):  # pragma: no cover - njit
+    """Gather per-row variant indices: for each row's offset slice into the
+    sparse arrays, copy its values out into flat ``(data, offsets)``."""
     n_rows = geno_offset_idx.shape[0]
     out_offsets = np.empty(n_rows + 1, np.int64)
     out_offsets[0] = 0
@@ -165,6 +174,8 @@ def _gather_v_idxs(geno_offset_idx, geno_offsets, geno_v_idxs):  # pragma: no co
 
 @nb.njit(nogil=True, cache=True)
 def _gather_alleles(v_idxs, allele_bytes, allele_offsets):  # pragma: no cover - njit
+    """Gather variable-length allele bytestrings for ``v_idxs`` from the global
+    allele byte buffer into flat ``(data, seq_offsets)``."""
     n = v_idxs.shape[0]
     seq_offsets = np.empty(n + 1, np.int64)
     seq_offsets[0] = 0
@@ -185,6 +196,9 @@ def _gather_alleles(v_idxs, allele_bytes, allele_offsets):  # pragma: no cover -
 
 @nb.njit(nogil=True, cache=True)
 def _compact_keep(v_idxs, row_offsets, keep):  # pragma: no cover - njit
+    """Drop variants where ``keep`` is False, rebuilding row offsets. The first
+    param is per-variant values to compact -- either ``v_idxs`` itself or a
+    parallel array (e.g. gathered dosage values) sharing the same row layout."""
     n_rows = row_offsets.shape[0] - 1
     new_offsets = np.empty(n_rows + 1, np.int64)
     new_offsets[0] = 0
@@ -250,11 +264,9 @@ def get_variants_flat(haps: "Haps", idx: NDArray[np.integer]) -> _FlatVariants:
     if haps.dosages is not None and "dosage" in haps.var_fields:
         dos_offsets = np.asarray(haps.dosages.offsets, np.int64)
         dos_all = np.asarray(haps.dosages.data)
-        dosage_data, dos_row_offsets = _gather_v_idxs(
-            geno_offset_idx, dos_offsets, dos_all
-        )
-        # dos_row_offsets == unfiltered_row_offsets by construction (genotypes and
-        # dosages share offset structure).
+        # The returned row offsets == unfiltered_row_offsets by construction
+        # (genotypes and dosages share offset structure), so discard them.
+        dosage_data, _ = _gather_v_idxs(geno_offset_idx, dos_offsets, dos_all)
 
     # Apply AF compaction to v_idxs / row_offsets / dosage.
     if keep is not None:

--- a/python/genvarloader/_dataset/_haps.py
+++ b/python/genvarloader/_dataset/_haps.py
@@ -509,12 +509,17 @@ class Haps(Reconstructor[_H]):
         rng: np.random.Generator,
         deterministic: bool,
         splice_plan: SplicePlan | None = None,
+        flat: bool = False,
     ) -> _H:
         if issubclass(self.kind, RaggedVariants):
             if splice_plan is not None:
                 raise NotImplementedError(
                     "Spliced output is not supported for RaggedVariants."
                 )
+            if flat:
+                from ._flat_variants import get_variants_flat
+
+                return cast(_H, get_variants_flat(self, idx))
             ragv = self._get_variants(idx=idx, regions=None, shifts=None)
             ragv = cast(_H, ragv)
             return ragv

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -648,6 +648,19 @@ class Dataset:
         new_recon = _build_reconstructor(self._seqs, new_tracks, self._seqs_kind)
         return replace(self, _tracks=new_tracks, _recon=new_recon)
 
+    def with_output_format(self, fmt: Literal["ragged", "flat"]) -> "Dataset":
+        """Return a copy that yields ``fmt`` containers from eager indexing.
+
+        Parameters
+        ----------
+        fmt
+            ``"ragged"`` for awkward-backed ``Ragged``/``RaggedVariants`` (default),
+            or ``"flat"`` for pure-numpy ``FlatRagged``/``FlatVariants``.
+        """
+        if fmt not in ("ragged", "flat"):
+            raise ValueError(f"output_format must be 'ragged' or 'flat', got {fmt!r}.")
+        return replace(self, output_format=fmt)
+
     path: Path
     """Path to the dataset."""
     output_length: Literal["ragged", "variable"] | int
@@ -698,6 +711,10 @@ class Dataset:
         | HapsTracks[RaggedVariants, RaggedIntervals]
     )
     _rng: np.random.Generator
+    output_format: Literal["ragged", "flat"] = "ragged"
+    """Container format for eager indexing. ``"ragged"`` (default) returns awkward-backed
+    seqpro ``Ragged`` / ``RaggedVariants``; ``"flat"`` returns pure-numpy ``FlatRagged`` /
+    ``FlatVariants`` with zero awkward on the hot path. See ``with_output_format``."""
 
     @property
     def is_subset(self) -> bool:
@@ -1595,6 +1612,7 @@ class Dataset:
             jitter=self.jitter,
             deterministic=self.deterministic,
             rc_neg=self.rc_neg,
+            flat_output=self.output_format == "flat",
         )
         return getitem(view, idx)
 

--- a/python/genvarloader/_dataset/_protocol.py
+++ b/python/genvarloader/_dataset/_protocol.py
@@ -32,4 +32,8 @@ class Reconstructor(Protocol[T]):
         deterministic: bool,
         splice_plan: SplicePlan | None = None,
         flat: bool = False,
-    ) -> T: ...
+    ) -> T:
+        """``flat`` only changes behavior for :class:`Haps` producing
+        ``RaggedVariants`` (it returns a flat ``_FlatVariants`` instead); all
+        other reconstructors are already flat-native and accept-and-ignore it."""
+        ...

--- a/python/genvarloader/_dataset/_protocol.py
+++ b/python/genvarloader/_dataset/_protocol.py
@@ -31,4 +31,5 @@ class Reconstructor(Protocol[T]):
         rng: np.random.Generator,
         deterministic: bool,
         splice_plan: SplicePlan | None = None,
+        flat: bool = False,
     ) -> T: ...

--- a/python/genvarloader/_dataset/_query.py
+++ b/python/genvarloader/_dataset/_query.py
@@ -90,28 +90,29 @@ def getitem(
     else:
         recon, squeeze, out_reshape = _getitem_unspliced(view, idx)
 
-    if view.output_length == "variable":
-        recon = tuple(
-            r if isinstance(r, (RaggedVariants, RaggedIntervals)) else pad(r)
-            for r in recon
-        )
-    elif isinstance(view.output_length, int):
-        recon = tuple(
-            r
-            if isinstance(r, (RaggedVariants, RaggedIntervals))
-            else r.to_fixed(view.output_length)
-            for r in recon
-        )
+    if not view.flat_output:
+        if view.output_length == "variable":
+            recon = tuple(
+                r if isinstance(r, (RaggedVariants, RaggedIntervals)) else pad(r)
+                for r in recon
+            )
+        elif isinstance(view.output_length, int):
+            recon = tuple(
+                r
+                if isinstance(r, (RaggedVariants, RaggedIntervals))
+                else r.to_fixed(view.output_length)
+                for r in recon
+            )
 
-    # Convert any still-flat elements (ragged output_length path) to their
-    # public Ragged types before reshape/squeeze apply the existing logic.
-    recon = tuple(
-        o.to_ragged() if isinstance(o, (_Flat, _FlatAnnotatedHaps)) else o
-        for o in recon
-    )
+        # Convert any still-flat elements (ragged output_length path) to their
+        # public Ragged types before reshape/squeeze apply the existing logic.
+        recon = tuple(
+            o.to_ragged() if isinstance(o, (_Flat, _FlatAnnotatedHaps)) else o
+            for o in recon
+        )
 
     if out_reshape is not None:
-        recon = tuple(o.reshape(out_reshape + o.shape[1:]) for o in recon)  # type: ignore[bad-argument-type, no-matching-overload]  # heterogeneous reshape() across array kinds; shape tuple may contain None for ragged dims
+        recon = tuple(_reshape_outer(o, out_reshape) for o in recon)
 
     if squeeze:
         # (1 [p] l) -> ([p] l)
@@ -121,6 +122,22 @@ def getitem(
         recon = recon[0]
 
     return recon
+
+
+def _reshape_outer(o, out_reshape: tuple[int, ...]):
+    """Reshape the outer (leading) dims of a query output to ``out_reshape``.
+
+    Reshape conventions differ by type. An awkward ``Ragged`` (or
+    ``RaggedAnnotatedHaps``) ``.reshape()`` takes the FULL new shape, including
+    the trailing ragged ``None`` axis, so we pass ``out_reshape + o.shape[1:]``.
+    By contrast ``_Flat``/``_FlatAnnotatedHaps`` ``.reshape()`` takes only the
+    OUTER fixed dims and re-appends its own trailing ``None``; passing the full
+    shape (which already ends in ``None``) would yield a double ragged axis.
+    For those we drop the trailing ``None`` and pass only the outer dims.
+    """
+    if isinstance(o, (_Flat, _FlatAnnotatedHaps)):
+        return o.reshape(out_reshape + o.shape[1:-1])
+    return o.reshape(out_reshape + o.shape[1:])  # type: ignore[bad-argument-type, no-matching-overload]  # heterogeneous reshape() across array kinds; shape tuple may contain None for ragged dims
 
 
 def _getitem_unspliced(

--- a/python/genvarloader/_dataset/_query.py
+++ b/python/genvarloader/_dataset/_query.py
@@ -17,6 +17,7 @@ from seqpro.rag import Ragged
 from typing_extensions import assert_never
 
 from .._flat import _Flat, _FlatAnnotatedHaps
+from ._flat_variants import _FlatVariants
 from .._ragged import (
     RaggedAnnotatedHaps,
     RaggedIntervals,
@@ -135,7 +136,7 @@ def _reshape_outer(o, out_reshape: tuple[int, ...]):
     shape (which already ends in ``None``) would yield a double ragged axis.
     For those we drop the trailing ``None`` and pass only the outer dims.
     """
-    if isinstance(o, (_Flat, _FlatAnnotatedHaps)):
+    if isinstance(o, (_Flat, _FlatAnnotatedHaps, _FlatVariants)):
         return o.reshape(out_reshape + o.shape[1:-1])
     return o.reshape(out_reshape + o.shape[1:])  # type: ignore[bad-argument-type, no-matching-overload]  # heterogeneous reshape() across array kinds; shape tuple may contain None for ragged dims
 
@@ -168,6 +169,7 @@ def _getitem_unspliced(
         jitter=view.jitter,
         rng=view.rng,
         deterministic=view.deterministic,
+        flat=view.flat_output,
     )
 
     if not isinstance(recon, tuple):
@@ -234,6 +236,7 @@ def _getitem_spliced(
         rng=view.rng,
         deterministic=view.deterministic,
         splice_plan=plan,
+        flat=view.flat_output,
     )
 
     if not isinstance(recon, tuple):
@@ -344,6 +347,10 @@ def reverse_complement_ragged(
 ) -> _FlatAnnotatedHaps: ...
 @overload
 def reverse_complement_ragged(
+    rag: _FlatVariants, to_rc: NDArray[np.bool_]
+) -> _FlatVariants: ...
+@overload
+def reverse_complement_ragged(
     rag: RaggedVariants, to_rc: NDArray[np.bool_]
 ) -> RaggedVariants: ...
 @overload
@@ -351,15 +358,17 @@ def reverse_complement_ragged(
     rag: RaggedIntervals, to_rc: NDArray[np.bool_]
 ) -> RaggedIntervals: ...
 def reverse_complement_ragged(
-    rag: _Flat | _FlatAnnotatedHaps | RaggedVariants | RaggedIntervals,
+    rag: _Flat | _FlatAnnotatedHaps | _FlatVariants | RaggedVariants | RaggedIntervals,
     to_rc: NDArray[np.bool_],
-) -> _Flat | _FlatAnnotatedHaps | RaggedVariants | RaggedIntervals:
+) -> _Flat | _FlatAnnotatedHaps | _FlatVariants | RaggedVariants | RaggedIntervals:
     """Reverse-complement (or reverse) ragged outputs according to a per-row mask."""
     if isinstance(rag, _Flat):
         comp = _COMP if rag.data.dtype.kind == "S" else None
         return rag.reverse_masked(to_rc, comp=comp)
     if isinstance(rag, _FlatAnnotatedHaps):
         return rag.reverse_masked(to_rc, _COMP)
+    if isinstance(rag, _FlatVariants):
+        return rag.reverse_masked(to_rc)
     if isinstance(rag, RaggedVariants):
         return rag.rc_(to_rc)
     if isinstance(rag, RaggedIntervals):

--- a/python/genvarloader/_dataset/_query.py
+++ b/python/genvarloader/_dataset/_query.py
@@ -51,6 +51,7 @@ class QueryView:
     jitter: int
     deterministic: bool
     rc_neg: bool
+    flat_output: bool = False
 
     @property
     def full_shape(self) -> tuple[int, int]:

--- a/python/genvarloader/_dataset/_reconstruct.py
+++ b/python/genvarloader/_dataset/_reconstruct.py
@@ -65,6 +65,7 @@ class RefTracks(Reconstructor[tuple[Ragged[np.bytes_], _T]]):
         rng: np.random.Generator,
         deterministic: bool,
         splice_plan: SplicePlan | None = None,
+        flat: bool = False,
     ) -> tuple[Ragged[np.bytes_], _T]:
         if splice_plan is not None:
             raise NotImplementedError(
@@ -113,6 +114,7 @@ class HapsTracks(Reconstructor[tuple[_H, _T]]):
         rng: np.random.Generator,
         deterministic: bool,
         splice_plan: SplicePlan | None = None,
+        flat: bool = False,
     ) -> tuple[_H, _T]:
         if splice_plan is not None:
             raise NotImplementedError(

--- a/python/genvarloader/_dataset/_ref.py
+++ b/python/genvarloader/_dataset/_ref.py
@@ -35,6 +35,7 @@ class Ref(Reconstructor[Ragged[np.bytes_]]):
         rng: np.random.Generator,
         deterministic: bool,
         splice_plan: SplicePlan | None = None,
+        flat: bool = False,
     ) -> Ragged[np.bytes_]:
         batch_size = len(idx)
 

--- a/python/genvarloader/_dataset/_tracks.py
+++ b/python/genvarloader/_dataset/_tracks.py
@@ -556,6 +556,7 @@ class Tracks(Reconstructor[_T]):
         rng: np.random.Generator,
         deterministic: bool,
         splice_plan: SplicePlan | None = None,
+        flat: bool = False,
     ) -> _T:
         if splice_plan is not None and not issubclass(self.kind, RaggedTracks):
             raise NotImplementedError(

--- a/skills/genvarloader/SKILL.md
+++ b/skills/genvarloader/SKILL.md
@@ -153,6 +153,29 @@ Without `reference=`, a genotypes-only dataset opens with the **`"variants"`** v
 
 Returns either a `RaggedDataset` or `ArrayDataset` (frozen dataclass views) based on `with_len`. See `docs/source/dataset.md` for diagrams.
 
+`with_output_format(fmt)` selects the container type returned by eager indexing:
+
+| `fmt`      | Container types returned                                                   | Default? |
+|------------|----------------------------------------------------------------------------|----------|
+| `"ragged"` | Awkward-backed `Ragged` / `RaggedVariants` / `RaggedAnnotatedHaps`         | Yes      |
+| `"flat"`   | Pure-numpy `FlatRagged` / `FlatVariants` / `FlatAnnotatedHaps`             | No       |
+
+In `"flat"` mode the hot path is zero-awkward; the returned containers carry `.data` (flat numpy array) and `.offsets` (int64). All flat types expose `.to_ragged()`, `.to_fixed(length)`, and `.to_padded(pad_value)` as escape hatches back to dense or awkward-backed forms.
+
+```python
+ds_flat = ds.with_output_format("flat")
+result = ds_flat[0:8, :]   # FlatRagged or FlatAnnotatedHaps or FlatVariants
+# direct tensorization — no awkward round-trip
+import torch
+t = torch.from_numpy(result.data)
+# or convert back
+ragged = result.to_ragged()
+```
+
+`with_output_format` is orthogonal to and composes with `with_len` and `subset_to`.
+
+**Scope note:** only seqs/haplotypes/annotated-haps/reference and variants outputs are flattened. Tracks and intervals are **not** yet flattened — they still return ragged containers in `"flat"` mode.
+
 ## Track insertion fill (only when haps + tracks together)
 
 Indels make track length differ from reference length. `Dataset.with_insertion_fill(fill)` controls what gets written into inserted positions. Only valid when the dataset returns **both** haplotypes and tracks — pure-ref and pure-hap datasets ignore it (raises if attempted).
@@ -238,6 +261,10 @@ Footprint is computed exactly via `Dataset._output_bytes_per_instance(...)` (use
 - `gvl.Reference.from_path(fasta, contigs=None)` — wrap a FASTA (path to a `.fa`/`.fa.bgz`, or a `.gvlfa` cache dir). Builds/reuses a sibling `.gvlfa` cache directory (self-describing, fingerprint-validated; legacy `.fa.gvl` caches auto-migrate). The cache is built atomically (temp + `os.replace`) under a best-effort lock, so concurrent builders sharing one reference are safe; the cache **auto-rebuilds** from its source when stale or missing.
 - `gvl.read_bedlike(path)` / `gvl.with_length(bed, L)` — BED helpers (re-exported from `seqpro`).
 - `gvl.Ragged`, `gvl.RaggedAnnotatedHaps`, `gvl.RaggedVariants`, `gvl.RaggedIntervals` — ragged return containers.
+- `gvl.FlatRagged` — flat analog of `Ragged`: `.data` (flat numpy array), `.offsets` (int64), `.shape`. Methods: `.to_ragged()`, `.to_fixed(length)`, `.to_padded(pad_value)`, `.reshape(shape)`, `.squeeze(axis)`. Source: `python/genvarloader/_flat.py`.
+- `gvl.FlatAnnotatedHaps` — flat analog of `RaggedAnnotatedHaps`: fields `.haps`, `.var_idxs`, `.ref_coords` (each a `FlatRagged`). Methods: `.to_ragged()`, `.to_fixed(length)`, `.to_padded()`, `.reshape(shape)`, `.squeeze(axis)`. Source: `python/genvarloader/_flat.py`.
+- `gvl.FlatVariants` — flat analog of `RaggedVariants`: `.fields` dict mapping field names to `FlatRagged` (scalar fields: `start`/`ilen`/`dosage`/info) or `FlatAlleles` (`alt`/`ref`). `.shape` delegates to `fields["start"].shape`. Methods: `.to_ragged()`, `.reshape(shape)`, `.squeeze(axis)`. Source: `python/genvarloader/_dataset/_flat_variants.py`.
+- `gvl.FlatAlleles` — two-level flat bytestring for allele fields: `.byte_data` (uint8), `.seq_offsets` (per-variant byte offsets, int64), `.var_offsets` (per-(batch×ploidy)-row variant offsets, int64), `.shape`. Methods: `.to_ragged()`, `.reshape(shape)`, `.squeeze(axis)`. Source: `python/genvarloader/_dataset/_flat_variants.py`.
 - `gvl.to_nested_tensor(ragged)` — convert to a PyTorch nested tensor (requires `torch`).
 - `gvl.get_dummy_dataset()` — small in-memory dataset for examples/tests.
 - `gvl.RefDataset` — reference-only dataset (no genotypes).
@@ -274,6 +301,8 @@ See `docs/source/format.md` for the full schema, versioning, and SVAR-link detai
 | Track re-alignment internals          | `python/genvarloader/_dataset/_tracks.py`, `_reconstruct.py` |
 | Insertion fill internals              | `python/genvarloader/_dataset/_insertion_fill.py`      |
 | SVAR back-reference / migration       | `python/genvarloader/_dataset/_svar_link.py`           |
+| Flat-buffer ragged containers         | `python/genvarloader/_flat.py`                         |
+| Flat variants + alleles types         | `python/genvarloader/_dataset/_flat_variants.py`       |
 
 ## Common gotchas
 
@@ -287,6 +316,8 @@ See `docs/source/format.md` for the full schema, versioning, and SVAR-link detai
 - Splicing is a read-time setting on a *flat* BED of exons — do not pre-concatenate exons before `gvl.write`.
 - `extend_to_length=False` at write time will produce haplotypes shorter than the BED region when deletions are present; downstream code must tolerate `<` region length.
 - Missing a `dosage` field on a `RaggedVariants` output you expected? Check `var_fields` — `dosage` must be requested explicitly even if `dosages.npy` exists on disk.
+- `FlatRagged` / `FlatVariants` offsets are **int64**. PyTorch nested tensors require int32 offsets — cast with `.astype(np.int32)` or `tensor.to(torch.int32)` before passing to `torch.nested.narrow`.
+- In `"flat"` mode, tracks and intervals are **not yet flattened** — they still return the same `Ragged`-backed containers as in `"ragged"` mode. Only seqs/haplotypes/annotated-haps/reference and variants outputs are affected.
 
 ## Maintaining this skill
 

--- a/skills/genvarloader/SKILL.md
+++ b/skills/genvarloader/SKILL.md
@@ -160,7 +160,7 @@ Returns either a `RaggedDataset` or `ArrayDataset` (frozen dataclass views) base
 | `"ragged"` | Awkward-backed `Ragged` / `RaggedVariants` / `RaggedAnnotatedHaps`         | Yes      |
 | `"flat"`   | Pure-numpy `FlatRagged` / `FlatVariants` / `FlatAnnotatedHaps`             | No       |
 
-In `"flat"` mode the hot path is zero-awkward; the returned containers carry `.data` (flat numpy array) and `.offsets` (int64). All flat types expose `.to_ragged()`, `.to_fixed(length)`, and `.to_padded(pad_value)` as escape hatches back to dense or awkward-backed forms.
+In `"flat"` mode the hot path is zero-awkward; the returned containers carry `.data` (flat numpy array) and `.offsets` (int64). Every flat type has `.to_ragged()` back to its awkward-backed form. Densification escape hatches vary by type: `FlatRagged` has `.to_fixed(length)` and `.to_padded(pad_value)`; `FlatAnnotatedHaps` has `.to_fixed(length)` and `.to_padded()` (no arg — uses per-field pad defaults); `FlatVariants`/`FlatAlleles` expose only `.to_ragged()` (plus `.reshape`/`.squeeze`).
 
 ```python
 ds_flat = ds.with_output_format("flat")

--- a/tests/dataset/conftest.py
+++ b/tests/dataset/conftest.py
@@ -1,0 +1,54 @@
+"""Shared fixtures for tests/dataset/."""
+
+from __future__ import annotations
+
+import pytest
+import pyBigWig
+
+import genvarloader as gvl
+
+SEQLEN = 20
+
+
+@pytest.fixture(scope="session")
+def snap_dataset(source_bed, vcf_dir, reference, tmp_path_factory):
+    """Phased VCF dataset with a "5ss" BigWig track, opened with a reference.
+
+    Mirrors the ``base_ds`` fixture in ``tests/dataset/test_with_methods.py``.
+    Opened with default settings (output_length="ragged", sequence_type="haplotypes",
+    jitter=0, max_jitter=2, deterministic=True, rc_neg=True).
+    """
+    from genoray import VCF
+
+    tmp_dir = tmp_path_factory.mktemp("snap_ds")
+    out = tmp_dir / "snap.gvl"
+
+    vcf_samples = ["s0", "s1", "s2"]
+    # Header lengths are generous upper bounds for the regions in source.bed.
+    contig_sizes = [("chr1", 2_000_000), ("chr2", 2_000_000)]
+    bw_paths: dict[str, str] = {}
+    for i, sample in enumerate(vcf_samples):
+        bw_path = tmp_dir / f"{sample}.bw"
+        with pyBigWig.open(str(bw_path), "w") as bw:
+            bw.addHeader(contig_sizes, maxZooms=0)
+            # One short interval per contig region in source.bed; values differ
+            # per sample. Mirrors base_ds in tests/dataset/test_with_methods.py.
+            value = float(i + 1)
+            bw.addEntries(
+                ["chr1", "chr1", "chr2", "chr2"],
+                [499_990, 1_010_686, 17_320, 1_234_560],
+                ends=[500_030, 1_010_706, 17_340, 1_234_580],
+                values=[value, value, value, value],
+            )
+        bw_paths[sample] = str(bw_path)
+
+    bigwigs = gvl.BigWigs("5ss", bw_paths)
+    vcf = VCF(vcf_dir / "filtered_source.vcf.gz")
+    gvl.write(
+        path=out,
+        bed=source_bed,
+        variants=vcf,
+        tracks=bigwigs,
+        max_jitter=2,
+    )
+    return gvl.Dataset.open(out, reference=reference)

--- a/tests/dataset/test_flat_getitem_snapshot.py
+++ b/tests/dataset/test_flat_getitem_snapshot.py
@@ -34,10 +34,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
-import pyBigWig
 import pytest
 
-import genvarloader as gvl
 from genvarloader import RaggedVariants
 from genvarloader._ragged import RaggedAnnotatedHaps
 from genvarloader._types import AnnotatedHaps
@@ -59,54 +57,7 @@ CASES = [
     ("variants_ragged", dict(seqs="variants"), "ragged"),
 ]
 
-# ---------------------------------------------------------------------------
-# Fixture
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="session")
-def snap_dataset(source_bed, vcf_dir, reference, tmp_path_factory):
-    """Phased VCF dataset with a "5ss" BigWig track, opened with a reference.
-
-    Mirrors the ``base_ds`` fixture in ``tests/dataset/test_with_methods.py``.
-    Opened with default settings (output_length="ragged", sequence_type="haplotypes",
-    jitter=0, max_jitter=2, deterministic=True, rc_neg=True).
-    """
-    from genoray import VCF
-
-    tmp_dir = tmp_path_factory.mktemp("snap_ds")
-    out = tmp_dir / "snap.gvl"
-
-    vcf_samples = ["s0", "s1", "s2"]
-    # Header lengths are generous upper bounds for the regions in source.bed.
-    contig_sizes = [("chr1", 2_000_000), ("chr2", 2_000_000)]
-    bw_paths: dict[str, str] = {}
-    for i, sample in enumerate(vcf_samples):
-        bw_path = tmp_dir / f"{sample}.bw"
-        with pyBigWig.open(str(bw_path), "w") as bw:
-            bw.addHeader(contig_sizes, maxZooms=0)
-            # One short interval per contig region in source.bed; values differ
-            # per sample. Mirrors base_ds in tests/dataset/test_with_methods.py.
-            value = float(i + 1)
-            bw.addEntries(
-                ["chr1", "chr1", "chr2", "chr2"],
-                [499_990, 1_010_686, 17_320, 1_234_560],
-                ends=[500_030, 1_010_706, 17_340, 1_234_580],
-                values=[value, value, value, value],
-            )
-        bw_paths[sample] = str(bw_path)
-
-    bigwigs = gvl.BigWigs("5ss", bw_paths)
-    vcf = VCF(vcf_dir / "filtered_source.vcf.gz")
-    gvl.write(
-        path=out,
-        bed=source_bed,
-        variants=vcf,
-        tracks=bigwigs,
-        max_jitter=2,
-    )
-    return gvl.Dataset.open(out, reference=reference)
-
+# snap_dataset fixture is defined in tests/dataset/conftest.py
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/dataset/test_flat_mode_equivalence.py
+++ b/tests/dataset/test_flat_mode_equivalence.py
@@ -54,6 +54,25 @@ def test_a_flat_variants_to_ragged_matches_ragged(snap_dataset, idx):
     assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
 
 
+def test_a_flat_variants_scalar_scalar_index_matches_ragged(snap_dataset):
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    # both region AND sample scalar -> triggers squeeze(0) on the variant output
+    ragged = ds[0, 0]
+    rewrapped = ds.with_output_format("flat")[0, 0].to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+
+
+def test_a_flat_variants_scalar_scalar_index_nonempty_matches_ragged(snap_dataset):
+    # Second scalar-scalar case with NON-EMPTY alleles, so actual allele bytes are
+    # exercised through the squeezed (b, p, None) -> (p, None) path, not just empty
+    # lists. (region=0, sample=2) is known to carry variants in snap_dataset.
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    ragged = ds[0, 2]
+    assert any(len(p) > 0 for p in ak.to_list(ragged["alt"])), "expected non-empty alt"
+    rewrapped = ds.with_output_format("flat")[0, 2].to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+
+
 def test_a_flat_variants_2d_index_matches_ragged(snap_dataset):
     # Exercise the MULTI-DIM path through _reshape_outer: a genuine 2-D fancy
     # index (region, sample) produces a multi-dim out_reshape, so _FlatAlleles

--- a/tests/dataset/test_flat_mode_equivalence.py
+++ b/tests/dataset/test_flat_mode_equivalence.py
@@ -1,10 +1,12 @@
 """flat-mode output, re-wrapped via .to_ragged(), must be byte-identical to ragged mode."""
 from __future__ import annotations
 
+import awkward as ak
 import numpy as np
 import pytest
 from seqpro.rag import Ragged
 
+from genvarloader import RaggedVariants
 from genvarloader._ragged import RaggedAnnotatedHaps
 
 IDX = [0, (np.array([0, 1, 2]),)]  # scalar-ish and a list index
@@ -33,3 +35,28 @@ def test_a0_flat_to_ragged_matches_ragged(snap_dataset, seqs, idx):
     assert r.keys() == f.keys()
     for k in r:
         np.testing.assert_array_equal(r[k], f[k], err_msg=f"field {k}")
+
+
+def _rv_to_lists(rv: RaggedVariants) -> dict:
+    out = {"alt": ak.to_list(rv["alt"]), "start": ak.to_list(rv["start"])}
+    for f in ("ref", "ilen", "dosage"):
+        if f in rv.fields:
+            out[f] = ak.to_list(rv[f])
+    return out
+
+
+@pytest.mark.parametrize("idx", IDX)
+def test_a_flat_variants_to_ragged_matches_ragged(snap_dataset, idx):
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    ragged = ds[idx]                                  # RaggedVariants (current path)
+    flat = ds.with_output_format("flat")[idx]         # _FlatVariants
+    rewrapped = flat.to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+
+
+def test_a_flat_variants_empty_region_and_ploidy(snap_dataset):
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    idx = (np.arange(min(6, snap_dataset.shape[0])),)
+    ragged = ds[idx]
+    rewrapped = ds.with_output_format("flat")[idx].to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)

--- a/tests/dataset/test_flat_mode_equivalence.py
+++ b/tests/dataset/test_flat_mode_equivalence.py
@@ -54,6 +54,27 @@ def test_a_flat_variants_to_ragged_matches_ragged(snap_dataset, idx):
     assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
 
 
+def test_a_flat_variants_2d_index_matches_ragged(snap_dataset):
+    # Exercise the MULTI-DIM path through _reshape_outer: a genuine 2-D fancy
+    # index (region, sample) produces a multi-dim out_reshape, so _FlatAlleles
+    # must re-append its ragged None just like its _Flat siblings.
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    n_r, n_s = snap_dataset.shape
+    r = np.arange(min(3, n_r))
+    s = np.arange(min(2, n_s))
+    idx = (r[:, None], s[None, :])  # 2-D (region, sample) fancy index
+    ragged = ds[idx]
+    flat = ds.with_output_format("flat")[idx]
+    # Structural invariant: every field (both _Flat and _FlatAlleles) must carry
+    # the ragged None as its trailing axis after the multi-dim out_reshape. A
+    # _FlatAlleles that stored out_reshape verbatim would be missing it.
+    for name, f in flat.fields.items():
+        assert f.shape[-1] is None, f"field {name} shape {f.shape} lost ragged axis"
+        assert f.shape.count(None) == 1, f"field {name} shape {f.shape} not single-ragged"
+    rewrapped = flat.to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+
+
 def test_a_flat_variants_empty_region_and_ploidy(snap_dataset):
     ds = snap_dataset.with_seqs("variants").with_tracks(False)
     idx = (np.arange(min(6, snap_dataset.shape[0])),)

--- a/tests/dataset/test_flat_mode_equivalence.py
+++ b/tests/dataset/test_flat_mode_equivalence.py
@@ -1,0 +1,35 @@
+"""flat-mode output, re-wrapped via .to_ragged(), must be byte-identical to ragged mode."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from seqpro.rag import Ragged
+
+from genvarloader._ragged import RaggedAnnotatedHaps
+
+IDX = [0, (np.array([0, 1, 2]),)]  # scalar-ish and a list index
+
+
+def _to_plain(obj):
+    """Normalize a ragged/annot/flat object into dict of ndarrays for comparison."""
+    if isinstance(obj, RaggedAnnotatedHaps):
+        return {
+            "haps": np.asarray(obj.haps.data), "haps_off": np.asarray(obj.haps.offsets),
+            "vidx": np.asarray(obj.var_idxs.data), "pos": np.asarray(obj.ref_coords.data),
+        }
+    if isinstance(obj, Ragged):
+        return {"data": np.asarray(obj.data), "off": np.asarray(obj.offsets)}
+    raise TypeError(type(obj))
+
+
+@pytest.mark.parametrize("seqs", ["haplotypes", "reference", "annotated"])
+@pytest.mark.parametrize("idx", IDX)
+def test_a0_flat_to_ragged_matches_ragged(snap_dataset, seqs, idx):
+    ds = snap_dataset.with_seqs(seqs).with_tracks(False)
+    ragged = ds[idx]
+    flat = ds.with_output_format("flat")[idx]
+    rewrapped = flat.to_ragged()
+    r, f = _to_plain(ragged), _to_plain(rewrapped)
+    assert r.keys() == f.keys()
+    for k in r:
+        np.testing.assert_array_equal(r[k], f[k], err_msg=f"field {k}")

--- a/tests/dataset/test_flat_mode_equivalence.py
+++ b/tests/dataset/test_flat_mode_equivalence.py
@@ -1,4 +1,5 @@
 """flat-mode output, re-wrapped via .to_ragged(), must be byte-identical to ragged mode."""
+
 from __future__ import annotations
 
 import awkward as ak
@@ -16,8 +17,10 @@ def _to_plain(obj):
     """Normalize a ragged/annot/flat object into dict of ndarrays for comparison."""
     if isinstance(obj, RaggedAnnotatedHaps):
         return {
-            "haps": np.asarray(obj.haps.data), "haps_off": np.asarray(obj.haps.offsets),
-            "vidx": np.asarray(obj.var_idxs.data), "pos": np.asarray(obj.ref_coords.data),
+            "haps": np.asarray(obj.haps.data),
+            "haps_off": np.asarray(obj.haps.offsets),
+            "vidx": np.asarray(obj.var_idxs.data),
+            "pos": np.asarray(obj.ref_coords.data),
         }
     if isinstance(obj, Ragged):
         return {"data": np.asarray(obj.data), "off": np.asarray(obj.offsets)}
@@ -48,8 +51,8 @@ def _rv_to_lists(rv: RaggedVariants) -> dict:
 @pytest.mark.parametrize("idx", IDX)
 def test_a_flat_variants_to_ragged_matches_ragged(snap_dataset, idx):
     ds = snap_dataset.with_seqs("variants").with_tracks(False)
-    ragged = ds[idx]                                  # RaggedVariants (current path)
-    flat = ds.with_output_format("flat")[idx]         # _FlatVariants
+    ragged = ds[idx]  # RaggedVariants (current path)
+    flat = ds.with_output_format("flat")[idx]  # _FlatVariants
     rewrapped = flat.to_ragged()
     assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
 
@@ -89,7 +92,9 @@ def test_a_flat_variants_2d_index_matches_ragged(snap_dataset):
     # _FlatAlleles that stored out_reshape verbatim would be missing it.
     for name, f in flat.fields.items():
         assert f.shape[-1] is None, f"field {name} shape {f.shape} lost ragged axis"
-        assert f.shape.count(None) == 1, f"field {name} shape {f.shape} not single-ragged"
+        assert f.shape.count(None) == 1, (
+            f"field {name} shape {f.shape} not single-ragged"
+        )
     rewrapped = flat.to_ragged()
     assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
 

--- a/tests/dataset/test_no_awkward_in_hotpath.py
+++ b/tests/dataset/test_no_awkward_in_hotpath.py
@@ -197,7 +197,11 @@ def test_flat_variants_decode_has_no_awkward(monkeypatch, guard_dataset):
     """
     calls = _install_ak_counters(monkeypatch)
 
-    ds = guard_dataset.with_seqs("variants").with_tracks(False).with_output_format("flat")
+    ds = (
+        guard_dataset.with_seqs("variants")
+        .with_tracks(False)
+        .with_output_format("flat")
+    )
     n_regions = min(4, ds.shape[0])
     regions = list(range(n_regions))
     samples = [i % ds.shape[1] for i in range(n_regions)]

--- a/tests/dataset/test_no_awkward_in_hotpath.py
+++ b/tests/dataset/test_no_awkward_in_hotpath.py
@@ -188,6 +188,29 @@ def test_haps_ragged_no_awkward(monkeypatch, guard_dataset):
     )
 
 
+def test_flat_variants_decode_has_no_awkward(monkeypatch, guard_dataset):
+    """Flat variant decode must dispatch zero awkward kernels.
+
+    ``with_output_format("flat")`` routes ``ds[...]`` through ``get_variants_flat``
+    which is pure-numpy/numba.  None of the patched awkward kernels
+    (to_numpy, to_packed, flatten, where) should be called.
+    """
+    calls = _install_ak_counters(monkeypatch)
+
+    ds = guard_dataset.with_seqs("variants").with_tracks(False).with_output_format("flat")
+    n_regions = min(4, ds.shape[0])
+    regions = list(range(n_regions))
+    samples = [i % ds.shape[1] for i in range(n_regions)]
+
+    _ = ds[regions, samples]
+
+    assert calls["n"] == 0, (
+        f"flat variant decode dispatched {calls['n']} awkward kernel(s) "
+        "(to_numpy/to_packed/flatten/where); get_variants_flat has a residual "
+        "awkward call that must be wrapped in np.asarray."
+    )
+
+
 def test_variants_ragged_minimal_awkward(monkeypatch, guard_dataset):
     """Variants gather + rc_ + to_packed must dispatch no awkward kernels.
 

--- a/tests/dataset/test_output_format.py
+++ b/tests/dataset/test_output_format.py
@@ -1,0 +1,17 @@
+"""Unit tests for Dataset.output_format field and with_output_format method."""
+
+import pytest
+
+
+def test_with_output_format_sets_field(snap_dataset):
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    assert ds.output_format == "ragged"
+    flat = ds.with_output_format("flat")
+    assert flat.output_format == "flat"
+    # original is unchanged (frozen dataclass / replace semantics)
+    assert ds.output_format == "ragged"
+
+
+def test_with_output_format_rejects_bad_value(snap_dataset):
+    with pytest.raises(ValueError):
+        snap_dataset.with_output_format("nope")

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import awkward as ak
 import numpy as np
-from seqpro.rag import Ragged
 
 from genvarloader import RaggedVariants
 from genvarloader._dataset._flat_variants import _FlatAlleles, _FlatVariants
@@ -40,6 +39,67 @@ def test_flat_variants_to_ragged_matches_handbuilt():
 
     assert isinstance(rv, RaggedVariants)
     # _build_allele_layout with ploidy=1 produces shape (b, p, ~v, ~l) = (2, 1, ~v, ~l)
+    assert ak.to_list(rv["alt"]) == [[[b"ACG", b"T"]], [[b"GG"]]]
+    assert ak.to_list(rv["ref"]) == [[[b"A", b"CC"]], [[b"T"]]]
+    assert ak.to_list(rv["start"]) == [[1, 5], [9]]
+
+
+def test_flat_variants_squeeze_leading_axis():
+    """_FlatVariants.squeeze(0) drops a leading size-1 fixed axis from all fields,
+    including _FlatAlleles fields, and to_ragged() still produces correct output."""
+    # b=2, p=1 but wrapped in a leading size-1 axis -> shape (1, 2, 1, None)
+    # group_off: 1*2*1=2 rows, row0 has 2 variants, row1 has 1 variant
+    group_off = [0, 2, 3]
+    ploidy = 1
+
+    # Build _FlatAlleles with shape (1, 2, 1, None) — leading size-1 axis
+    data_bytes = [b"ACG", b"T", b"GG"]
+    byte_data = np.frombuffer(b"".join(data_bytes), np.uint8).copy()
+    seq_off = np.concatenate([[0], np.cumsum([len(r) for r in data_bytes])]).astype(np.int64)
+    alt = _FlatAlleles(
+        byte_data=byte_data,
+        seq_offsets=seq_off,
+        var_offsets=np.asarray(group_off, np.int64),
+        shape=(1, 2, ploidy, None),
+    )
+
+    from genvarloader._flat import _Flat
+
+    # _Flat with shape (1, 2, None) — leading size-1 axis
+    start = _Flat.from_offsets(
+        np.array([1, 5, 9], np.int32), (1, 2, None), np.asarray(group_off, np.int64)
+    )
+
+    ref_bytes = [b"A", b"CC", b"T"]
+    ref_byte_data = np.frombuffer(b"".join(ref_bytes), np.uint8).copy()
+    ref_seq_off = np.concatenate([[0], np.cumsum([len(r) for r in ref_bytes])]).astype(np.int64)
+    ref = _FlatAlleles(
+        byte_data=ref_byte_data,
+        seq_offsets=ref_seq_off,
+        var_offsets=np.asarray(group_off, np.int64),
+        shape=(1, 2, ploidy, None),
+    )
+
+    fv = _FlatVariants(fields={"alt": alt, "start": start, "ref": ref})
+
+    # Before squeeze: shape has leading 1
+    assert fv.shape == (1, 2, None)
+    assert alt.shape == (1, 2, 1, None)
+
+    # squeeze(0) drops the leading size-1 axis
+    fv2 = fv.squeeze(0)
+    assert fv2.shape == (2, None), f"expected (2, None), got {fv2.shape}"
+    assert fv2.fields["alt"].shape == (2, 1, None), (
+        f"expected (2, 1, None), got {fv2.fields['alt'].shape}"
+    )
+
+    # Verify squeeze(0) on _FlatAlleles matches the house pattern from _Flat.squeeze(0)
+    flat_squeezed = start.squeeze(0)
+    assert flat_squeezed.shape == (2, None)
+
+    # to_ragged() still works correctly after squeeze
+    rv = fv2.to_ragged()
+    assert isinstance(rv, RaggedVariants)
     assert ak.to_list(rv["alt"]) == [[[b"ACG", b"T"]], [[b"GG"]]]
     assert ak.to_list(rv["ref"]) == [[[b"A", b"CC"]], [[b"T"]]]
     assert ak.to_list(rv["start"]) == [[1, 5], [9]]

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import awkward as ak
+import numpy as np
+from seqpro.rag import Ragged
+
+from genvarloader import RaggedVariants
+from genvarloader._dataset._flat_variants import _FlatAlleles, _FlatVariants
+
+
+def _alleles(rows, group_off, ploidy):
+    """rows: list[bytes] per variant; group_off: per-(b*p)-row variant boundaries.
+    shape is (b, p, None) where b = (len(group_off)-1) // ploidy.
+    """
+    data = np.frombuffer(b"".join(rows), np.uint8).copy()
+    seq_off = np.concatenate([[0], np.cumsum([len(r) for r in rows])]).astype(np.int64)
+    b = (len(group_off) - 1) // ploidy
+    return _FlatAlleles(
+        byte_data=data,
+        seq_offsets=seq_off,
+        var_offsets=np.asarray(group_off, np.int64),
+        shape=(b, ploidy, None),
+    )
+
+
+def test_flat_variants_to_ragged_matches_handbuilt():
+    # b=2, p=1: group_off has 3 entries (2*1+1)
+    # row0 has 2 variants, row1 has 1 variant
+    group_off = [0, 2, 3]
+    ploidy = 1
+    alt = _alleles([b"ACG", b"T", b"GG"], group_off, ploidy)
+    ref = _alleles([b"A", b"CC", b"T"], group_off, ploidy)
+    from genvarloader._flat import _Flat
+
+    start = _Flat.from_offsets(
+        np.array([1, 5, 9], np.int32), (2, None), np.asarray(group_off, np.int64)
+    )
+    fv = _FlatVariants(fields={"alt": alt, "start": start, "ref": ref})
+    rv = fv.to_ragged()
+
+    assert isinstance(rv, RaggedVariants)
+    # _build_allele_layout with ploidy=1 produces shape (b, p, ~v, ~l) = (2, 1, ~v, ~l)
+    assert ak.to_list(rv["alt"]) == [[[b"ACG", b"T"]], [[b"GG"]]]
+    assert ak.to_list(rv["ref"]) == [[[b"A", b"CC"]], [[b"T"]]]
+    assert ak.to_list(rv["start"]) == [[1, 5], [9]]

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -55,7 +55,9 @@ def test_flat_variants_squeeze_leading_axis():
     # Build _FlatAlleles with shape (1, 2, 1, None) — leading size-1 axis
     data_bytes = [b"ACG", b"T", b"GG"]
     byte_data = np.frombuffer(b"".join(data_bytes), np.uint8).copy()
-    seq_off = np.concatenate([[0], np.cumsum([len(r) for r in data_bytes])]).astype(np.int64)
+    seq_off = np.concatenate([[0], np.cumsum([len(r) for r in data_bytes])]).astype(
+        np.int64
+    )
     alt = _FlatAlleles(
         byte_data=byte_data,
         seq_offsets=seq_off,
@@ -72,7 +74,9 @@ def test_flat_variants_squeeze_leading_axis():
 
     ref_bytes = [b"A", b"CC", b"T"]
     ref_byte_data = np.frombuffer(b"".join(ref_bytes), np.uint8).copy()
-    ref_seq_off = np.concatenate([[0], np.cumsum([len(r) for r in ref_bytes])]).astype(np.int64)
+    ref_seq_off = np.concatenate([[0], np.cumsum([len(r) for r in ref_bytes])]).astype(
+        np.int64
+    )
     ref = _FlatAlleles(
         byte_data=ref_byte_data,
         seq_offsets=ref_seq_off,

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -103,3 +103,20 @@ def test_flat_variants_squeeze_leading_axis():
     assert ak.to_list(rv["alt"]) == [[[b"ACG", b"T"]], [[b"GG"]]]
     assert ak.to_list(rv["ref"]) == [[[b"A", b"CC"]], [[b"T"]]]
     assert ak.to_list(rv["start"]) == [[1, 5], [9]]
+
+
+def test_public_flat_exports():
+    import genvarloader as gvl
+
+    assert gvl.FlatRagged is not None
+    assert gvl.FlatAnnotatedHaps is not None
+    assert gvl.FlatVariants is not None
+    assert gvl.FlatAlleles is not None
+    # aliases point at the existing internals
+    from genvarloader._flat import _Flat, _FlatAnnotatedHaps
+    from genvarloader._dataset._flat_variants import _FlatVariants, _FlatAlleles
+
+    assert gvl.FlatRagged is _Flat
+    assert gvl.FlatAnnotatedHaps is _FlatAnnotatedHaps
+    assert gvl.FlatVariants is _FlatVariants
+    assert gvl.FlatAlleles is _FlatAlleles

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -105,6 +105,49 @@ def test_flat_variants_squeeze_leading_axis():
     assert ak.to_list(rv["start"]) == [[1, 5], [9]]
 
 
+def test_compact_keep_compacts_v_idxs_and_offsets():
+    """_compact_keep drops masked-out variants per row and rebuilds offsets.
+    This is the AF-filter compaction kernel; exercised here in isolation since
+    snap_dataset (a phased VCF) cannot carry an AF cache for integration."""
+    from genvarloader._dataset._flat_variants import _compact_keep
+
+    # 2 rows: row0 has variants [10,11,12], row1 has [20,21]
+    v_idxs = np.array([10, 11, 12, 20, 21], np.int32)
+    row_offsets = np.array([0, 3, 5], np.int64)
+    # keep middle of row0 dropped, all of row1
+    keep = np.array([True, False, True, True, True], np.bool_)
+
+    new_v, new_off = _compact_keep(v_idxs, row_offsets, keep)
+    np.testing.assert_array_equal(new_v, [10, 12, 20, 21])
+    np.testing.assert_array_equal(new_off, [0, 2, 4])
+
+
+def test_compact_keep_used_for_dosage_values():
+    """When compacting dosage, _compact_keep is called with the dosage VALUES in
+    place of v_idxs and the UNFILTERED row offsets — verify it gathers correctly."""
+    from genvarloader._dataset._flat_variants import _compact_keep
+
+    dos = np.array([0.5, 0.1, 0.9, 0.2, 0.8], np.float32)
+    row_offsets = np.array([0, 3, 5], np.int64)
+    keep = np.array([True, False, True, True, True], np.bool_)
+
+    new_dos, new_off = _compact_keep(dos, row_offsets, keep)
+    np.testing.assert_array_equal(new_dos, np.array([0.5, 0.9, 0.2, 0.8], np.float32))
+    np.testing.assert_array_equal(new_off, [0, 2, 4])
+    assert new_dos.dtype == np.float32
+
+
+def test_flat_alleles_to_ragged_multidim_outer():
+    """_FlatAlleles.to_ragged() rebuilds the full regular-axis stack for shapes
+    with more than one leading fixed dim (b, s, p, ~v, ~l)."""
+    # shape (2, 1, 2, None): b=2, s=1, p=2 -> 4 b*p rows.
+    group_off = [0, 1, 1, 2, 2]  # rows: [v], [], [v], []
+    alt = _alleles([b"AC", b"GGG"], group_off, ploidy=2)
+    alt = _FlatAlleles(alt.byte_data, alt.seq_offsets, alt.var_offsets, (2, 1, 2, None))
+    rv = alt.to_ragged()
+    assert ak.to_list(rv) == [[[[b"AC"], []]], [[[b"GGG"], []]]]
+
+
 def test_public_flat_exports():
     import genvarloader as gvl
 


### PR DESCRIPTION
## Summary

Adds a **flat output mode** to gvl: `dataset.with_output_format("flat")[idx]` returns pure-numpy `(data, offsets, shape)` containers with **zero awkward on the hot path**, **byte-identical when re-wrapped** (`.to_ragged()`) to today's awkward-backed output. Implements **A0 + A** of the issue #214 super-batch / flat-buffer decomposition.

- **A0** — flat passthrough for non-variant outputs (seqs / haplotypes / annotated-haps / reference). The reconstructors already produced `_Flat`/`_FlatAnnotatedHaps`; in flat mode the `_query.py` boundary skips the `output_length` massaging and the `to_ragged()` conversion and returns the flat wrappers raw. Tracks/intervals remain ragged (deferred to B/E).
- **A** — flat **variant** decode (`get_variants_flat`): a numba reimplementation of `_get_variants` over the sparse genotype + variant store (`_gather_v_idxs` / `_gather_alleles` / `_compact_keep`), producing a new `FlatVariants`/`FlatAlleles` with no awkward. Removes gvl's internal awkward indexing from the variants path.

### Public API
- `Dataset.with_output_format("ragged" | "flat") -> Dataset` (default `"ragged"`), orthogonal to and composing with `output_length` / `subset_to`.
- New public types: `FlatRagged` (= `_Flat`), `FlatAnnotatedHaps`, `FlatVariants`, `FlatAlleles` — each with `.to_ragged()` (and `.to_fixed`/`.to_padded` where applicable). Underscored internals kept as aliases.
- `skills/genvarloader/SKILL.md` updated to document the new method, types, and the int64-offset / tracks-not-flattened gotchas (per CLAUDE.md).

The branch also carries the design spec and implementation plan docs (`docs/superpowers/{specs,plans}/2026-06-13-flat-output-mode-*`).

## Test Plan
- [x] **Byte-identity gate** (`tests/dataset/test_flat_mode_equivalence.py`): `flat.to_ragged()` element-identical to ragged-mode `dataset[idx]` across seqs/haps/annotated/reference + variants, over scalar, scalar-scalar (squeeze), 1-D, and 2-D `(region, sample)` indices, plus empty regions and multi-ploidy (phased, ploidy=2, rc_neg).
- [x] **No-awkward guard** (`tests/dataset/test_no_awkward_in_hotpath.py`): flat variant decode dispatches zero awkward densification kernels.
- [x] **Unit tests** (`tests/unit/dataset/test_flat_variants_type.py`): `_FlatVariants.to_ragged()` round-trip, squeeze, multi-dim reshape, `_compact_keep` (incl. AF-filter compaction + dosage parallel-gather, which the integration fixture can't exercise without an AF cache).
- [x] **No ragged-path regression**: `test_flat_getitem_snapshot.py` byte-identical snapshots unchanged.
- [x] Full suite: **659 passed, 39 skipped, 4 xfailed**.

Refs #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)