### PR TITLE
feat(flat): always-flat variant decode + optional empty-group dummy fill (Variant Assembly B)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-variant-assembly-B.md
+++ b/docs/superpowers/plans/2026-06-13-variant-assembly-B.md
@@ -1,0 +1,700 @@
+# Variant assembly (B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `get_variants_flat` the single variant decode (retiring the awkward `_get_variants`) and add an optional empty-group dummy-variant fill to gvl's variant-record output, working identically in flat and ragged modes.
+
+**Architecture:** B1 routes both `Haps.__call__` and the `get_haps_and_shifts` variants branch through `get_variants_flat`; ragged mode converts at the `_query.py` boundary via `_FlatVariants.to_ragged()` (already wired for `_Flat`/`_FlatAnnotatedHaps` in A). B2 adds two numba kernels (`_fill_empty_scalar`, `_fill_empty_seq`) and `_FlatVariants.fill_empty_groups(dummy)`, applied as the final step inside `get_variants_flat` when a `DummyVariant` is configured via `with_settings`. The dummy spec lives on the `Haps` reconstructor (like `min_af`/`max_af`/`var_fields`), not on `QueryView`.
+
+**Tech Stack:** Python, numba (`@nb.njit`), numpy, awkward (only for `to_ragged()` + the snapshot reference), seqpro `Ragged`, pytest, pixi.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-variant-assembly-B-design.md`
+
+**Run tests with:** `pixi run -e dev pytest <path> -v` (test data already generated; if not, `pixi run -e dev gen` once).
+
+---
+
+## File Structure
+
+- **Modify** `python/genvarloader/_dataset/_haps.py` — `Haps.__call__` + `get_haps_and_shifts` variants branch route to `get_variants_flat`; **delete** `_get_variants`, `_get_alleles`, `_get_info`; add a `dummy_variant: "DummyVariant | None" = None` field to the `Haps` dataclass (TYPE_CHECKING import).
+- **Modify** `python/genvarloader/_dataset/_query.py` — add `_FlatVariants` to the boundary `to_ragged()` conversion in `getitem`.
+- **Modify** `python/genvarloader/_dataset/_flat_variants.py` — add `DummyVariant` dataclass, the `_fill_empty_scalar`/`_fill_empty_seq` numba kernels, `_FlatVariants.fill_empty_groups(dummy)`, and apply the fill at the end of `get_variants_flat`.
+- **Modify** `python/genvarloader/_dataset/_impl.py` — add `dummy_variant` parameter to `with_settings`; add a guard in `__getitem__` (raise if `dummy_variant` set and output kind ≠ variants).
+- **Modify** `python/genvarloader/__init__.py` — export `DummyVariant`.
+- **Modify** `tests/dataset/test_flat_mode_equivalence.py` — flat↔ragged parity with dummy fill.
+- **Modify** `tests/unit/dataset/test_flat_variants_type.py` — kernel + `fill_empty_groups` + `DummyVariant` unit tests.
+- **Modify** `tests/dataset/test_no_awkward_in_hotpath.py` — assert the dummy-fill path stays awkward-free.
+- **Modify** `tests/dataset/test_output_format.py` (or `test_with_methods.py`) — `with_settings(dummy_variant=...)` + validation tests.
+- **Modify** `skills/genvarloader/SKILL.md` — document `with_settings(dummy_variant=...)` + `DummyVariant`.
+
+---
+
+## Task 1: B1 — always-flat variant decode (retire the awkward path)
+
+This is a behavior-preserving refactor. The regression oracle is the committed snapshot `tests/dataset/_snapshots/variants_ragged.npz` (generated from the old awkward path); it must stay green and **must not be regenerated**.
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_haps.py` (`__call__` ~514-525; `get_haps_and_shifts` variants branch ~569-580; delete `_get_variants`/`_get_alleles`/`_get_info`)
+- Modify: `python/genvarloader/_dataset/_query.py` (`getitem` ~110-113)
+
+- [ ] **Step 1: Confirm the baseline is green**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_getitem_snapshot.py tests/dataset/test_flat_mode_equivalence.py tests/dataset/test_flat_variants.py -q`
+Expected: PASS. This is the pre-refactor reference (esp. `test_flat_getitem_snapshot.py::test_getitem_snapshot[variants_ragged-*]`, which pins the awkward output via `_snapshots/variants_ragged.npz`).
+
+- [ ] **Step 2: Route `Haps.__call__` variants branch to the flat decode**
+
+In `python/genvarloader/_dataset/_haps.py`, replace the variants branch of `__call__` (currently the `if flat: ... else: ragv = self._get_variants(...)` block) with an unconditional flat decode:
+
+```python
+        if issubclass(self.kind, RaggedVariants):
+            if splice_plan is not None:
+                raise NotImplementedError(
+                    "Spliced output is not supported for RaggedVariants."
+                )
+            from ._flat_variants import get_variants_flat
+
+            return cast(_H, get_variants_flat(self, idx))
+```
+
+(The `flat` parameter on `__call__` is retained for signature stability across reconstructors but is no longer read for variants — the `_query.py` boundary decides ragged-vs-flat via `view.flat_output`.)
+
+- [ ] **Step 3: Route the `get_haps_and_shifts` variants branch to the flat decode**
+
+In `get_haps_and_shifts`, replace the `elif issubclass(self.kind, RaggedVariants):` branch (which calls `self._get_variants(... keep=..., keep_offsets=...)`) with:
+
+```python
+        elif issubclass(self.kind, RaggedVariants):
+            if splice_plan is not None:
+                raise NotImplementedError(
+                    "Spliced output is not supported for RaggedVariants."
+                )
+            from ._flat_variants import get_variants_flat
+
+            out = get_variants_flat(self, idx)
+```
+
+- [ ] **Step 4: Delete the awkward decode helpers**
+
+Delete the methods `_get_variants`, `_get_alleles`, and `_get_info` from `_haps.py` (they are now unused — verify with `rtk grep "_get_variants\|_get_alleles\|_get_info" python/genvarloader/` returning only references inside docstrings/comments of `_flat_variants.py`). Do NOT delete `_allele_bytes_sum` or `_build_allele_layout` (still used by `_FlatAlleles.to_ragged` / elsewhere — verify before removing anything else).
+
+- [ ] **Step 5: Add `_FlatVariants` to the boundary `to_ragged()` conversion**
+
+In `python/genvarloader/_dataset/_query.py`, in `getitem`, extend the conversion tuple (currently converts `_Flat`/`_FlatAnnotatedHaps`):
+
+```python
+        recon = tuple(
+            o.to_ragged() if isinstance(o, (_Flat, _FlatAnnotatedHaps, _FlatVariants)) else o
+            for o in recon
+        )
+```
+
+`_FlatVariants` is already imported at module top (from A). In flat mode this block is skipped (the `if not view.flat_output:` guard), so `_FlatVariants` passes through; in ragged mode it now converts.
+
+- [ ] **Step 6: Run the regression gate**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_getitem_snapshot.py tests/dataset/test_flat_mode_equivalence.py tests/dataset/test_flat_variants.py tests/dataset/test_no_awkward_in_hotpath.py -q`
+Expected: PASS, with `_snapshots/variants_ragged.npz` unchanged (do NOT pass `--snapshot-update` or regenerate). Then run the broader suite:
+Run: `pixi run -e dev pytest tests/ -q`
+Expected: PASS (same skip/xfail counts as before).
+
+- [ ] **Step 7: Confirm the awkward helpers are gone**
+
+Run: `rtk grep "def _get_variants\|def _get_alleles\|def _get_info" python/genvarloader/`
+Expected: no matches.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /root/GenVarLoader/.claude/worktrees/flat-output-impl
+rtk git add python/genvarloader/_dataset/_haps.py python/genvarloader/_dataset/_query.py
+rtk git commit -m "refactor(flat): retire awkward _get_variants; ragged variants decode via flat path"
+```
+
+---
+
+## Task 2: `DummyVariant` type + empty-group fill kernels + `fill_empty_groups`
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_flat_variants.py`
+- Test: `tests/unit/dataset/test_flat_variants_type.py` (append)
+
+- [ ] **Step 1: Write the failing tests (append)**
+
+```python
+# append to tests/unit/dataset/test_flat_variants_type.py
+def test_fill_empty_scalar_kernel():
+    from genvarloader._dataset._flat_variants import _fill_empty_scalar
+
+    data = np.array([10, 11, 20], np.int32)
+    offsets = np.array([0, 0, 2, 2, 3], np.int64)  # rows: empty, [10,11], empty, [20]
+    new_data, new_off = _fill_empty_scalar(data, offsets, np.int32(-1))
+    assert new_off.tolist() == [0, 1, 3, 4, 5]
+    assert new_data.tolist() == [-1, 10, 11, -1, 20]
+
+
+def test_fill_empty_seq_kernel():
+    from genvarloader._dataset._flat_variants import _fill_empty_seq
+
+    # 3 rows: empty, ["AC","G"], empty
+    data = np.frombuffer(b"ACG", np.uint8).copy()
+    var_off = np.array([0, 0, 2, 2], np.int64)      # per-row variant boundaries
+    seq_off = np.array([0, 2, 3], np.int64)         # per-variant byte boundaries
+    dummy = np.frombuffer(b"N", np.uint8).copy()
+    nd, nvar, nseq = _fill_empty_seq(data, var_off, seq_off, dummy)
+    assert nvar.tolist() == [0, 1, 3, 4]            # each empty row gains 1 variant
+    assert nseq.tolist() == [0, 1, 3, 4, 5]         # dummy(1) AC(2) G(1) dummy(1)
+    assert bytes(nd) == b"NACGN"
+
+
+def test_fill_empty_groups_roundtrip():
+    import awkward as ak
+
+    from genvarloader._dataset._flat_variants import DummyVariant, _FlatAlleles, _FlatVariants
+    from genvarloader._flat import _Flat
+
+    # b*p = 3 rows: row0 empty, row1 has [b"AC", b"G"], row2 empty
+    group_off = np.array([0, 0, 2, 2], np.int64)
+    alt = _FlatAlleles(
+        byte_data=np.frombuffer(b"ACG", np.uint8).copy(),
+        seq_offsets=np.array([0, 2, 3], np.int64),
+        var_offsets=group_off.copy(),
+        shape=(3, None),
+    )
+    start = _Flat.from_offsets(np.array([5, 9], np.int32), (3, None), group_off.copy())
+    fv = _FlatVariants(fields={"alt": alt, "start": start})
+    filled = fv.fill_empty_groups(DummyVariant(start=-1, alt=b"N"))
+    rv = filled.to_ragged()
+    # empty rows now hold exactly the dummy; non-empty row unchanged
+    assert ak.to_list(rv["alt"]) == [[b"N"], [b"AC", b"G"], [b"N"]]
+    assert ak.to_list(rv["start"]) == [[-1], [5, 9], [-1]]
+
+
+def test_fill_empty_groups_noop_when_no_empties():
+    from genvarloader._dataset._flat_variants import DummyVariant, _FlatAlleles, _FlatVariants
+    from genvarloader._flat import _Flat
+    import awkward as ak
+
+    group_off = np.array([0, 1, 2], np.int64)  # every row has 1 variant
+    alt = _FlatAlleles(np.frombuffer(b"AG", np.uint8).copy(),
+                       np.array([0, 1, 2], np.int64), group_off.copy(), (2, None))
+    start = _Flat.from_offsets(np.array([3, 7], np.int32), (2, None), group_off.copy())
+    fv = _FlatVariants(fields={"alt": alt, "start": start})
+    filled = fv.fill_empty_groups(DummyVariant())
+    assert ak.to_list(filled.to_ragged()["alt"]) == [[b"A"], [b"G"]]
+    assert ak.to_list(filled.to_ragged()["start"]) == [[3], [7]]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_flat_variants_type.py -k "fill or dummy" -v`
+Expected: FAIL with `ImportError`/`AttributeError` (`DummyVariant`, `_fill_empty_scalar`, `_fill_empty_seq`, `fill_empty_groups` not defined).
+
+- [ ] **Step 3: Implement `DummyVariant`, kernels, and `fill_empty_groups`**
+
+Add to `python/genvarloader/_dataset/_flat_variants.py`. First the dataclass (place near the top, after the imports):
+
+```python
+@dataclass(frozen=True)
+class DummyVariant:
+    """Per-field values for the dummy variant inserted into empty
+    (region, sample, ploid) groups. Unspecified info fields default to ``0``
+    for integer columns and ``NaN`` for float columns."""
+
+    start: int = -1
+    ilen: int = 0
+    dosage: float = 0.0
+    ref: bytes = b"N"
+    alt: bytes = b"N"
+    info: dict[str, Any] = field(default_factory=dict)
+
+    def scalar_for(self, name: str, dtype: np.dtype):
+        """Return the dummy fill value for a scalar field, as a numpy scalar of ``dtype``."""
+        dt = np.dtype(dtype)
+        if name == "start":
+            return dt.type(self.start)
+        if name == "ilen":
+            return dt.type(self.ilen)
+        if name == "dosage":
+            return dt.type(self.dosage)
+        if name in self.info:
+            return dt.type(self.info[name])
+        if np.issubdtype(dt, np.floating):
+            return dt.type(np.nan)
+        return dt.type(0)
+```
+
+Then the kernels (place near the other `@nb.njit` kernels):
+
+```python
+@nb.njit(nogil=True, cache=True)
+def _fill_empty_scalar(data, offsets, fill):  # pragma: no cover - njit
+    """Insert one ``fill`` element into each empty row; copy non-empty rows
+    through. Returns ``(new_data, new_offsets)``."""
+    n_rows = offsets.shape[0] - 1
+    new_offsets = np.empty(n_rows + 1, np.int64)
+    new_offsets[0] = 0
+    for i in range(n_rows):
+        ln = offsets[i + 1] - offsets[i]
+        new_offsets[i + 1] = new_offsets[i] + (ln if ln > 0 else 1)
+    new_data = np.empty(new_offsets[n_rows], data.dtype)
+    for i in range(n_rows):
+        s = offsets[i]
+        e = offsets[i + 1]
+        d = new_offsets[i]
+        if e == s:
+            new_data[d] = fill
+        else:
+            for k in range(s, e):
+                new_data[d] = data[k]
+                d += 1
+    return new_data, new_offsets
+
+
+@nb.njit(nogil=True, cache=True)
+def _fill_empty_seq(data, var_offsets, seq_offsets, dummy):  # pragma: no cover - njit
+    """Two-level analogue of ``_fill_empty_scalar`` for allele bytestrings.
+    Empty variant-rows receive one dummy allele of ``dummy`` bytes. Returns
+    ``(new_data, new_var_offsets, new_seq_offsets)``."""
+    n_rows = var_offsets.shape[0] - 1
+    L = dummy.shape[0]
+    new_var = np.empty(n_rows + 1, np.int64)
+    new_var[0] = 0
+    for i in range(n_rows):
+        nv = var_offsets[i + 1] - var_offsets[i]
+        new_var[i + 1] = new_var[i] + (nv if nv > 0 else 1)
+    total_vars = new_var[n_rows]
+    new_seq = np.empty(total_vars + 1, np.int64)
+    new_seq[0] = 0
+    vptr = 0
+    for i in range(n_rows):
+        vs = var_offsets[i]
+        ve = var_offsets[i + 1]
+        if ve == vs:
+            new_seq[vptr + 1] = new_seq[vptr] + L
+            vptr += 1
+        else:
+            for v in range(vs, ve):
+                vlen = seq_offsets[v + 1] - seq_offsets[v]
+                new_seq[vptr + 1] = new_seq[vptr] + vlen
+                vptr += 1
+    new_data = np.empty(new_seq[total_vars], np.uint8)
+    vptr = 0
+    dptr = 0
+    for i in range(n_rows):
+        vs = var_offsets[i]
+        ve = var_offsets[i + 1]
+        if ve == vs:
+            for k in range(L):
+                new_data[dptr] = dummy[k]
+                dptr += 1
+            vptr += 1
+        else:
+            for v in range(vs, ve):
+                bs = seq_offsets[v]
+                be = seq_offsets[v + 1]
+                for k in range(bs, be):
+                    new_data[dptr] = data[k]
+                    dptr += 1
+                vptr += 1
+    return new_data, new_var, new_seq
+```
+
+Then `fill_empty_groups` on `_FlatVariants` (add as a method):
+
+```python
+    def fill_empty_groups(self, dummy: "DummyVariant") -> "_FlatVariants":
+        """Insert one dummy variant into each empty (b*p) group; non-empty
+        groups are unchanged. Every field shares the same empty-row pattern, so
+        the rebuilt offsets stay consistent across fields."""
+        from .._flat import _Flat
+
+        new_fields: dict[str, Any] = {}
+        for name, f in self.fields.items():
+            if isinstance(f, _FlatAlleles):
+                db = np.frombuffer(dummy.alt if name == "alt" else dummy.ref, np.uint8).copy()
+                nd, nvar, nseq = _fill_empty_seq(f.byte_data, f.var_offsets, f.seq_offsets, db)
+                new_fields[name] = _FlatAlleles(nd, nseq, nvar, f.shape)
+            else:
+                fill = dummy.scalar_for(name, f.data.dtype)
+                nd, noff = _fill_empty_scalar(f.data, f.offsets, fill)
+                new_fields[name] = _Flat.from_offsets(nd, f.shape, noff)
+        return _FlatVariants(new_fields)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_flat_variants_type.py -k "fill or dummy" -v`
+Expected: PASS. Then ruff: `pixi run -e dev ruff check python/genvarloader/_dataset/_flat_variants.py tests/unit/dataset/test_flat_variants_type.py`
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_flat_variants.py tests/unit/dataset/test_flat_variants_type.py
+rtk git commit -m "feat(flat): DummyVariant + empty-group fill kernels + fill_empty_groups"
+```
+
+---
+
+## Task 3: Apply the fill in `get_variants_flat` (Haps.dummy_variant field)
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_haps.py` (Haps dataclass field)
+- Modify: `python/genvarloader/_dataset/_flat_variants.py` (`get_variants_flat`)
+- Test: `tests/unit/dataset/test_flat_variants_type.py` (append)
+
+- [ ] **Step 1: Write the failing test (append)**
+
+This test constructs a `Haps` via the public dataset and sets `dummy_variant` directly on the reconstructor (the user-facing `with_settings` path is Task 4):
+
+```python
+# append to tests/unit/dataset/test_flat_variants_type.py
+def test_get_variants_flat_fills_empty_groups(snap_dataset):
+    import awkward as ak
+    from dataclasses import replace
+
+    from genvarloader._dataset._flat_variants import DummyVariant, get_variants_flat
+
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    haps = ds._seqs  # the Haps reconstructor
+    idx = np.arange(min(6, snap_dataset.shape[0]) * snap_dataset.shape[1])
+
+    plain = get_variants_flat(haps, idx).to_ragged()
+    has_empty = any(len(g) == 0 for row in ak.to_list(plain["start"]) for g in [row])
+    # (snap_dataset has regions with no variants for some samples)
+
+    haps_d = replace(haps, dummy_variant=DummyVariant(start=-1, alt=b"N", ref=b"N"))
+    filled = get_variants_flat(haps_d, idx).to_ragged()
+
+    # no group is empty after filling
+    for ploid_groups in ak.to_list(filled["start"]):
+        for g in ploid_groups:
+            assert len(g) >= 1
+    # non-empty groups are unchanged vs plain (dummy only added to empties)
+    plain_starts = ak.to_list(plain["start"])
+    filled_starts = ak.to_list(filled["start"])
+    for pr, fr in zip(plain_starts, filled_starts):
+        for pg, fg in zip(pr, fr):
+            if len(pg) > 0:
+                assert fg == pg
+            else:
+                assert fg == [-1]
+```
+
+`snap_dataset` is in `tests/dataset/conftest.py`; if this unit test can't see it (different tree), reference it via the integration test in Task 5 instead and keep this as a fixture-built `Haps`. If `ds._seqs` is not the right attribute, inspect `Dataset` for the reconstructor handle (it is `_seqs`, a `Haps`, per `_impl.py`).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_flat_variants_type.py::test_get_variants_flat_fills_empty_groups -v`
+Expected: FAIL with `TypeError` (`replace` rejects unknown field `dummy_variant`) — the Haps field doesn't exist yet.
+
+- [ ] **Step 3: Add the `dummy_variant` field to `Haps`**
+
+In `python/genvarloader/_dataset/_haps.py`, add a TYPE_CHECKING import and the field. In the existing `if TYPE_CHECKING:` block (add one if absent) include:
+
+```python
+if TYPE_CHECKING:
+    from ._flat_variants import DummyVariant
+```
+
+In the `Haps` dataclass, add the field immediately after `var_fields` (which has a default) and before the `available_var_fields: ... = field(init=False)` line:
+
+```python
+    var_fields: list[str] = field(default_factory=lambda: ["alt", "ilen", "start"])
+    dummy_variant: "DummyVariant | None" = None
+    available_var_fields: list[str] = field(init=False)
+```
+
+(The string annotation avoids a runtime import cycle; the default `None` keeps it optional so existing `Haps(...)` construction is unaffected. Verify `Haps.to_kind` / `_build_reconstructor` preserve it — they use `replace`, so it carries through.)
+
+- [ ] **Step 4: Apply the fill at the end of `get_variants_flat`**
+
+In `python/genvarloader/_dataset/_flat_variants.py`, change the final `return _FlatVariants(fields)` to:
+
+```python
+    result = _FlatVariants(fields)
+    if haps.dummy_variant is not None:
+        result = result.fill_empty_groups(haps.dummy_variant)
+    return result
+```
+
+(The fill runs AFTER AF/exonic compaction — i.e. a group emptied by filtering is also padded — because it is the last step.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_flat_variants_type.py::test_get_variants_flat_fills_empty_groups -v`
+Expected: PASS. Then ruff on the two modified files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_haps.py python/genvarloader/_dataset/_flat_variants.py tests/unit/dataset/test_flat_variants_type.py
+rtk git commit -m "feat(flat): Haps.dummy_variant + apply empty-group fill in get_variants_flat"
+```
+
+---
+
+## Task 4: Public API — `with_settings(dummy_variant=...)` + export + guard
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_impl.py` (`with_settings`; `__getitem__` guard)
+- Modify: `python/genvarloader/__init__.py` (export `DummyVariant`)
+- Test: `tests/dataset/test_output_format.py` (append)
+
+- [ ] **Step 1: Write the failing tests (append)**
+
+```python
+# append to tests/dataset/test_output_format.py
+import pytest
+
+
+def test_with_settings_dummy_variant_sets_field(snap_dataset):
+    import genvarloader as gvl
+
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N")
+    ds2 = ds.with_settings(dummy_variant=dv)
+    assert ds2._seqs.dummy_variant == dv
+    # original unchanged
+    assert ds._seqs.dummy_variant is None
+    # disable with False
+    ds3 = ds2.with_settings(dummy_variant=False)
+    assert ds3._seqs.dummy_variant is None
+
+
+def test_dummy_variant_rejected_on_non_variant_kind(snap_dataset):
+    import genvarloader as gvl
+
+    ds = snap_dataset.with_seqs("haplotypes").with_settings(
+        dummy_variant=gvl.DummyVariant()
+    )
+    # guard fires at access time when the output kind is not variants
+    with pytest.raises(ValueError):
+        _ = ds[0]
+
+
+def test_dummy_variant_export():
+    import genvarloader as gvl
+
+    from genvarloader._dataset._flat_variants import DummyVariant
+
+    assert gvl.DummyVariant is DummyVariant
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run -e dev pytest tests/dataset/test_output_format.py -k dummy -v`
+Expected: FAIL (`with_settings` has no `dummy_variant` kwarg; `gvl.DummyVariant` missing).
+
+- [ ] **Step 3: Add the `dummy_variant` parameter to `with_settings`**
+
+In `python/genvarloader/_dataset/_impl.py`, add to the `with_settings` signature (after `var_filter`):
+
+```python
+        dummy_variant: "DummyVariant | Literal[False] | None" = None,
+```
+
+Add a runtime import at the top of `_impl.py` (no cycle — `_flat_variants` imports only `_flat` at runtime):
+
+```python
+from ._flat_variants import DummyVariant
+```
+
+Add a handling block inside `with_settings` (alongside the `min_af`/`var_filter` blocks, before the `if "_seqs" in to_evolve ...` rebuild):
+
+```python
+        if dummy_variant is not None:
+            if not isinstance(self._seqs, Haps):
+                raise ValueError(
+                    "dummy_variant requires a dataset with variants/genotypes."
+                )
+            dv = None if dummy_variant is False else dummy_variant
+            haps = to_evolve.get("_seqs", self._seqs)
+            to_evolve["_seqs"] = replace(haps, dummy_variant=dv)
+```
+
+Add a `dummy_variant` entry to the `with_settings` docstring Parameters section:
+
+```
+        dummy_variant
+            A :class:`DummyVariant` to insert into empty (region, sample, ploid) variant
+            groups so every group has at least one variant. Only valid for the variants
+            output (:meth:`with_seqs("variants") <genvarloader.Dataset.with_seqs>`). Pass
+            :code:`False` to disable.
+```
+
+- [ ] **Step 4: Add the guard in `__getitem__`**
+
+Find `Dataset.__getitem__` in `_impl.py`. Near its top (before constructing `QueryView`), add:
+
+```python
+        if (
+            isinstance(self._seqs, Haps)
+            and self._seqs.dummy_variant is not None
+            and self._seqs_kind != "variants"
+        ):
+            raise ValueError(
+                "dummy_variant is only valid for the variants output; "
+                "call with_seqs('variants') (got output kind "
+                f"{self._seqs_kind!r})."
+            )
+```
+
+(Validating here — rather than in `with_settings` — keeps `dummy_variant` order-independent with `with_seqs`, and catches switching away from variants after setting it.)
+
+- [ ] **Step 5: Export `DummyVariant`**
+
+In `python/genvarloader/__init__.py`, add the import grouped with the other `_dataset._flat_variants` imports:
+
+```python
+from ._dataset._flat_variants import _FlatAlleles as FlatAlleles
+from ._dataset._flat_variants import _FlatVariants as FlatVariants
+from ._dataset._flat_variants import DummyVariant
+```
+
+Add `"DummyVariant",` to `__all__` in its correct alphabetical position (between `"Dataset"`/`"DatasetWithSites"` and `"FlankSample"`).
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `pixi run -e dev pytest tests/dataset/test_output_format.py -k dummy -v`
+Expected: PASS. Then:
+Run: `pixi run -e dev python -c "import genvarloader as gvl; print(gvl.DummyVariant())"`
+Run: `pixi run -e dev ruff check python/genvarloader/_dataset/_impl.py python/genvarloader/__init__.py tests/dataset/test_output_format.py`
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_impl.py python/genvarloader/__init__.py tests/dataset/test_output_format.py
+rtk git commit -m "feat(flat): with_settings(dummy_variant=...) + export DummyVariant + non-variant guard"
+```
+
+---
+
+## Task 5: Flat↔ragged parity + no-awkward guard for the dummy fill
+
+**Files:**
+- Modify: `tests/dataset/test_flat_mode_equivalence.py` (append)
+- Modify: `tests/dataset/test_no_awkward_in_hotpath.py` (append)
+
+- [ ] **Step 1: Write the parity test (append to `test_flat_mode_equivalence.py`)**
+
+```python
+# append to tests/dataset/test_flat_mode_equivalence.py
+import genvarloader as gvl
+
+
+@pytest.mark.parametrize("idx", IDX)
+def test_b_dummy_fill_flat_to_ragged_matches_ragged(snap_dataset, idx):
+    dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N", ilen=0)
+    ds = snap_dataset.with_seqs("variants").with_tracks(False).with_settings(dummy_variant=dv)
+    ragged = ds[idx]                                   # ragged mode (now flat decode + to_ragged)
+    rewrapped = ds.with_output_format("flat")[idx].to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+
+
+def test_b_dummy_fill_no_empty_groups(snap_dataset):
+    import awkward as ak
+
+    dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N")
+    ds = snap_dataset.with_seqs("variants").with_tracks(False).with_settings(dummy_variant=dv)
+    idx = (np.arange(min(6, snap_dataset.shape[0])),)
+    rv = ds[idx]
+    for ploid_groups in ak.to_list(rv["start"]):
+        for g in ploid_groups:
+            assert len(g) >= 1
+```
+
+(`_rv_to_lists` and `IDX` already exist in this file from A.)
+
+- [ ] **Step 2: Run to verify pass**
+
+Run: `pixi run -e dev pytest tests/dataset/test_flat_mode_equivalence.py -k "dummy or b_" -v`
+Expected: PASS for all index shapes (scalar, scalar-scalar squeeze, 1-D, 2-D from `IDX`), exercising the fill in both flat and ragged modes byte-identically.
+
+- [ ] **Step 3: Write the no-awkward test (append to `test_no_awkward_in_hotpath.py`)**
+
+Reuse the file's existing `_install_ak_counters(monkeypatch)` helper and `guard_dataset` fixture (inspect the file to confirm names):
+
+```python
+# append to tests/dataset/test_no_awkward_in_hotpath.py
+def test_flat_variants_dummy_fill_has_no_awkward(monkeypatch, guard_dataset):
+    import genvarloader as gvl
+
+    calls = _install_ak_counters(monkeypatch)
+    ds = (
+        guard_dataset.with_seqs("variants")
+        .with_tracks(False)
+        .with_output_format("flat")
+        .with_settings(dummy_variant=gvl.DummyVariant(start=-1, alt=b"N", ref=b"N"))
+    )
+    n_regions = min(4, ds.shape[0])
+    regions = list(range(n_regions))
+    samples = [i % ds.shape[1] for i in range(n_regions)]
+    _ = ds[regions, samples]
+    assert calls["n"] == 0, (
+        f"flat dummy-fill decode dispatched {calls['n']} awkward kernel(s)"
+    )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pixi run -e dev pytest tests/dataset/test_no_awkward_in_hotpath.py -k dummy -v`
+Expected: PASS (the fill is pure numba/numpy). Then the whole no-awkward file:
+Run: `pixi run -e dev pytest tests/dataset/test_no_awkward_in_hotpath.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full-suite regression**
+
+Run: `pixi run -e dev pytest tests/ -q`
+Expected: PASS (snapshot `variants_ragged.npz` still unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add tests/dataset/test_flat_mode_equivalence.py tests/dataset/test_no_awkward_in_hotpath.py
+rtk git commit -m "test(flat): dummy-fill flat<->ragged parity + no-awkward guard"
+```
+
+---
+
+## Task 6: Update the genvarloader skill
+
+**Files:**
+- Modify: `skills/genvarloader/SKILL.md`
+
+- [ ] **Step 1: Document the new API**
+
+Read `skills/genvarloader/SKILL.md` and add, matching its existing conventions:
+- A `with_settings(dummy_variant=...)` entry: inserts a dummy variant into empty `(region, sample, ploid)` groups so every group has ≥1 variant; only valid for the variants output (raises otherwise); `False` disables; default `None`. Note it fills **only** empty groups (not every group).
+- `gvl.DummyVariant` in the public-types / symbol list with its fields (`start=-1`, `ref=b"N"`, `alt=b"N"`, `ilen=0`, `dosage=0.0`, `info={}`) and per-field defaults, and a pointer to `python/genvarloader/_dataset/_flat_variants.py`.
+- A "Common gotchas" note: dummy padding is variant-output-only; a non-`N` dummy allele is reverse-complemented on negative-strand regions like any allele (the default `b"N"` is rc-invariant).
+
+- [ ] **Step 2: Commit**
+
+```bash
+rtk git add skills/genvarloader/SKILL.md
+rtk git commit -m "docs(skill): document with_settings(dummy_variant) + DummyVariant"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 B1 always-flat decode (retire `_get_variants`) → Task 1.
+- §1 B2 empty-group fill; §2 fill-only-empty semantics → Tasks 2, 3.
+- §3 public API (`with_settings(dummy_variant=...)`, `DummyVariant`, defaults, `False` disables, raise on non-variant kind) → Task 4.
+- §4 boundary `to_ragged` for `_FlatVariants`; snapshot oracle → Task 1.
+- §5 kernels + `fill_empty_groups`, applied after filters → Tasks 2, 3.
+- §6 data flow / rc interaction (dummy before rc; `b"N"` rc-invariant) → Tasks 3, 6 (documented).
+- §7 error handling (raise on non-variant kind, bad info key handled by `scalar_for` defaults) → Task 4.
+- §8 testing (snapshot regression, flat↔ragged parity, fill golden units, no-awkward, validation) → Tasks 1, 2, 3, 4, 5.
+- §9 deferred merge/sort → out of scope (no task), rationale in spec.
+- §10 gvf consumer thinning → cross-repo, not in this gvl plan.
+- Skill update (CLAUDE.md mandate) → Task 6.
+
+**Placeholder scan:** No TBD/TODO. Kernel and `DummyVariant` code is complete. The one verification note (Task 3 `ds._seqs` attribute / fixture visibility) names the concrete fallback, not a placeholder.
+
+**Type consistency:** `DummyVariant(start, ilen, dosage, ref, alt, info)` + `scalar_for(name, dtype)`; `_fill_empty_scalar(data, offsets, fill) -> (data, offsets)`; `_fill_empty_seq(data, var_offsets, seq_offsets, dummy) -> (data, var_offsets, seq_offsets)`; `_FlatVariants.fill_empty_groups(dummy) -> _FlatVariants`; `Haps.dummy_variant`; `with_settings(dummy_variant=...)`; `gvl.DummyVariant`. Names are used consistently across tasks. `get_variants_flat(haps, idx)` signature unchanged (reads `haps.dummy_variant`).
+
+**Known verification points (forced by tests):** snapshot `variants_ragged.npz` unchanged after retiring the awkward path (Task 1); flat↔ragged parity of the fill across scalar/scalar-scalar/1-D/2-D indices + empty/ploidy (Task 5); fill-only-empty (non-empty groups untouched) (Tasks 2, 3); no-awkward in the fill path (Task 5); raise on non-variant kind (Task 4).

--- a/docs/superpowers/specs/2026-06-13-variant-assembly-B-design.md
+++ b/docs/superpowers/specs/2026-06-13-variant-assembly-B-design.md
@@ -1,0 +1,255 @@
+# Variant assembly (B) — design: always-flat decode + empty-region dummy padding
+
+**Date:** 2026-06-13
+**Repo:** `mcvickerlab/GenVarLoader` (gvl)
+**Driven by:** gvl issue #214 (super-batch / flat-buffer output mode), sub-project **B**.
+Consumer: genvarformer `Variants` source (`tokens.py`).
+**Status:** approved design; ready for `writing-plans`.
+
+Builds directly on sub-project **A** (flat variant decode, PR #215):
+`docs/superpowers/specs/2026-06-13-flat-output-mode-design.md`.
+Sibling sub-project **C** (flank fetch + tokenization) is independent and specced separately.
+
+---
+
+## 0. Context
+
+Issue #214 decomposes a flat-buffer / super-batch output mode into sub-projects A0, A, B,
+C, D, E. **A** (merged) made `get_variants_flat` produce pure-numpy `_FlatVariants` with zero
+awkward on the hot path, byte-identical (via `.to_ragged()`) to the legacy awkward
+`_get_variants`. The byte-identity gate is the committed snapshot
+`tests/dataset/_snapshots/variants_ragged.npz`.
+
+The design doc's original **B** was "absorb variant assembly into gvl: phased+unphased ploidy
+merge, within-group sort, dummy-variant / empty-region padding." During brainstorming the scope
+was deliberately trimmed:
+
+- **Phased+unphased sorted-merge — deferred.** No project in the last year has needed phased
+  and unphased variants in the same input, and none is emerging. Adding a multi-source genotype
+  concept to gvl is unjustified now.
+- **Within-group sort — deferred (falls out of the above).** Verified in genvarformer
+  (`src/genvarformer/data/sources/tokens.py:526–533`): `_merge_phased_unphased_numba`
+  (the `expand_groups_*` + `concat_*` kernels) runs **only** when both phased and unphased
+  datasets are present (`len(rag_vars) == 2`), and `_sort_by_start_numba`
+  (`segmented_argsort` + `take_*`) runs **only** inside that branch. The single-source path
+  calls `infer_germline_ccfs_()` with no preceding sort, relying on gvl's native
+  per-group sorted order. So a within-group sort is needed *only* to repair the order that
+  `concat` breaks during the dual-source merge — i.e. only the deferred case needs it.
+
+What remains of B is therefore: **(B1)** finish what A started by making the flat decode the
+*single* variant decode path, and **(B2)** add optional **empty-region dummy padding**.
+
+---
+
+## 1. Goal & scope
+
+Two coupled changes to gvl's variant-record output (`with_seqs("variants")`):
+
+- **B1 — always-flat variant decode (refactor).** Make `get_variants_flat` the single decode.
+  Retire the awkward `_get_variants` / `_get_alleles` / `_get_info`. Ragged-mode variant output
+  becomes flat decode + boundary `to_ragged()`.
+- **B2 — empty-group dummy padding (feature).** Optionally, for any
+  `(region, sample, ploid)` variant group with **zero** variants, insert exactly one
+  caller-specified dummy variant. Non-empty groups are left untouched. Guarantees ≥1 variant per
+  group. Works identically in flat (`_FlatVariants`) and ragged (`RaggedVariants`) modes.
+
+**Out of scope (own future specs):** phased+unphased sorted-merge and within-group sort (§9);
+sub-project C (flank + tokenize); D (windows); E (`double_buffered` / `__getitems__`);
+the tracks / intervals flat path.
+
+---
+
+## 2. Decision: padding semantics
+
+**Fill only empty groups** (not gvf's "prepend a dummy to every group").
+
+A group here is one `(region, sample, ploid)` row — i.e. one row of the `b*p` offset structure
+of the `(b, p, ~v)` variant output. A group with N ≥ 1 real variants is unchanged; a group with
+0 variants receives exactly one dummy, becoming length 1. This guarantees no zero-length groups
+(which break downstream tensorization / per-group reductions) without forcing a sentinel slot
+into every group.
+
+This **diverges** from genvarformer's current `_add_dummy_variant`, which prepends a dummy to
+every group. The genvarformer consumer (and its golden snapshot) adapt to fill-only-empty when
+gvf adopts B — a deliberate behavior change on the consumer side, not a byte-match (§8, §10).
+
+---
+
+## 3. Public API
+
+Configured via the existing `Dataset.with_settings(...)` — **not** a new `with_*` method, since
+padding does not change the return type (gvl convention: `with_*` is reserved for type-state
+transitions like `with_seqs` / `with_output_format`; type-preserving knobs live in
+`with_settings`).
+
+```python
+from genvarloader import DummyVariant
+
+ds.with_settings(dummy_variant=DummyVariant(start=-1, ref=b"N", alt=b"N", ilen=0, dosage=0.0))
+ds.with_settings(dummy_variant=False)   # disable; mirrors the min_af/max_af `False` convention
+```
+
+- New parameter `dummy_variant: DummyVariant | Literal[False] | None = None` on `with_settings`
+  (`None` = leave unchanged, `False` = disable, a `DummyVariant` = enable). Backed by a frozen
+  `Dataset` field `dummy_variant: DummyVariant | None = None`, threaded through `QueryView` into
+  the decode using the same plumbing pattern as A's `flat_output`.
+
+- **`DummyVariant`** — new public dataclass (exported in `genvarloader.__all__`, alongside the
+  existing config types `Constant` / `FlankSample` / `InsertionFill`). Per-`var_field` values,
+  all with sensible defaults and all caller-overridable:
+
+  | field | default | notes |
+  |-------|---------|-------|
+  | `start` | `-1` | sentinel position |
+  | `ref` | `b"N"` | length-1 placeholder allele (avoid `b""` zero-length leaf) |
+  | `alt` | `b"N"` | length-1 placeholder allele |
+  | `ilen` | `0` | no indel |
+  | `dosage` | `0.0` | |
+  | `info` | `{}` | `dict[str, Any]`; per-info-field overrides. Unspecified info fields default to `0` (integer columns) / `NaN` (float columns) |
+
+  The dummy must supply a value for every **active** `var_field`; unspecified builtin fields take
+  the defaults above, unspecified info fields take the per-dtype default. An `info` key that is
+  not an active var_field raises `ValueError`.
+
+- **Validation:** if `dummy_variant` is set but the output kind is **not** variants
+  (i.e. `with_seqs(...)` is haplotypes / reference / annotated), `Dataset.__getitem__` (or
+  `with_settings`) raises `ValueError`. Padding applies only to the variant-record output.
+
+---
+
+## 4. B1 — always-flat variant decode
+
+- `Haps.__call__` and the `get_haps_and_shifts` variants branch (`_haps.py:523`, `:574`) always
+  call `get_variants_flat(...) -> _FlatVariants`, regardless of the `flat` flag.
+- The `_query.py` boundary already converts `_Flat` / `_FlatAnnotatedHaps -> to_ragged()` in
+  ragged mode (`getitem`, the `if not view.flat_output:` block). **Add `_FlatVariants` to that
+  conversion.** In flat mode `_FlatVariants` passes through unconverted (A's behavior).
+  `_reshape_outer` and `squeeze` already handle `_FlatVariants` (added in A).
+- **Delete** `_get_variants`, `_get_alleles`, `_get_info` (`_haps.py`). Verified they are used
+  only by the variant decode — haplotype/annotated reconstruction uses
+  `reconstruct_haplotypes_from_sparse`, not these helpers.
+- The `flat` parameter on `Haps.__call__` / reconstructors stays (it still selects the *return
+  boundary* behavior via `flat_output`); it simply no longer selects between two decode
+  implementations, because there is now only one.
+
+**Regression oracle.** The committed snapshot `tests/dataset/_snapshots/variants_ragged.npz`
+(generated from the legacy awkward path) is the gate proving the refactor preserves ragged output.
+It **must not be regenerated** during B. Note that A's equivalence test
+(`flat.to_ragged() == ds[idx]` in ragged mode) becomes tautological once ragged output *is*
+flat-derived; the snapshot becomes the real regression gate. To retain an independent awkward
+reference, keep one small inline awkward-built expectation in the unit tests (the
+`test_flat_variants.py` `to_packed`/`rc` tests already build awkward expectations inline and do
+not depend on `_get_variants`, so they survive the deletion).
+
+---
+
+## 5. B2 — empty-group dummy fill
+
+Numba kernels on flat `(data, offsets)` buffers — the same family as genvarformer's `prepend_*`,
+but **conditional**: act on a row `i` only when `offsets[i+1] == offsets[i]` (empty), inserting
+one dummy element; non-empty rows are copied through unchanged.
+
+- `fill_empty_scalar(data, offsets, fill) -> (new_data, new_offsets)` — scalar fields
+  (`start` / `ilen` / `dosage` / info).
+- `fill_empty_seq(data, var_offsets, seq_offsets, dummy_bytes) -> (new_data, new_var_offsets, new_seq_offsets)`
+  — allele fields (`alt` / `ref`), inserting one `dummy_bytes` allele into empty variant rows.
+
+Exposed as **`_FlatVariants.fill_empty_groups(dummy: DummyVariant) -> _FlatVariants`**, which
+dispatches `_Flat` fields to the scalar kernel and `_FlatAlleles` fields to the seq kernel,
+producing a new `_FlatVariants` with consistent offsets across all fields. (`_Flat` /
+`_FlatAlleles` gain thin per-field `fill_empty(fill)` helpers that the dispatcher calls, mirroring
+their existing `reshape` / `squeeze` / `reverse_masked` surface.)
+
+Applied as the **final step inside `get_variants_flat`**, *after* AF/exonic compaction, so a
+group emptied by filtering is also padded. Because the decode is now always flat (B1), ragged mode
+inherits the fill for free via the boundary `to_ragged()`.
+
+---
+
+## 6. Data flow
+
+```
+get_variants_flat(haps, idx, dummy_variant):
+  gather v_idxs + row_offsets           (numba; from sparse genotypes)
+  AF / exonic compaction                (if filters active)
+  build flat fields                     (alt/ref -> _FlatAlleles; start/ilen/dosage/info -> _Flat)
+  if dummy_variant is not None:
+      fill_empty_groups(dummy_variant)  (numba; only zero-length rows)
+  -> _FlatVariants
+
+_query.py getitem:
+  reshape / squeeze   (flat methods, _reshape_outer)
+  flat mode  -> return _FlatVariants as-is
+  ragged mode-> _FlatVariants.to_ragged() -> RaggedVariants
+```
+
+`rc_neg` runs in `_getitem_unspliced` before the boundary squeeze (A). The dummy is inserted
+during decode, i.e. before `rc`; with the default `b"N"` alleles, reverse-complement is a no-op
+(`N -> N`). A caller-supplied non-`N` dummy allele *would* be reverse-complemented like any other
+allele on a negative-strand region — documented so it is not surprising.
+
+---
+
+## 7. Error handling & edge cases
+
+- `dummy_variant` set with a non-variant output kind → `ValueError` (§3).
+- `DummyVariant.info` key not among active var_fields → `ValueError`.
+- Default allele `b"N"` (length 1) avoids reintroducing zero-length allele leaves.
+- Composes with `subset_to`, `output_length` (variable / int), `rc_neg`, multi-ploidy, and both
+  output formats. In flat mode the consumer densifies via `.to_fixed` / `.to_padded` as usual; the
+  fill changes only which rows are non-empty, not the flat container contract.
+- A region that is empty for *every* `(sample, ploid)` is handled uniformly — each empty group
+  gets its own dummy.
+
+---
+
+## 8. Testing & acceptance
+
+1. **B1 snapshot regression (primary gate):** `tests/dataset/_snapshots/variants_ragged.npz`
+   stays green via `test_flat_getitem_snapshot.py`, with the file **not** regenerated. This proves
+   retiring `_get_variants` preserves ragged output byte-for-byte.
+2. **Flat↔ragged parity for the fill:** `ds.with_output_format("flat").with_settings(dummy_variant=D)[idx].to_ragged()`
+   element-identical to `ds.with_settings(dummy_variant=D)[idx]` (ragged), across scalar /
+   scalar-scalar (squeeze) / 1-D / 2-D indices, multi-ploidy, naturally-empty regions, and
+   filter-emptied groups. Extends `tests/dataset/test_flat_mode_equivalence.py`.
+3. **Fill golden unit tests** (`tests/unit/dataset/`): empty group → exactly one dummy with the
+   specified field values; non-empty groups untouched; defaults vs per-field overrides; all
+   var_fields including dynamically-loaded info; the `fill_empty_scalar` / `fill_empty_seq` kernels
+   in isolation (hand-built offsets, including the all-empty and no-empty extremes).
+4. **No-awkward guard:** the fill path runs zero awkward kernels (extend
+   `test_no_awkward_in_hotpath.py`), since `fill_empty_groups` is pure numba on flat buffers.
+5. **Validation tests:** `dummy_variant` + non-variant kind raises; bad `info` key raises.
+6. **No ragged-path regression:** full suite green (`pixi run -e dev test`).
+
+---
+
+## 9. Deferred (explicitly out of scope)
+
+- **Phased+unphased sorted-merge** and the **within-group sort** it requires. Rationale in §0:
+  no current/near-term need, and both are reachable in genvarformer only in the simultaneous
+  dual-dataset branch. When revived, the merge should exploit that **both sources are already
+  position-sorted** — a sorted-merge (merge-step of merge-sort, O(n+m)) rather than gvf's current
+  concat-then-`segmented_argsort`. `sortednp`
+  (https://gitlab.sauerburger.com/frank/sortednp) is a reference for the algorithm, but it is a
+  compiled C++/numpy extension and **not** `@nb.njit`-callable, so it cannot live in the numba hot
+  path — at most a non-njit fallback or an implementation reference. This becomes its own
+  sub-project (provisionally "B2/merge") with its own source-provision design (read-time merge of
+  two `Dataset`s vs a write-time combined dataset).
+
+---
+
+## 10. genvarformer consumer thinning (validation, separate repo)
+
+Lands alongside B to prove the win and exercise the API (its own gvf PR, like A's Task 8):
+
+- Switch the `Variants` source to gvl's `with_settings(dummy_variant=...)` for empty-region
+  padding, deleting gvf's `_add_dummy_variant` for the variant-record fields and the conditional
+  `prepend_*` kernels for those fields. (The flank-row dummy stays in gvf until C/D.)
+- Because B2 is **fill-only-empty**, gvf's behavior changes from prepend-to-every-group:
+  update `tests/test_ragged_numba.py::test_add_dummy_variant_golden_snapshot` (and the model's
+  expectation of a per-group sentinel slot, if any) to the new semantics. This is a deliberate
+  behavior change validated by gvf's batch-equality guardrail under the new contract — not a
+  byte-identity match against the old gvf output.
+- The retired awkward decode (`_get_variants`) means gvf's `Variants._fetch` consumes
+  `FlatVariants` directly in flat mode (already enabled by A); B removes the last awkward decode
+  fallback on gvl's side.

--- a/python/genvarloader/__init__.py
+++ b/python/genvarloader/__init__.py
@@ -6,6 +6,7 @@ from seqpro.rag import Ragged
 
 from . import data_registry
 from ._bigwig import BigWigs
+from ._dataset._flat_variants import DummyVariant
 from ._dataset._flat_variants import _FlatAlleles as FlatAlleles
 from ._dataset._flat_variants import _FlatVariants as FlatVariants
 from ._dataset._impl import ArrayDataset, Dataset, RaggedDataset
@@ -39,6 +40,7 @@ __all__ = [
     "Constant",
     "Dataset",
     "DatasetWithSites",
+    "DummyVariant",
     "FlankSample",
     "FlatAlleles",
     "FlatAnnotatedHaps",

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -155,7 +155,11 @@ def _gather_v_idxs(
     geno_offset_idx, geno_offsets, geno_v_idxs
 ):  # pragma: no cover - njit
     """Gather per-row variant indices: for each row's offset slice into the
-    sparse arrays, copy its values out into flat ``(data, offsets)``."""
+    sparse arrays, copy its values out into flat ``(data, offsets)``.
+
+    ``geno_offsets`` must be 1-D contiguous (length n_rows + 1).  For the
+    non-contiguous (2, n_rows) starts/stops form use :func:`_gather_v_idxs_ss`.
+    """
     n_rows = geno_offset_idx.shape[0]
     out_offsets = np.empty(n_rows + 1, np.int64)
     out_offsets[0] = 0
@@ -171,6 +175,36 @@ def _gather_v_idxs(
         goi = geno_offset_idx[i]
         s = geno_offsets[goi]
         e = geno_offsets[goi + 1]
+        for k in range(s, e):
+            v_idxs[dst] = geno_v_idxs[k]
+            dst += 1
+    return v_idxs, out_offsets
+
+
+@nb.njit(nogil=True, cache=True)
+def _gather_v_idxs_ss(
+    geno_offset_idx, geno_starts, geno_stops, geno_v_idxs
+):  # pragma: no cover - njit
+    """Like :func:`_gather_v_idxs` but for non-contiguous (starts, stops) offsets.
+
+    ``geno_starts`` and ``geno_stops`` are the two rows of a ``(2, n)`` offset
+    array (``geno_starts = geno_offsets[0]``, ``geno_stops = geno_offsets[1]``).
+    """
+    n_rows = geno_offset_idx.shape[0]
+    out_offsets = np.empty(n_rows + 1, np.int64)
+    out_offsets[0] = 0
+    for i in range(n_rows):
+        goi = geno_offset_idx[i]
+        out_offsets[i + 1] = out_offsets[i] + (
+            geno_stops[goi] - geno_starts[goi]
+        )
+    total = out_offsets[n_rows]
+    v_idxs = np.empty(total, geno_v_idxs.dtype)
+    dst = 0
+    for i in range(n_rows):
+        goi = geno_offset_idx[i]
+        s = geno_starts[goi]
+        e = geno_stops[goi]
         for k in range(s, e):
             v_idxs[dst] = geno_v_idxs[k]
             dst += 1
@@ -224,6 +258,23 @@ def _compact_keep(v_idxs, row_offsets, keep):  # pragma: no cover - njit
     return new_v, new_offsets
 
 
+def _gather_rows(
+    geno_offset_idx: NDArray[np.intp],
+    offsets: NDArray[np.int64],
+    data: NDArray,
+) -> tuple[NDArray, NDArray[np.int64]]:
+    """Dispatch to the correct gather kernel based on offset array shape.
+
+    ``offsets`` may be:
+    - 1-D ``(n + 1,)``: contiguous offsets — use :func:`_gather_v_idxs`.
+    - 2-D ``(2, n)``: non-contiguous starts/stops — use :func:`_gather_v_idxs_ss`.
+    """
+    if offsets.ndim == 1:
+        return _gather_v_idxs(geno_offset_idx, offsets, data)
+    else:
+        return _gather_v_idxs_ss(geno_offset_idx, offsets[0], offsets[1], data)
+
+
 def get_variants_flat(haps: "Haps", idx: NDArray[np.integer]) -> _FlatVariants:
     """Flat-buffer analog of :meth:`Haps._get_variants`: builds a
     :class:`_FlatVariants` with no awkward on the hot path. Re-wrapping the
@@ -249,7 +300,8 @@ def get_variants_flat(haps: "Haps", idx: NDArray[np.integer]) -> _FlatVariants:
     geno_v_idxs = np.asarray(genotypes.data)
 
     # v_idxs: gathered per (b*ploidy) row; row_offsets length b*ploidy + 1.
-    v_idxs, row_offsets = _gather_v_idxs(geno_offset_idx, geno_offsets, geno_v_idxs)
+    # Dispatch on offsets shape: 1-D contiguous vs 2-D starts/stops.
+    v_idxs, row_offsets = _gather_rows(geno_offset_idx, geno_offsets, geno_v_idxs)
 
     # Unfiltered offsets needed for dosage parallel-gather + compaction.
     unfiltered_row_offsets = row_offsets
@@ -273,7 +325,7 @@ def get_variants_flat(haps: "Haps", idx: NDArray[np.integer]) -> _FlatVariants:
         dos_all = np.asarray(haps.dosages.data)
         # The returned row offsets == unfiltered_row_offsets by construction
         # (genotypes and dosages share offset structure), so discard them.
-        dosage_data, _ = _gather_v_idxs(geno_offset_idx, dos_offsets, dos_all)
+        dosage_data, _ = _gather_rows(geno_offset_idx, dos_offsets, dos_all)
 
     # Apply AF compaction to v_idxs / row_offsets / dosage.
     if keep is not None:

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -187,8 +187,12 @@ class _FlatVariants:
         new_fields: dict[str, Any] = {}
         for name, f in self.fields.items():
             if isinstance(f, _FlatAlleles):
-                db = np.frombuffer(dummy.alt if name == "alt" else dummy.ref, np.uint8).copy()
-                nd, nvar, nseq = _fill_empty_seq(f.byte_data, f.var_offsets, f.seq_offsets, db)
+                db = np.frombuffer(
+                    dummy.alt if name == "alt" else dummy.ref, np.uint8
+                ).copy()
+                nd, nvar, nseq = _fill_empty_seq(
+                    f.byte_data, f.var_offsets, f.seq_offsets, db
+                )
                 new_fields[name] = _FlatAlleles(nd, nseq, nvar, f.shape)
             else:
                 fill = dummy.scalar_for(name, f.data.dtype)
@@ -242,9 +246,7 @@ def _gather_v_idxs_ss(
     out_offsets[0] = 0
     for i in range(n_rows):
         goi = geno_offset_idx[i]
-        out_offsets[i + 1] = out_offsets[i] + (
-            geno_stops[goi] - geno_starts[goi]
-        )
+        out_offsets[i + 1] = out_offsets[i] + (geno_stops[goi] - geno_starts[goi])
     total = out_offsets[n_rows]
     v_idxs = np.empty(total, geno_v_idxs.dtype)
     dst = 0

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -490,4 +490,7 @@ def get_variants_flat(haps: "Haps", idx: NDArray[np.integer]) -> _FlatVariants:
         info_data = np.asarray(haps.variants.info[k])[v_idxs]
         fields[k] = _Flat.from_offsets(info_data, shape, row_offsets)
 
-    return _FlatVariants(fields)
+    result = _FlatVariants(fields)
+    if haps.dummy_variant is not None:
+        result = result.fill_empty_groups(haps.dummy_variant)
+    return result

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -14,6 +14,35 @@ if TYPE_CHECKING:
     from ._haps import Haps
 
 
+@dataclass(frozen=True)
+class DummyVariant:
+    """Per-field values for the dummy variant inserted into empty
+    (region, sample, ploid) groups. Unspecified info fields default to ``0``
+    for integer columns and ``NaN`` for float columns."""
+
+    start: int = -1
+    ilen: int = 0
+    dosage: float = 0.0
+    ref: bytes = b"N"
+    alt: bytes = b"N"
+    info: dict[str, Any] = field(default_factory=dict)
+
+    def scalar_for(self, name: str, dtype: np.dtype):
+        """Return the dummy fill value for a scalar field, as a numpy scalar of ``dtype``."""
+        dt = np.dtype(dtype)
+        if name == "start":
+            return dt.type(self.start)
+        if name == "ilen":
+            return dt.type(self.ilen)
+        if name == "dosage":
+            return dt.type(self.dosage)
+        if name in self.info:
+            return dt.type(self.info[name])
+        if np.issubdtype(dt, np.floating):
+            return dt.type(np.nan)
+        return dt.type(0)
+
+
 @dataclass(slots=True)
 class _FlatAlleles:
     """Two-level flat bytestring for an alt/ref allele field, shape (b, p, ~v, ~l).
@@ -149,6 +178,24 @@ class _FlatVariants:
                 self.fields[name] = self.fields[name].reverse_masked(mask)
         return self
 
+    def fill_empty_groups(self, dummy: "DummyVariant") -> "_FlatVariants":
+        """Insert one dummy variant into each empty (b*p) group; non-empty
+        groups are unchanged. Every field shares the same empty-row pattern, so
+        the rebuilt offsets stay consistent across fields."""
+        from .._flat import _Flat
+
+        new_fields: dict[str, Any] = {}
+        for name, f in self.fields.items():
+            if isinstance(f, _FlatAlleles):
+                db = np.frombuffer(dummy.alt if name == "alt" else dummy.ref, np.uint8).copy()
+                nd, nvar, nseq = _fill_empty_seq(f.byte_data, f.var_offsets, f.seq_offsets, db)
+                new_fields[name] = _FlatAlleles(nd, nseq, nvar, f.shape)
+            else:
+                fill = dummy.scalar_for(name, f.data.dtype)
+                nd, noff = _fill_empty_scalar(f.data, f.offsets, fill)
+                new_fields[name] = _Flat.from_offsets(nd, f.shape, noff)
+        return _FlatVariants(new_fields)
+
 
 @nb.njit(nogil=True, cache=True)
 def _gather_v_idxs(
@@ -273,6 +320,79 @@ def _gather_rows(
         return _gather_v_idxs(geno_offset_idx, offsets, data)
     else:
         return _gather_v_idxs_ss(geno_offset_idx, offsets[0], offsets[1], data)
+
+
+@nb.njit(nogil=True, cache=True)
+def _fill_empty_scalar(data, offsets, fill):  # pragma: no cover - njit
+    """Insert one ``fill`` element into each empty row; copy non-empty rows
+    through. Returns ``(new_data, new_offsets)``."""
+    n_rows = offsets.shape[0] - 1
+    new_offsets = np.empty(n_rows + 1, np.int64)
+    new_offsets[0] = 0
+    for i in range(n_rows):
+        ln = offsets[i + 1] - offsets[i]
+        new_offsets[i + 1] = new_offsets[i] + (ln if ln > 0 else 1)
+    new_data = np.empty(new_offsets[n_rows], data.dtype)
+    for i in range(n_rows):
+        s = offsets[i]
+        e = offsets[i + 1]
+        d = new_offsets[i]
+        if e == s:
+            new_data[d] = fill
+        else:
+            for k in range(s, e):
+                new_data[d] = data[k]
+                d += 1
+    return new_data, new_offsets
+
+
+@nb.njit(nogil=True, cache=True)
+def _fill_empty_seq(data, var_offsets, seq_offsets, dummy):  # pragma: no cover - njit
+    """Two-level analogue of ``_fill_empty_scalar`` for allele bytestrings.
+    Empty variant-rows receive one dummy allele of ``dummy`` bytes. Returns
+    ``(new_data, new_var_offsets, new_seq_offsets)``."""
+    n_rows = var_offsets.shape[0] - 1
+    L = dummy.shape[0]
+    new_var = np.empty(n_rows + 1, np.int64)
+    new_var[0] = 0
+    for i in range(n_rows):
+        nv = var_offsets[i + 1] - var_offsets[i]
+        new_var[i + 1] = new_var[i] + (nv if nv > 0 else 1)
+    total_vars = new_var[n_rows]
+    new_seq = np.empty(total_vars + 1, np.int64)
+    new_seq[0] = 0
+    vptr = 0
+    for i in range(n_rows):
+        vs = var_offsets[i]
+        ve = var_offsets[i + 1]
+        if ve == vs:
+            new_seq[vptr + 1] = new_seq[vptr] + L
+            vptr += 1
+        else:
+            for v in range(vs, ve):
+                vlen = seq_offsets[v + 1] - seq_offsets[v]
+                new_seq[vptr + 1] = new_seq[vptr] + vlen
+                vptr += 1
+    new_data = np.empty(new_seq[total_vars], np.uint8)
+    vptr = 0
+    dptr = 0
+    for i in range(n_rows):
+        vs = var_offsets[i]
+        ve = var_offsets[i + 1]
+        if ve == vs:
+            for k in range(L):
+                new_data[dptr] = dummy[k]
+                dptr += 1
+            vptr += 1
+        else:
+            for v in range(vs, ve):
+                bs = seq_offsets[v]
+                be = seq_offsets[v + 1]
+                for k in range(bs, be):
+                    new_data[dptr] = data[k]
+                    dptr += 1
+                vptr += 1
+    return new_data, new_var, new_seq
 
 
 def get_variants_flat(haps: "Haps", idx: NDArray[np.integer]) -> _FlatVariants:

--- a/python/genvarloader/_dataset/_haps.py
+++ b/python/genvarloader/_dataset/_haps.py
@@ -15,7 +15,10 @@ import json
 import warnings
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Literal, TypeVar, cast
+from typing import TYPE_CHECKING, Literal, TypeVar, cast
+
+if TYPE_CHECKING:
+    from ._flat_variants import DummyVariant
 
 import awkward as ak
 import numpy as np
@@ -254,6 +257,7 @@ class Haps(Reconstructor[_H]):
     max_af: float | None
     """The maximum allele frequency to keep."""
     var_fields: list[str] = field(default_factory=lambda: ["alt", "ilen", "start"])
+    dummy_variant: "DummyVariant | None" = None
     available_var_fields: list[str] = field(init=False)
 
     def __post_init__(self):

--- a/python/genvarloader/_dataset/_haps.py
+++ b/python/genvarloader/_dataset/_haps.py
@@ -518,6 +518,7 @@ class Haps(Reconstructor[_H]):
                 )
             from ._flat_variants import get_variants_flat
 
+            # `flat` is not checked here: variants always decode flat; the param is retained for protocol/signature stability.
             return cast(_H, get_variants_flat(self, idx))
         else:
             haps, *_ = self.get_haps_and_shifts(

--- a/python/genvarloader/_dataset/_haps.py
+++ b/python/genvarloader/_dataset/_haps.py
@@ -516,13 +516,9 @@ class Haps(Reconstructor[_H]):
                 raise NotImplementedError(
                     "Spliced output is not supported for RaggedVariants."
                 )
-            if flat:
-                from ._flat_variants import get_variants_flat
+            from ._flat_variants import get_variants_flat
 
-                return cast(_H, get_variants_flat(self, idx))
-            ragv = self._get_variants(idx=idx, regions=None, shifts=None)
-            ragv = cast(_H, ragv)
-            return ragv
+            return cast(_H, get_variants_flat(self, idx))
         else:
             haps, *_ = self.get_haps_and_shifts(
                 idx=idx,
@@ -571,13 +567,9 @@ class Haps(Reconstructor[_H]):
                 raise NotImplementedError(
                     "Spliced output is not supported for RaggedVariants."
                 )
-            out = self._get_variants(
-                idx=idx,
-                regions=req.regions,
-                shifts=req.shifts,
-                keep=req.keep,
-                keep_offsets=req.keep_offsets,
-            )
+            from ._flat_variants import get_variants_flat
+
+            out = get_variants_flat(self, idx)
         else:
             assert_never(self.kind)
 
@@ -683,69 +675,6 @@ class Haps(Reconstructor[_H]):
         )  # type: ignore[no-matching-overload]  # Ragged.shape is tuple[int | None, ...]; numpy overload expects all-int
         return geno_offset_idx
 
-    def _get_variants(
-        self,
-        idx: NDArray[np.integer],
-        regions: NDArray[np.integer] | None = None,
-        shifts: NDArray[np.integer] | None = None,
-        keep: NDArray[np.bool_] | None = None,
-        keep_offsets: NDArray[np.integer] | None = None,
-    ) -> RaggedVariants:
-        # TODO: maybe filter variants for region, shifts?
-        r, s = np.unravel_index(idx, self.genotypes.shape[:2])  # type: ignore[no-matching-overload]  # Ragged.shape is tuple[int | None, ...]; numpy overload expects all-int
-        # (b p ~v)
-        genos = cast(Ragged[V_IDX_TYPE], self.genotypes[r, s]).to_packed()
-        v_idxs = genos.data
-
-        if self.min_af is not None or self.max_af is not None:
-            geno_afs = self.variants.info["AF"][v_idxs]
-            keep = np.full(len(v_idxs), True, np.bool_)
-            if self.min_af is not None:
-                keep &= geno_afs >= self.min_af
-            if self.max_af is not None:
-                keep &= geno_afs <= self.max_af
-            _keep = Ragged.from_offsets(keep, genos.shape, genos.offsets)
-            # genos[_keep] yields a bare ak.Array; wrap before to_packed
-            genos = Ragged(ak.to_regular(genos[_keep], 1)).to_packed()
-            v_idxs = genos.data
-        else:
-            _keep = None
-
-        fields = {}
-
-        fields["alt"] = self._get_alleles(genos, "alt")
-        fields["start"] = Ragged.from_offsets(
-            self.variants.start[v_idxs], genos.shape, genos.offsets
-        )
-
-        if "ref" in self.var_fields:
-            fields["ref"] = self._get_alleles(genos, "ref")
-        if "ilen" in self.var_fields:
-            fields["ilen"] = Ragged.from_offsets(
-                self.variants.ilen[v_idxs], genos.shape, genos.offsets
-            )
-
-        if self.dosages is not None and "dosage" in self.var_fields:
-            # guaranteed to have same shape as genotypes but need to make it contiguous/copy the data
-            dosages = cast(Ragged, self.dosages[r, s])
-            if _keep is not None:
-                # dosages[_keep] yields a bare ak.Array; wrap before to_packed
-                fields["dosage"] = Ragged(ak.to_regular(dosages[_keep], 1)).to_packed()
-            else:
-                fields["dosage"] = dosages.to_packed()
-
-        fields.update(
-            {
-                k: self._get_info(genos, k)
-                for k in self.var_fields
-                if k not in {"alt", "start", "ref", "ilen", "dosage"}
-            }
-        )
-
-        variants = RaggedVariants(**fields)
-
-        return variants
-
     def _allele_bytes_sum(
         self, idx: NDArray[np.integer], kind: Literal["alt", "ref"]
     ) -> NDArray[np.int64]:
@@ -775,23 +704,6 @@ class Haps(Reconstructor[_H]):
         # genos.offsets has length b*p + 1 (one offset per (instance, ploid) group).
         # reduceat needs starts, not full offsets; drop the last.
         return np.add.reduceat(v_lens, genos.offsets[:-1])
-
-    def _get_alleles(
-        self, genos: Ragged[V_IDX_TYPE], kind: Literal["alt", "ref"]
-    ) -> ak.Array:
-        v_idxs = genos.data
-        # (b*p*v ~l) packed allele bytes for the selected variants
-        alleles = cast(RaggedAlleles, getattr(self.variants, kind)[v_idxs]).to_packed()
-        return _build_allele_layout(
-            np.asarray(alleles.data).view(np.uint8),
-            np.asarray(alleles.offsets),
-            np.asarray(genos.offsets),
-            genos.shape[-2],
-        )
-
-    def _get_info(self, genos: Ragged[V_IDX_TYPE], attr: str) -> Ragged[np.number]:
-        data = self.variants.info[attr][genos.data]
-        return Ragged.from_offsets(data, genos.shape, genos.offsets)
 
     def _reconstruct_haplotypes(self, req: ReconstructionRequest) -> Ragged[np.bytes_]:
         """Reconstruct haplotype byte sequences from sparse genotypes."""

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -27,6 +27,7 @@ from .._utils import (
     lengths_to_offsets,
     normalize_contig_name,
 )
+from ._flat_variants import DummyVariant
 from ._indexing import DatasetIndexer, SpliceIndexer, is_str_arr
 from ._insertion_fill import InsertionFill
 from ._rag_variants import RaggedVariants
@@ -214,6 +215,7 @@ class Dataset:
         var_fields: list[str] | None = None,
         splice_info: str | tuple[str, str] | Literal[False] | None = None,
         var_filter: Literal[False, "exonic"] | None = None,
+        dummy_variant: "DummyVariant | Literal[False] | None" = None,
     ) -> Self:
         """Modify settings of the dataset, returning a new dataset without modifying the old one.
 
@@ -246,6 +248,11 @@ class Dataset:
             If False, splicing will be disabled.
         var_filter
             Whether to filter variants. If set to :code:`"exonic"`, only exonic variants will be applied.
+        dummy_variant
+            A :class:`DummyVariant` to insert into empty (region, sample, ploid) variant
+            groups so every group has at least one variant. Only valid for the variants
+            output (:meth:`with_seqs("variants") <genvarloader.Dataset.with_seqs>`). Pass
+            :code:`False` to disable.
         """
         to_evolve = {}
 
@@ -344,6 +351,15 @@ class Dataset:
             if var_filter != self._seqs.filter:
                 haps = to_evolve.get("_seqs", self._seqs)
                 to_evolve["_seqs"] = replace(haps, filter=var_filter)
+
+        if dummy_variant is not None:
+            if not isinstance(self._seqs, Haps):
+                raise ValueError(
+                    "dummy_variant requires a dataset with variants/genotypes."
+                )
+            dv = None if dummy_variant is False else dummy_variant
+            haps = to_evolve.get("_seqs", self._seqs)
+            to_evolve["_seqs"] = replace(haps, dummy_variant=dv)
 
         # If any source state changed, rebuild _recon via the factory.
         if "_seqs" in to_evolve or "_tracks" in to_evolve:
@@ -1600,6 +1616,17 @@ class Dataset:
     ):
         # Thin facade: package state into a QueryView and hand off to the
         # query module's free functions, which carry the actual logic.
+        if (
+            isinstance(self._seqs, Haps)
+            and self._seqs.dummy_variant is not None
+            and self._seqs_kind != "variants"
+        ):
+            raise ValueError(
+                "dummy_variant is only valid for the variants output; "
+                "call with_seqs('variants') (got output kind "
+                f"{self._seqs_kind!r})."
+            )
+
         from ._query import QueryView, getitem
 
         view = QueryView(

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -353,13 +353,18 @@ class Dataset:
                 to_evolve["_seqs"] = replace(haps, filter=var_filter)
 
         if dummy_variant is not None:
-            if not isinstance(self._seqs, Haps):
-                raise ValueError(
-                    "dummy_variant requires a dataset with variants/genotypes."
-                )
-            dv = None if dummy_variant is False else dummy_variant
-            haps = to_evolve.get("_seqs", self._seqs)
-            to_evolve["_seqs"] = replace(haps, dummy_variant=dv)
+            if dummy_variant is False:
+                # disable is a no-op on datasets without variants/genotypes
+                if isinstance(self._seqs, Haps):
+                    haps = to_evolve.get("_seqs", self._seqs)
+                    to_evolve["_seqs"] = replace(haps, dummy_variant=None)
+            else:
+                if not isinstance(self._seqs, Haps):
+                    raise ValueError(
+                        "dummy_variant requires a dataset with variants/genotypes."
+                    )
+                haps = to_evolve.get("_seqs", self._seqs)
+                to_evolve["_seqs"] = replace(haps, dummy_variant=dummy_variant)
 
         # If any source state changed, rebuild _recon via the factory.
         if "_seqs" in to_evolve or "_tracks" in to_evolve:

--- a/python/genvarloader/_dataset/_query.py
+++ b/python/genvarloader/_dataset/_query.py
@@ -108,7 +108,9 @@ def getitem(
         # Convert any still-flat elements (ragged output_length path) to their
         # public Ragged types before reshape/squeeze apply the existing logic.
         recon = tuple(
-            o.to_ragged() if isinstance(o, (_Flat, _FlatAnnotatedHaps, _FlatVariants)) else o
+            o.to_ragged()
+            if isinstance(o, (_Flat, _FlatAnnotatedHaps, _FlatVariants))
+            else o
             for o in recon
         )
 

--- a/python/genvarloader/_dataset/_query.py
+++ b/python/genvarloader/_dataset/_query.py
@@ -108,7 +108,7 @@ def getitem(
         # Convert any still-flat elements (ragged output_length path) to their
         # public Ragged types before reshape/squeeze apply the existing logic.
         recon = tuple(
-            o.to_ragged() if isinstance(o, (_Flat, _FlatAnnotatedHaps)) else o
+            o.to_ragged() if isinstance(o, (_Flat, _FlatAnnotatedHaps, _FlatVariants)) else o
             for o in recon
         )
 

--- a/skills/genvarloader/SKILL.md
+++ b/skills/genvarloader/SKILL.md
@@ -126,6 +126,8 @@ gvl.Dataset.open(
 
 Without `reference=`, a genotypes-only dataset opens with the **`"variants"`** view by default (yielding `RaggedVariants`) — `Dataset.open(path)` just works, no `with_seqs` needed. The `"haplotypes"`, `"annotated"`, and `"reference"` views all require a reference; requesting one via `with_seqs` on a reference-less dataset raises a clear `ValueError`. `svar=` overrides the recorded SVAR location.
 
+**`with_settings(dummy_variant=...)`** — inserts a `gvl.DummyVariant` into every **empty** `(region, sample, ploid)` variant group so that every group has at least one variant. Only fills groups that are empty; non-empty groups are unchanged. Only valid when the output kind is `"variants"` (set via `with_seqs("variants")`); indexing raises `ValueError` if `dummy_variant` is set and the output kind is not variants (the check is order-independent with `with_seqs`). `False` disables dummy padding; `None` (default) leaves the current setting unchanged. Applies before reverse-complementing, so a non-`b"N"` dummy allele is reverse-complemented on negative-strand regions like any real allele — the default `b"N"` is rc-invariant. Setting `dummy_variant=False` when the output is not variants is a harmless no-op.
+
 **Format validation:** `Dataset.open` validates the dataset's `format_version` and structural integrity (file presence + sizes). An incompatible or corrupt dataset raises a `ValueError` instructing regeneration with `gvl.write`. Datasets do **not** auto-rebuild.
 
 - **`var_fields: list[str] | None`** — Variant fields to include on `RaggedVariants` output. Defaults to the minimum useful set `["alt", "ilen", "start"]`. Pass additional names (e.g. `"ref"`, `"dosage"`, or any numeric info column in the source variants table) to load them eagerly at open time. Must be a subset of `Dataset.available_var_fields`. Can be reconfigured later via `Dataset.with_settings(var_fields=...)`, which lazily loads any newly-requested columns. `"dosage"` must be requested explicitly — it is *not* added automatically even when `dosages.npy` exists on disk.
@@ -265,6 +267,7 @@ Footprint is computed exactly via `Dataset._output_bytes_per_instance(...)` (use
 - `gvl.FlatAnnotatedHaps` — flat analog of `RaggedAnnotatedHaps`: fields `.haps`, `.var_idxs`, `.ref_coords` (each a `FlatRagged`). Methods: `.to_ragged()`, `.to_fixed(length)`, `.to_padded()`, `.reshape(shape)`, `.squeeze(axis)`. Source: `python/genvarloader/_flat.py`.
 - `gvl.FlatVariants` — flat analog of `RaggedVariants`: `.fields` dict mapping field names to `FlatRagged` (scalar fields: `start`/`ilen`/`dosage`/info) or `FlatAlleles` (`alt`/`ref`). `.shape` delegates to `fields["start"].shape`. Methods: `.to_ragged()`, `.reshape(shape)`, `.squeeze(axis)`. Source: `python/genvarloader/_dataset/_flat_variants.py`.
 - `gvl.FlatAlleles` — two-level flat bytestring for allele fields: `.byte_data` (uint8), `.seq_offsets` (per-variant byte offsets, int64), `.var_offsets` (per-(batch×ploidy)-row variant offsets, int64), `.shape`. Methods: `.to_ragged()`, `.reshape(shape)`, `.squeeze(axis)`. Source: `python/genvarloader/_dataset/_flat_variants.py`.
+- `gvl.DummyVariant` — frozen dataclass used with `with_settings(dummy_variant=...)`. Fields and defaults: `start: int = -1`, `ilen: int = 0`, `dosage: float = 0.0`, `ref: bytes = b"N"`, `alt: bytes = b"N"`, `info: dict = {}`. Unspecified `info` keys default to `0` for integer columns and `NaN` for float columns. Source: `python/genvarloader/_dataset/_flat_variants.py`.
 - `gvl.to_nested_tensor(ragged)` — convert to a PyTorch nested tensor (requires `torch`).
 - `gvl.get_dummy_dataset()` — small in-memory dataset for examples/tests.
 - `gvl.RefDataset` — reference-only dataset (no genotypes).
@@ -318,6 +321,8 @@ See `docs/source/format.md` for the full schema, versioning, and SVAR-link detai
 - Missing a `dosage` field on a `RaggedVariants` output you expected? Check `var_fields` — `dosage` must be requested explicitly even if `dosages.npy` exists on disk.
 - `FlatRagged` / `FlatVariants` offsets are **int64**. PyTorch nested tensors require int32 offsets — cast with `.astype(np.int32)` or `tensor.to(torch.int32)` before passing to `torch.nested.narrow`.
 - In `"flat"` mode, tracks and intervals are **not yet flattened** — they still return the same `Ragged`-backed containers as in `"ragged"` mode. Only seqs/haplotypes/annotated-haps/reference and variants outputs are affected.
+- `dummy_variant` padding is **variants-output-only**. Setting `dummy_variant=<DummyVariant>` and then indexing with any other `with_seqs` kind (or no seqs at all) raises `ValueError`. `dummy_variant=False` with a non-variants output is silently ignored.
+- A non-`b"N"` `DummyVariant.alt` (or `.ref`) **is reverse-complemented** on negative-strand regions, exactly like a real variant allele. The default `b"N"` is rc-invariant; use it if you want a strand-neutral sentinel.
 
 ## Maintaining this skill
 

--- a/tests/dataset/test_flat_mode_equivalence.py
+++ b/tests/dataset/test_flat_mode_equivalence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import awkward as ak
+import genvarloader as gvl
 import numpy as np
 import pytest
 from seqpro.rag import Ragged
@@ -111,14 +112,27 @@ def test_a_flat_variants_empty_region_and_ploidy(snap_dataset):
 # Task-B: dummy-fill parity tests
 # ---------------------------------------------------------------------------
 
-import genvarloader as gvl  # noqa: E402 — appended after prior imports
-
 
 @pytest.mark.parametrize("idx", IDX)
 def test_b_dummy_fill_flat_to_ragged_matches_ragged(snap_dataset, idx):
-    dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N", ilen=0)
+    dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N")
     ds = snap_dataset.with_seqs("variants").with_tracks(False).with_settings(dummy_variant=dv)
-    ragged = ds[idx]                                   # ragged mode (flat decode + to_ragged)
+    ragged = ds[idx]  # RaggedVariants (both modes share the flat decode path)
+    rewrapped = ds.with_output_format("flat")[idx].to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+
+
+def test_b_dummy_fill_2d_index_matches_ragged(snap_dataset):
+    # Exercise dummy-fill under a genuine 2-D fancy index (region, sample).
+    # Mirrors test_a_flat_variants_2d_index_matches_ragged but with dummy_variant
+    # applied, so fill_empty_groups is exercised under a multi-dim out_reshape.
+    dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N")
+    ds = snap_dataset.with_seqs("variants").with_tracks(False).with_settings(dummy_variant=dv)
+    n_r, n_s = snap_dataset.shape
+    r = np.arange(min(3, n_r))
+    s = np.arange(min(2, n_s))
+    idx = (r[:, None], s[None, :])  # 2-D (region, sample) fancy index
+    ragged = ds[idx]  # RaggedVariants (both modes share the flat decode path)
     rewrapped = ds.with_output_format("flat")[idx].to_ragged()
     assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
 

--- a/tests/dataset/test_flat_mode_equivalence.py
+++ b/tests/dataset/test_flat_mode_equivalence.py
@@ -116,7 +116,11 @@ def test_a_flat_variants_empty_region_and_ploidy(snap_dataset):
 @pytest.mark.parametrize("idx", IDX)
 def test_b_dummy_fill_flat_to_ragged_matches_ragged(snap_dataset, idx):
     dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N")
-    ds = snap_dataset.with_seqs("variants").with_tracks(False).with_settings(dummy_variant=dv)
+    ds = (
+        snap_dataset.with_seqs("variants")
+        .with_tracks(False)
+        .with_settings(dummy_variant=dv)
+    )
     ragged = ds[idx]  # RaggedVariants (both modes share the flat decode path)
     rewrapped = ds.with_output_format("flat")[idx].to_ragged()
     assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
@@ -127,7 +131,11 @@ def test_b_dummy_fill_2d_index_matches_ragged(snap_dataset):
     # Mirrors test_a_flat_variants_2d_index_matches_ragged but with dummy_variant
     # applied, so fill_empty_groups is exercised under a multi-dim out_reshape.
     dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N")
-    ds = snap_dataset.with_seqs("variants").with_tracks(False).with_settings(dummy_variant=dv)
+    ds = (
+        snap_dataset.with_seqs("variants")
+        .with_tracks(False)
+        .with_settings(dummy_variant=dv)
+    )
     n_r, n_s = snap_dataset.shape
     r = np.arange(min(3, n_r))
     s = np.arange(min(2, n_s))
@@ -139,7 +147,11 @@ def test_b_dummy_fill_2d_index_matches_ragged(snap_dataset):
 
 def test_b_dummy_fill_no_empty_groups(snap_dataset):
     dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N")
-    ds = snap_dataset.with_seqs("variants").with_tracks(False).with_settings(dummy_variant=dv)
+    ds = (
+        snap_dataset.with_seqs("variants")
+        .with_tracks(False)
+        .with_settings(dummy_variant=dv)
+    )
     idx = (np.arange(min(6, snap_dataset.shape[0])),)
     rv = ds[idx]
     for ploid_groups in ak.to_list(rv["start"]):

--- a/tests/dataset/test_flat_mode_equivalence.py
+++ b/tests/dataset/test_flat_mode_equivalence.py
@@ -105,3 +105,29 @@ def test_a_flat_variants_empty_region_and_ploidy(snap_dataset):
     ragged = ds[idx]
     rewrapped = ds.with_output_format("flat")[idx].to_ragged()
     assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+
+
+# ---------------------------------------------------------------------------
+# Task-B: dummy-fill parity tests
+# ---------------------------------------------------------------------------
+
+import genvarloader as gvl  # noqa: E402 — appended after prior imports
+
+
+@pytest.mark.parametrize("idx", IDX)
+def test_b_dummy_fill_flat_to_ragged_matches_ragged(snap_dataset, idx):
+    dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N", ilen=0)
+    ds = snap_dataset.with_seqs("variants").with_tracks(False).with_settings(dummy_variant=dv)
+    ragged = ds[idx]                                   # ragged mode (flat decode + to_ragged)
+    rewrapped = ds.with_output_format("flat")[idx].to_ragged()
+    assert _rv_to_lists(rewrapped) == _rv_to_lists(ragged)
+
+
+def test_b_dummy_fill_no_empty_groups(snap_dataset):
+    dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N")
+    ds = snap_dataset.with_seqs("variants").with_tracks(False).with_settings(dummy_variant=dv)
+    idx = (np.arange(min(6, snap_dataset.shape[0])),)
+    rv = ds[idx]
+    for ploid_groups in ak.to_list(rv["start"]):
+        for g in ploid_groups:
+            assert len(g) >= 1

--- a/tests/dataset/test_no_awkward_in_hotpath.py
+++ b/tests/dataset/test_no_awkward_in_hotpath.py
@@ -243,3 +243,26 @@ def test_variants_ragged_minimal_awkward(monkeypatch, guard_dataset):
         "(to_packed/where/flatten/to_numpy); a removed kernel is still being called. "
         "Note: ak.zip (RaggedVariants record construction) is intentionally NOT patched."
     )
+
+
+def test_flat_variants_dummy_fill_has_no_awkward(monkeypatch, guard_dataset):
+    """Flat variant decode with dummy fill must dispatch zero awkward kernels.
+
+    ``with_settings(dummy_variant=...)`` routes empty (region, sample, ploid) slots
+    through the numba fill kernel in ``get_variants_flat``.  None of the patched
+    awkward kernels (to_numpy, to_packed, flatten, where) should be called.
+    """
+    calls = _install_ak_counters(monkeypatch)
+    ds = (
+        guard_dataset.with_seqs("variants")
+        .with_tracks(False)
+        .with_output_format("flat")
+        .with_settings(dummy_variant=gvl.DummyVariant(start=-1, alt=b"N", ref=b"N"))
+    )
+    n_regions = min(4, ds.shape[0])
+    regions = list(range(n_regions))
+    samples = [i % ds.shape[1] for i in range(n_regions)]
+    _ = ds[regions, samples]
+    assert calls["n"] == 0, (
+        f"flat dummy-fill decode dispatched {calls['n']} awkward kernel(s)"
+    )

--- a/tests/dataset/test_output_format.py
+++ b/tests/dataset/test_output_format.py
@@ -15,3 +15,36 @@ def test_with_output_format_sets_field(snap_dataset):
 def test_with_output_format_rejects_bad_value(snap_dataset):
     with pytest.raises(ValueError):
         snap_dataset.with_output_format("nope")
+
+
+def test_with_settings_dummy_variant_sets_field(snap_dataset):
+    import genvarloader as gvl
+
+    ds = snap_dataset.with_seqs("variants").with_tracks(False)
+    dv = gvl.DummyVariant(start=-1, alt=b"N", ref=b"N")
+    ds2 = ds.with_settings(dummy_variant=dv)
+    assert ds2._seqs.dummy_variant == dv
+    # original unchanged
+    assert ds._seqs.dummy_variant is None
+    # disable with False
+    ds3 = ds2.with_settings(dummy_variant=False)
+    assert ds3._seqs.dummy_variant is None
+
+
+def test_dummy_variant_rejected_on_non_variant_kind(snap_dataset):
+    import genvarloader as gvl
+
+    ds = snap_dataset.with_seqs("haplotypes").with_settings(
+        dummy_variant=gvl.DummyVariant()
+    )
+    # guard fires at access time when the output kind is not variants
+    with pytest.raises(ValueError):
+        _ = ds[0]
+
+
+def test_dummy_variant_export():
+    import genvarloader as gvl
+
+    from genvarloader._dataset._flat_variants import DummyVariant
+
+    assert gvl.DummyVariant is DummyVariant

--- a/tests/dataset/test_output_format.py
+++ b/tests/dataset/test_output_format.py
@@ -42,6 +42,22 @@ def test_dummy_variant_rejected_on_non_variant_kind(snap_dataset):
         _ = ds[0]
 
 
+def test_with_settings_dummy_variant_false_noop_on_non_variant(snap_dataset):
+    # disabling (False) on a ref-only dataset (Ref _seqs, not Haps) must be a
+    # harmless no-op — it previously raised ValueError spuriously.
+    # snap_dataset has a reference, so with_seqs("reference") gives a Ref _seqs.
+    ds = snap_dataset.with_seqs("reference").with_tracks(False)
+    # should NOT raise
+    ds2 = ds.with_settings(dummy_variant=False)
+    assert ds2 is not None
+    # Also confirm idempotent clear on a variants dataset that never had dummy_variant set:
+    # calling False on a Haps dataset with no prior dummy_variant leaves it None.
+    ds_haps = snap_dataset.with_seqs("variants").with_tracks(False)
+    assert ds_haps._seqs.dummy_variant is None
+    ds_haps2 = ds_haps.with_settings(dummy_variant=False)
+    assert ds_haps2._seqs.dummy_variant is None
+
+
 def test_dummy_variant_export():
     import genvarloader as gvl
 

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -184,19 +184,23 @@ def test_fill_empty_seq_kernel():
 
     # 3 rows: empty, ["AC","G"], empty
     data = np.frombuffer(b"ACG", np.uint8).copy()
-    var_off = np.array([0, 0, 2, 2], np.int64)      # per-row variant boundaries
-    seq_off = np.array([0, 2, 3], np.int64)         # per-variant byte boundaries
+    var_off = np.array([0, 0, 2, 2], np.int64)  # per-row variant boundaries
+    seq_off = np.array([0, 2, 3], np.int64)  # per-variant byte boundaries
     dummy = np.frombuffer(b"N", np.uint8).copy()
     nd, nvar, nseq = _fill_empty_seq(data, var_off, seq_off, dummy)
-    assert nvar.tolist() == [0, 1, 3, 4]            # each empty row gains 1 variant
-    assert nseq.tolist() == [0, 1, 3, 4, 5]         # dummy(1) AC(2) G(1) dummy(1)
+    assert nvar.tolist() == [0, 1, 3, 4]  # each empty row gains 1 variant
+    assert nseq.tolist() == [0, 1, 3, 4, 5]  # dummy(1) AC(2) G(1) dummy(1)
     assert bytes(nd) == b"NACGN"
 
 
 def test_fill_empty_groups_roundtrip():
     import awkward as ak
 
-    from genvarloader._dataset._flat_variants import DummyVariant, _FlatAlleles, _FlatVariants
+    from genvarloader._dataset._flat_variants import (
+        DummyVariant,
+        _FlatAlleles,
+        _FlatVariants,
+    )
     from genvarloader._flat import _Flat
 
     # b*p = 3 rows: row0 empty, row1 has [b"AC", b"G"], row2 empty
@@ -222,12 +226,20 @@ def test_fill_empty_groups_roundtrip():
 def test_fill_empty_groups_noop_when_no_empties():
     import awkward as ak
 
-    from genvarloader._dataset._flat_variants import DummyVariant, _FlatAlleles, _FlatVariants
+    from genvarloader._dataset._flat_variants import (
+        DummyVariant,
+        _FlatAlleles,
+        _FlatVariants,
+    )
     from genvarloader._flat import _Flat
 
     group_off = np.array([0, 1, 2], np.int64)  # every row has 1 variant
-    alt = _FlatAlleles(np.frombuffer(b"AG", np.uint8).copy(),
-                       np.array([0, 1, 2], np.int64), group_off.copy(), (2, None))
+    alt = _FlatAlleles(
+        np.frombuffer(b"AG", np.uint8).copy(),
+        np.array([0, 1, 2], np.int64),
+        group_off.copy(),
+        (2, None),
+    )
     start = _Flat.from_offsets(np.array([3, 7], np.int32), (2, None), group_off.copy())
     ilen = _Flat.from_offsets(np.array([0, 0], np.int32), (2, None), group_off.copy())
     fv = _FlatVariants(fields={"alt": alt, "start": start, "ilen": ilen})
@@ -267,7 +279,7 @@ def test_gather_rows_1d_vs_2d_dispatch():
 
     # Build equivalent 2D (2, n) starts/stops
     starts = offsets_1d[:-1]  # [0, 2, 2, 5]
-    stops = offsets_1d[1:]    # [2, 2, 5, 6]
+    stops = offsets_1d[1:]  # [2, 2, 5, 6]
     offsets_2d = np.stack([starts, stops])  # shape (2, 4)
 
     geno_offset_idx = np.array([2, 0, 3], np.intp)
@@ -279,12 +291,16 @@ def test_gather_rows_1d_vs_2d_dispatch():
     # 1D path
     v_1d, off_1d = _gather_rows(geno_offset_idx, offsets_1d, geno_v_idxs)
     np.testing.assert_array_equal(v_1d, expected_v_idxs, err_msg="1D v_idxs mismatch")
-    np.testing.assert_array_equal(off_1d, expected_offsets, err_msg="1D offsets mismatch")
+    np.testing.assert_array_equal(
+        off_1d, expected_offsets, err_msg="1D offsets mismatch"
+    )
 
     # 2D path
     v_2d, off_2d = _gather_rows(geno_offset_idx, offsets_2d, geno_v_idxs)
     np.testing.assert_array_equal(v_2d, expected_v_idxs, err_msg="2D v_idxs mismatch")
-    np.testing.assert_array_equal(off_2d, expected_offsets, err_msg="2D offsets mismatch")
+    np.testing.assert_array_equal(
+        off_2d, expected_offsets, err_msg="2D offsets mismatch"
+    )
 
     # 1D and 2D must agree with each other
     np.testing.assert_array_equal(v_1d, v_2d, err_msg="1D and 2D v_idxs disagree")
@@ -294,8 +310,12 @@ def test_gather_rows_1d_vs_2d_dispatch():
     v_ss, off_ss = _gather_v_idxs_ss(
         geno_offset_idx, offsets_2d[0], offsets_2d[1], geno_v_idxs
     )
-    np.testing.assert_array_equal(v_ss, expected_v_idxs, err_msg="_gather_v_idxs_ss v_idxs mismatch")
-    np.testing.assert_array_equal(off_ss, expected_offsets, err_msg="_gather_v_idxs_ss offsets mismatch")
+    np.testing.assert_array_equal(
+        v_ss, expected_v_idxs, err_msg="_gather_v_idxs_ss v_idxs mismatch"
+    )
+    np.testing.assert_array_equal(
+        off_ss, expected_offsets, err_msg="_gather_v_idxs_ss offsets mismatch"
+    )
 
 
 def test_get_variants_flat_fills_empty_groups():

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -236,6 +236,68 @@ def test_fill_empty_groups_noop_when_no_empties():
     assert ak.to_list(filled.to_ragged()["start"]) == [[3], [7]]
 
 
+def test_gather_rows_1d_vs_2d_dispatch():
+    """_gather_rows dispatches correctly for both 1D contiguous offsets and 2D
+    starts/stops. Both representations of the same logical ragged layout must
+    produce identical gathered results, and the result must match the expected
+    hand-computed values.
+
+    Layout: 4 rows with variant-index counts [2, 0, 3, 1].
+    geno_v_idxs = [10, 11,   20, 21, 22,   30]
+    contiguous offsets (1D): [0, 2, 2, 5, 6]   (length n_rows + 1)
+    starts/stops (2D):
+      starts = [0, 2, 2, 5]
+      stops  = [2, 2, 5, 6]
+
+    geno_offset_idx selects rows [2, 0, 3] (reorder, skip row 1).
+    Expected gather:
+      row 2: variants [20, 21, 22]
+      row 0: variants [10, 11]
+      row 3: variants [30]
+    => v_idxs  = [20, 21, 22, 10, 11, 30]
+    => offsets = [0, 3, 5, 6]
+    """
+    from genvarloader._dataset._flat_variants import (
+        _gather_rows,
+        _gather_v_idxs_ss,
+    )
+
+    geno_v_idxs = np.array([10, 11, 20, 21, 22, 30], np.int32)
+    offsets_1d = np.array([0, 2, 2, 5, 6], np.int64)
+
+    # Build equivalent 2D (2, n) starts/stops
+    starts = offsets_1d[:-1]  # [0, 2, 2, 5]
+    stops = offsets_1d[1:]    # [2, 2, 5, 6]
+    offsets_2d = np.stack([starts, stops])  # shape (2, 4)
+
+    geno_offset_idx = np.array([2, 0, 3], np.intp)
+
+    # Expected golden values
+    expected_v_idxs = np.array([20, 21, 22, 10, 11, 30], np.int32)
+    expected_offsets = np.array([0, 3, 5, 6], np.int64)
+
+    # 1D path
+    v_1d, off_1d = _gather_rows(geno_offset_idx, offsets_1d, geno_v_idxs)
+    np.testing.assert_array_equal(v_1d, expected_v_idxs, err_msg="1D v_idxs mismatch")
+    np.testing.assert_array_equal(off_1d, expected_offsets, err_msg="1D offsets mismatch")
+
+    # 2D path
+    v_2d, off_2d = _gather_rows(geno_offset_idx, offsets_2d, geno_v_idxs)
+    np.testing.assert_array_equal(v_2d, expected_v_idxs, err_msg="2D v_idxs mismatch")
+    np.testing.assert_array_equal(off_2d, expected_offsets, err_msg="2D offsets mismatch")
+
+    # 1D and 2D must agree with each other
+    np.testing.assert_array_equal(v_1d, v_2d, err_msg="1D and 2D v_idxs disagree")
+    np.testing.assert_array_equal(off_1d, off_2d, err_msg="1D and 2D offsets disagree")
+
+    # Also test _gather_v_idxs_ss directly against the golden value
+    v_ss, off_ss = _gather_v_idxs_ss(
+        geno_offset_idx, offsets_2d[0], offsets_2d[1], geno_v_idxs
+    )
+    np.testing.assert_array_equal(v_ss, expected_v_idxs, err_msg="_gather_v_idxs_ss v_idxs mismatch")
+    np.testing.assert_array_equal(off_ss, expected_offsets, err_msg="_gather_v_idxs_ss offsets mismatch")
+
+
 def test_get_variants_flat_fills_empty_groups():
     """get_variants_flat with haps.dummy_variant set fills empty (b*p) groups.
 

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -215,6 +215,8 @@ def test_fill_empty_groups_roundtrip():
     # empty rows now hold exactly the dummy; non-empty row unchanged
     assert ak.to_list(rv["alt"]) == [[b"N"], [b"AC", b"G"], [b"N"]]
     assert ak.to_list(rv["start"]) == [[-1], [5, 9], [-1]]
+    # ilen: empty rows get DummyVariant default (ilen=0); non-empty row keeps original values
+    assert ak.to_list(rv["ilen"]) == [[0], [1, -1], [0]]
 
 
 def test_fill_empty_groups_noop_when_no_empties():

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -299,8 +299,8 @@ def test_get_variants_flat_fills_empty_groups():
     # Without dummy: some groups are empty
     plain = get_variants_flat(haps, idx).to_ragged()
     plain_starts = ak.to_list(plain["start"])
-    # shape is (b=2, p=1, ~v): plain_starts = [[[10], []], [[20, 30], []]]
-    # row [0][0] has 1 variant, row [0][1] is empty, etc.
+    # shape is (b=4, p=1, ~v): plain_starts = [[[10]], [[]], [[20, 30]], [[]]]
+    # idx covers 4 (region, sample) combos; each outer row has p=1 ploidy group.
     assert any(len(g) == 0 for row in plain_starts for g in row)
 
     # With dummy: every group has >= 1 variant

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -234,3 +234,88 @@ def test_fill_empty_groups_noop_when_no_empties():
     filled = fv.fill_empty_groups(DummyVariant())
     assert ak.to_list(filled.to_ragged()["alt"]) == [[b"A"], [b"G"]]
     assert ak.to_list(filled.to_ragged()["start"]) == [[3], [7]]
+
+
+def test_get_variants_flat_fills_empty_groups():
+    """get_variants_flat with haps.dummy_variant set fills empty (b*p) groups.
+
+    NOTE: snap_dataset fixture is NOT visible from tests/unit/dataset/ (it lives
+    in tests/dataset/conftest.py, a sibling not a parent). Per plan fallback,
+    this test builds a minimal synthetic Haps with controlled empty groups.
+    Full integration coverage is deferred to Task 5.
+    """
+    import awkward as ak
+    from dataclasses import replace
+    from pathlib import Path
+
+    from genoray._types import POS_TYPE, V_IDX_TYPE
+    from seqpro.rag import Ragged
+
+    from genvarloader._dataset._flat_variants import DummyVariant, get_variants_flat
+    from genvarloader._dataset._haps import Haps, _Variants
+    from genvarloader._dataset._rag_variants import RaggedVariants
+    from genvarloader._variants._records import RaggedAlleles
+
+    # Build a minimal _Variants: 3 variants with ALT = [b"A", b"C", b"G"]
+    alt_bytes = np.frombuffer(b"ACG", np.uint8).copy().view("S1")
+    alt_offsets = np.array([0, 1, 2, 3], np.int64)
+    alt_ra = RaggedAlleles.from_offsets(alt_bytes, (3, None), alt_offsets)
+    variants = _Variants(
+        path=Path("dummy"),
+        start=np.array([10, 20, 30], POS_TYPE),
+        ilen=np.array([0, 1, -1], np.int32),
+        ref=None,
+        alt=alt_ra,
+        info={},
+    )
+
+    # Build genotypes: b=2 regions, s=2 samples, p=1 ploidy
+    # Layout (r=2, s=2, p=1, ~v):
+    #   [r0,s0,p0]: variant 0      (non-empty)
+    #   [r0,s1,p0]: empty          (empty group)
+    #   [r1,s0,p0]: variants 1,2   (non-empty)
+    #   [r1,s1,p0]: empty          (empty group)
+    v_idxs = np.array([0, 1, 2], V_IDX_TYPE)
+    # offsets for 4 rows: [1, 0, 2, 0] variants → cumsum → [0, 1, 1, 3, 3]
+    offsets = np.array([0, 1, 1, 3, 3], np.int64)
+    genotypes = Ragged.from_offsets(v_idxs, (2, 2, 1, None), offsets)
+
+    haps = Haps(
+        path=Path("dummy"),
+        reference=None,
+        variants=variants,
+        genotypes=genotypes,
+        dosages=None,
+        kind=RaggedVariants,
+        filter=None,
+        min_af=None,
+        max_af=None,
+        var_fields=["alt", "ilen", "start"],
+    )
+
+    # idx covers all b*s = 4 region/sample combos
+    idx = np.arange(4, dtype=np.intp)
+
+    # Without dummy: some groups are empty
+    plain = get_variants_flat(haps, idx).to_ragged()
+    plain_starts = ak.to_list(plain["start"])
+    # shape is (b=2, p=1, ~v): plain_starts = [[[10], []], [[20, 30], []]]
+    # row [0][0] has 1 variant, row [0][1] is empty, etc.
+    assert any(len(g) == 0 for row in plain_starts for g in row)
+
+    # With dummy: every group has >= 1 variant
+    haps_d = replace(haps, dummy_variant=DummyVariant(start=-1, alt=b"N", ref=b"N"))
+    filled = get_variants_flat(haps_d, idx).to_ragged()
+
+    filled_starts = ak.to_list(filled["start"])
+    for row in filled_starts:
+        for g in row:
+            assert len(g) >= 1, f"empty group found after fill: {filled_starts}"
+
+    # Non-empty groups are unchanged vs plain
+    for pr, fr in zip(plain_starts, filled_starts):
+        for pg, fg in zip(pr, fr):
+            if len(pg) > 0:
+                assert fg == pg, f"non-empty group changed: {pg} -> {fg}"
+            else:
+                assert fg == [-1], f"empty group not filled with dummy start=-1: {fg}"

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -167,3 +167,68 @@ def test_public_flat_exports():
     assert gvl.FlatAnnotatedHaps is _FlatAnnotatedHaps
     assert gvl.FlatVariants is _FlatVariants
     assert gvl.FlatAlleles is _FlatAlleles
+
+
+def test_fill_empty_scalar_kernel():
+    from genvarloader._dataset._flat_variants import _fill_empty_scalar
+
+    data = np.array([10, 11, 20], np.int32)
+    offsets = np.array([0, 0, 2, 2, 3], np.int64)  # rows: empty, [10,11], empty, [20]
+    new_data, new_off = _fill_empty_scalar(data, offsets, np.int32(-1))
+    assert new_off.tolist() == [0, 1, 3, 4, 5]
+    assert new_data.tolist() == [-1, 10, 11, -1, 20]
+
+
+def test_fill_empty_seq_kernel():
+    from genvarloader._dataset._flat_variants import _fill_empty_seq
+
+    # 3 rows: empty, ["AC","G"], empty
+    data = np.frombuffer(b"ACG", np.uint8).copy()
+    var_off = np.array([0, 0, 2, 2], np.int64)      # per-row variant boundaries
+    seq_off = np.array([0, 2, 3], np.int64)         # per-variant byte boundaries
+    dummy = np.frombuffer(b"N", np.uint8).copy()
+    nd, nvar, nseq = _fill_empty_seq(data, var_off, seq_off, dummy)
+    assert nvar.tolist() == [0, 1, 3, 4]            # each empty row gains 1 variant
+    assert nseq.tolist() == [0, 1, 3, 4, 5]         # dummy(1) AC(2) G(1) dummy(1)
+    assert bytes(nd) == b"NACGN"
+
+
+def test_fill_empty_groups_roundtrip():
+    import awkward as ak
+
+    from genvarloader._dataset._flat_variants import DummyVariant, _FlatAlleles, _FlatVariants
+    from genvarloader._flat import _Flat
+
+    # b*p = 3 rows: row0 empty, row1 has [b"AC", b"G"], row2 empty
+    group_off = np.array([0, 0, 2, 2], np.int64)
+    alt = _FlatAlleles(
+        byte_data=np.frombuffer(b"ACG", np.uint8).copy(),
+        seq_offsets=np.array([0, 2, 3], np.int64),
+        var_offsets=group_off.copy(),
+        shape=(3, None),
+    )
+    start = _Flat.from_offsets(np.array([5, 9], np.int32), (3, None), group_off.copy())
+    ilen = _Flat.from_offsets(np.array([1, -1], np.int32), (3, None), group_off.copy())
+    fv = _FlatVariants(fields={"alt": alt, "start": start, "ilen": ilen})
+    filled = fv.fill_empty_groups(DummyVariant(start=-1, alt=b"N"))
+    rv = filled.to_ragged()
+    # empty rows now hold exactly the dummy; non-empty row unchanged
+    assert ak.to_list(rv["alt"]) == [[b"N"], [b"AC", b"G"], [b"N"]]
+    assert ak.to_list(rv["start"]) == [[-1], [5, 9], [-1]]
+
+
+def test_fill_empty_groups_noop_when_no_empties():
+    import awkward as ak
+
+    from genvarloader._dataset._flat_variants import DummyVariant, _FlatAlleles, _FlatVariants
+    from genvarloader._flat import _Flat
+
+    group_off = np.array([0, 1, 2], np.int64)  # every row has 1 variant
+    alt = _FlatAlleles(np.frombuffer(b"AG", np.uint8).copy(),
+                       np.array([0, 1, 2], np.int64), group_off.copy(), (2, None))
+    start = _Flat.from_offsets(np.array([3, 7], np.int32), (2, None), group_off.copy())
+    ilen = _Flat.from_offsets(np.array([0, 0], np.int32), (2, None), group_off.copy())
+    fv = _FlatVariants(fields={"alt": alt, "start": start, "ilen": ilen})
+    filled = fv.fill_empty_groups(DummyVariant())
+    assert ak.to_list(filled.to_ragged()["alt"]) == [[b"A"], [b"G"]]
+    assert ak.to_list(filled.to_ragged()["start"]) == [[3], [7]]

--- a/tests/unit/dataset/test_haps_allele_bytes.py
+++ b/tests/unit/dataset/test_haps_allele_bytes.py
@@ -18,9 +18,9 @@ def ds():
 def _expected_bytes(haps, idx, kind):
     """Ground-truth: sum byte lengths of allele strings per (instance, ploid).
 
-    Uses _get_variants (a completely different code path from _allele_bytes_sum)
-    to materialise the RaggedVariants record, then sums allele byte lengths via
-    awkward's ak.num.
+    Uses get_variants_flat (the canonical decode path) to materialise a
+    _FlatVariants record, converts to RaggedVariants via to_ragged(), then sums
+    allele byte lengths via awkward's ak.num.
 
     The field type is ``b * p * var * bytes`` (four dimensions).  Awkward's
     ``bytes`` type is special: ``axis=-1`` does NOT reach into byte content;
@@ -30,7 +30,10 @@ def _expected_bytes(haps, idx, kind):
     """
     import awkward as ak
 
-    ragv = haps._get_variants(idx)
+    from genvarloader._dataset._flat_variants import get_variants_flat
+
+    flat_v = get_variants_flat(haps, idx)
+    ragv = flat_v.to_ragged()
     field = getattr(ragv, kind)  # type: b * p * ~v * bytes
     # axis=3: byte length of each allele string → shape (b, p, ~v)
     # axis=2: sum across variants per (b, p) → shape (b, p)


### PR DESCRIPTION
## Summary

**B1 — always-flat variant decode (refactor).** `get_variants_flat` is now the single variant decode path. The awkward-based helpers `_get_variants`/`_get_alleles`/`_get_info` in `_haps.py` are retired; ragged-mode variant output decodes flat and converts at the `_query.py` boundary via `_FlatVariants.to_ragged()`. A latent diploid bug surfaced and was fixed: `Ragged.offsets` returns a `(2, n)` starts/stops array for ploidy>1 (the old path masked it via `.to_packed()`), so `_gather_v_idxs_ss` + a `_gather_rows` dispatcher were added, matching the existing 1D/2D dispatch convention in `_genotypes.py`.

**B2 — optional empty-group dummy-variant fill (feature).** New `gvl.DummyVariant` lets you insert one dummy variant into each **empty** `(region, sample, ploid)` group so every group has ≥1 variant (non-empty groups are unchanged). Implemented via numba kernels `_fill_empty_scalar`/`_fill_empty_seq` and `_FlatVariants.fill_empty_groups`, applied as the final step of `get_variants_flat`. Configured with `Dataset.with_settings(dummy_variant=...)` (`False` disables, `None` is the default); exported as `gvl.DummyVariant`. Only valid for the variants output — indexing raises `ValueError` if set with another output kind (validated at access time, order-independent with `with_seqs`). Works byte-identically in flat and ragged modes. The fill runs before reverse-complement, so a non-`N` dummy allele is rc'd on negative-strand regions like any allele (default `b"N"` is rc-invariant).

The retired-path regression oracle (`tests/dataset/_snapshots/variants_ragged.npz`) is unchanged.

## Test Plan
- [x] Snapshot regression for the retired awkward path stays green (`test_flat_getitem_snapshot.py`, oracle not regenerated)
- [x] Flat↔ragged parity of the dummy fill across scalar/1-D/2-D index shapes (`test_flat_mode_equivalence.py`)
- [x] Golden unit tests for `_fill_empty_scalar`/`_fill_empty_seq`/`fill_empty_groups` + 1D/2D `_gather_rows` dispatch (`test_flat_variants_type.py`)
- [x] No-awkward-in-hotpath guard for the dummy-fill path (`test_no_awkward_in_hotpath.py`)
- [x] Public API: `with_settings(dummy_variant=...)` set/disable/no-op, non-variant guard, export (`test_output_format.py`)
- [x] Full non-slow suite: 666 passed, 35 skipped, 4 xfailed, 0 failures
- [x] `skills/genvarloader/SKILL.md` updated for the new public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)