### PR TITLE
perf: eliminate ref-fetch parallel overhead + fuse variant-window fetches (#221)

### DIFF
--- a/python/genvarloader/__init__.py
+++ b/python/genvarloader/__init__.py
@@ -1,4 +1,9 @@
+# ruff: noqa: E402  cap_numba_threads() must run before any numba kernel imports
 import importlib.metadata
+
+from ._threads import cap_numba_threads
+
+cap_numba_threads()
 
 from seqpro.bed import read as read_bedlike
 from seqpro.bed import with_len as with_length

--- a/python/genvarloader/_dataset/_flat_flanks.py
+++ b/python/genvarloader/_dataset/_flat_flanks.py
@@ -27,6 +27,20 @@ def build_token_lut(alphabet: bytes, unknown_token: int) -> tuple[NDArray, np.dt
     return lut, np.dtype(dtype)
 
 
+def _slice_flanks(data: NDArray[np.uint8], rw_off: NDArray[np.int64], flank_len: int):
+    """Derive per-variant (f5, f3) flanks from a contiguous ref-window read
+    ``rw = [start-L, end+L)``. ``f5`` = first ``L`` bytes of each row, ``f3`` =
+    last ``L``. Byte-identical to fetching ``[start-L, start)`` / ``[end, end+L)``
+    separately: rows are always ``ref_len + 2L >= 2L + 1`` long so the two
+    fixed-``L`` windows never overlap, and ``padded_slice`` pads OOB by absolute
+    coordinate so boundary padding matches. Both returned arrays are ``(n, L)``.
+    """
+    cols = np.arange(flank_len)
+    f5 = data[rw_off[:-1, None] + cols]
+    f3 = data[rw_off[1:, None] - flank_len + cols]
+    return f5, f3
+
+
 def compute_flank_tokens(
     reference,
     v_contigs: NDArray[np.integer],  # (n_var,) contig id per variant
@@ -57,11 +71,10 @@ def compute_flank_tokens(
     starts = np.asarray(starts, np.int32)
     ilens = np.asarray(ilens, np.int32)
     ends = starts - np.minimum(ilens, 0) + 1
-    f5 = reference.fetch(v_contigs, starts - flank_len, starts).data.view(np.uint8)
-    f3 = reference.fetch(v_contigs, ends, ends + flank_len).data.view(np.uint8)
-    n = starts.shape[0]
-    f5 = f5.reshape(n, flank_len)
-    f3 = f3.reshape(n, flank_len)
+    rw = reference.fetch(v_contigs, starts - flank_len, ends + flank_len)
+    f5, f3 = _slice_flanks(
+        rw.data.view(np.uint8), np.asarray(rw.offsets, np.int64), flank_len
+    )  # each (n, L)
     flank_bytes = np.concatenate([f5, f3], axis=1)  # (n, 2L)
     tokens = lut[flank_bytes]  # vectorized 256-LUT gather -> lut.dtype
     return tokens.reshape(-1), np.asarray(row_offsets, np.int64)
@@ -130,11 +143,13 @@ def compute_alt_window(
     starts = np.asarray(starts, np.int32)
     ilens = np.asarray(ilens, np.int32)
     ends = starts - np.minimum(ilens, 0) + 1
-    f5 = reference.fetch(v_contigs, starts - flank_len, starts).data.view(np.uint8)
-    f3 = reference.fetch(v_contigs, ends, ends + flank_len).data.view(np.uint8)
+    rw = reference.fetch(v_contigs, starts - flank_len, ends + flank_len)
+    f5, f3 = _slice_flanks(
+        rw.data.view(np.uint8), np.asarray(rw.offsets, np.int64), flank_len
+    )  # each (n, L)
     alt_bytes, alt_off = _assemble_alt_windows(
-        np.ascontiguousarray(f5),
-        np.ascontiguousarray(f3),
+        np.ascontiguousarray(f5).reshape(-1),
+        np.ascontiguousarray(f3).reshape(-1),
         np.asarray(alt_data, np.uint8),
         np.asarray(alt_seq_off, np.int64),
         flank_len,
@@ -175,22 +190,32 @@ def compute_windows(
     flank_len: int,
     lut: NDArray,
     row_offsets: NDArray[np.int64],
-) -> tuple[_FlatWindow, _FlatWindow]:
+) -> tuple["_FlatWindow", "_FlatWindow"]:
     """ref_window = [start-L, end+L) read; alt_window = flank5 . alt . flank3.
-    Thin wrapper over compute_ref_window / compute_alt_window."""
-    return (
-        compute_ref_window(
-            reference, v_contigs, starts, ilens, flank_len, lut, row_offsets
-        ),
-        compute_alt_window(
-            reference,
-            v_contigs,
-            starts,
-            ilens,
-            alt_data,
-            alt_seq_off,
-            flank_len,
-            lut,
-            row_offsets,
-        ),
+
+    Single fused fetch: read the ref window once and derive the alt-window flanks
+    by slicing it, instead of the previous 3 separate ``reference.fetch`` calls.
+    Byte-identical to ``(compute_ref_window, compute_alt_window)``.
+    """
+    starts = np.asarray(starts, np.int32)
+    ilens = np.asarray(ilens, np.int32)
+    ends = starts - np.minimum(ilens, 0) + 1
+    rw = reference.fetch(v_contigs, starts - flank_len, ends + flank_len)
+    data = rw.data.view(np.uint8)
+    rw_off = np.asarray(rw.offsets, np.int64)
+    row_off = np.asarray(row_offsets, np.int64)
+
+    # ref window: tokenize the contiguous read directly.
+    ref_w = _FlatWindow(lut[data], rw_off, row_off, (None,))
+
+    # alt window: flank5 . alt . flank3 from sliced flanks.
+    f5, f3 = _slice_flanks(data, rw_off, flank_len)
+    alt_bytes, alt_off = _assemble_alt_windows(
+        np.ascontiguousarray(f5).reshape(-1),
+        np.ascontiguousarray(f3).reshape(-1),
+        np.asarray(alt_data, np.uint8),
+        np.asarray(alt_seq_off, np.int64),
+        flank_len,
     )
+    alt_w = _FlatWindow(lut[alt_bytes], alt_off, row_off, (None,))
+    return ref_w, alt_w

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -762,6 +762,7 @@ def get_variants_flat(
         from ._flat_flanks import (
             compute_alt_window,
             compute_ref_window,
+            compute_windows,
             tokenize_alleles,
         )
 
@@ -776,22 +777,9 @@ def get_variants_flat(
         wfields = {k: v for k, v in fields.items() if k not in ("alt", "ref")}
         win = _FlatVariantWindows(wfields)
 
-        if opt.ref == "window":
-            rw = compute_ref_window(
-                haps.reference, v_contigs, starts_v, ilens_v, L, lut, row_offsets
-            )
-            rw.shape = wshape
-            win.ref_window = rw
-        else:  # "allele": bare tokenized ref allele
-            ref_bytes = np.asarray(haps.variants.ref.data).view(np.uint8)
-            ref_off = np.asarray(haps.variants.ref.offsets, np.int64)
-            ref_data, ref_seq_off = _gather_alleles(v_idxs, ref_bytes, ref_off)
-            rw = tokenize_alleles(ref_data, ref_seq_off, lut, row_offsets)
-            rw.shape = wshape
-            win.ref = rw
-
-        if opt.alt == "window":
-            aw = compute_alt_window(
+        if opt.ref == "window" and opt.alt == "window":
+            # Hot path: single fused fetch produces both windows.
+            rw, aw = compute_windows(
                 haps.reference,
                 v_contigs,
                 starts_v,
@@ -802,12 +790,43 @@ def get_variants_flat(
                 lut,
                 row_offsets,
             )
+            rw.shape = wshape
             aw.shape = wshape
+            win.ref_window = rw
             win.alt_window = aw
-        else:  # "allele": bare tokenized alt allele
-            aw = tokenize_alleles(alt_data, alt_seq_off, lut, row_offsets)
-            aw.shape = wshape
-            win.alt = aw
+        else:
+            if opt.ref == "window":
+                rw = compute_ref_window(
+                    haps.reference, v_contigs, starts_v, ilens_v, L, lut, row_offsets
+                )
+                rw.shape = wshape
+                win.ref_window = rw
+            else:  # "allele": bare tokenized ref allele
+                ref_bytes = np.asarray(haps.variants.ref.data).view(np.uint8)
+                ref_off = np.asarray(haps.variants.ref.offsets, np.int64)
+                ref_data, ref_seq_off = _gather_alleles(v_idxs, ref_bytes, ref_off)
+                rw = tokenize_alleles(ref_data, ref_seq_off, lut, row_offsets)
+                rw.shape = wshape
+                win.ref = rw
+
+            if opt.alt == "window":
+                aw = compute_alt_window(
+                    haps.reference,
+                    v_contigs,
+                    starts_v,
+                    ilens_v,
+                    alt_data,
+                    alt_seq_off,
+                    L,
+                    lut,
+                    row_offsets,
+                )
+                aw.shape = wshape
+                win.alt_window = aw
+            else:  # "allele": bare tokenized alt allele
+                aw = tokenize_alleles(alt_data, alt_seq_off, lut, row_offsets)
+                aw.shape = wshape
+                win.alt = aw
 
         if haps.dummy_variant is not None:
             win = win.fill_empty_groups(

--- a/python/genvarloader/_dataset/_reference.py
+++ b/python/genvarloader/_dataset/_reference.py
@@ -24,6 +24,7 @@ from .._utils import is_dtype
 from ._indexing import is_str_arr, s2i
 from ._splice import SpliceMap, SplicePlan, build_splice_plan
 from ._utils import bed_to_regions, padded_slice
+from .._threads import should_parallelize
 
 INT64_MAX = np.iinfo(np.int64).max
 
@@ -131,7 +132,12 @@ class Reference:
         lengths = ends - starts
         offsets = lengths_to_offsets(lengths)
         seqs = np.empty(offsets[-1], np.uint8)
-        _fetch_impl(
+        kernel = (
+            _fetch_impl_par
+            if should_parallelize(int(offsets[-1]))
+            else _fetch_impl_ser
+        )
+        kernel(
             c_idxs,
             starts,
             ends,
@@ -147,21 +153,34 @@ class Reference:
         return seqs
 
 
+@nb.njit(nogil=True, cache=True, inline="always")
+def _fetch_row(
+    i, c_idxs, starts, ends, reference, ref_offsets, pad_char, out, out_offsets
+):
+    r_s, r_e = ref_offsets[c_idxs[i]], ref_offsets[c_idxs[i] + 1]
+    o_s, o_e = out_offsets[i], out_offsets[i + 1]
+    padded_slice(reference[r_s:r_e], starts[i], ends[i], pad_char, out[o_s:o_e])
+
+
 @nb.njit(parallel=True, nogil=True, cache=True)
-def _fetch_impl(
-    c_idxs: NDArray[np.integer],
-    starts: NDArray[np.integer],
-    ends: NDArray[np.integer],
-    reference: NDArray[np.integer],
-    ref_offsets: NDArray[np.integer],
-    pad_char: int,
-    out: NDArray[np.uint8],
-    out_offsets: NDArray[np.integer],
+def _fetch_impl_par(
+    c_idxs, starts, ends, reference, ref_offsets, pad_char, out, out_offsets
 ):
     for i in nb.prange(len(c_idxs)):
-        r_s, r_e = ref_offsets[c_idxs[i]], ref_offsets[c_idxs[i] + 1]
-        o_s, o_e = out_offsets[i], out_offsets[i + 1]
-        padded_slice(reference[r_s:r_e], starts[i], ends[i], pad_char, out[o_s:o_e])
+        _fetch_row(
+            i, c_idxs, starts, ends, reference, ref_offsets, pad_char, out, out_offsets
+        )
+    return out
+
+
+@nb.njit(nogil=True, cache=True)
+def _fetch_impl_ser(
+    c_idxs, starts, ends, reference, ref_offsets, pad_char, out, out_offsets
+):
+    for i in range(len(c_idxs)):
+        _fetch_row(
+            i, c_idxs, starts, ends, reference, ref_offsets, pad_char, out, out_offsets
+        )
     return out
 
 

--- a/python/genvarloader/_dataset/_reference.py
+++ b/python/genvarloader/_dataset/_reference.py
@@ -685,7 +685,29 @@ class RefDataset(Generic[T]):
         )
 
 
+@nb.njit(nogil=True, cache=True, inline="always")
+def _get_reference_row(i, regions, out_offsets, reference, ref_offsets, pad_char, out):
+    o_s, o_e = out_offsets[i], out_offsets[i + 1]
+    c_idx, start, end = regions[i, 0], regions[i, 1], regions[i, 2]
+    c_s = ref_offsets[c_idx]
+    c_e = ref_offsets[c_idx + 1]
+    padded_slice(reference[c_s:c_e], start, end, pad_char, out[o_s:o_e])
+
+
 @nb.njit(parallel=True, nogil=True, cache=True)
+def _get_reference_par(regions, out_offsets, reference, ref_offsets, pad_char, out):
+    for i in nb.prange(len(regions)):
+        _get_reference_row(i, regions, out_offsets, reference, ref_offsets, pad_char, out)
+    return out
+
+
+@nb.njit(nogil=True, cache=True)
+def _get_reference_ser(regions, out_offsets, reference, ref_offsets, pad_char, out):
+    for i in range(len(regions)):
+        _get_reference_row(i, regions, out_offsets, reference, ref_offsets, pad_char, out)
+    return out
+
+
 def get_reference(
     regions: NDArray[np.integer],
     out_offsets: NDArray[np.integer],
@@ -694,13 +716,12 @@ def get_reference(
     pad_char: int,
 ) -> NDArray[np.uint8]:
     out = np.empty(out_offsets[-1], np.uint8)
-    for i in nb.prange(len(regions)):
-        o_s, o_e = out_offsets[i], out_offsets[i + 1]
-        c_idx, start, end = regions[i, :3]
-        c_s = ref_offsets[c_idx]
-        c_e = ref_offsets[c_idx + 1]
-        padded_slice(reference[c_s:c_e], start, end, pad_char, out[o_s:o_e])
-    return out
+    kernel = (
+        _get_reference_par
+        if should_parallelize(int(out_offsets[-1]))
+        else _get_reference_ser
+    )
+    return kernel(regions, out_offsets, reference, ref_offsets, pad_char, out)
 
 
 def _fetch_spliced_ref(

--- a/python/genvarloader/_dataset/_reference.py
+++ b/python/genvarloader/_dataset/_reference.py
@@ -133,9 +133,7 @@ class Reference:
         offsets = lengths_to_offsets(lengths)
         seqs = np.empty(offsets[-1], np.uint8)
         kernel = (
-            _fetch_impl_par
-            if should_parallelize(int(offsets[-1]))
-            else _fetch_impl_ser
+            _fetch_impl_par if should_parallelize(int(offsets[-1])) else _fetch_impl_ser
         )
         kernel(
             c_idxs,
@@ -697,14 +695,18 @@ def _get_reference_row(i, regions, out_offsets, reference, ref_offsets, pad_char
 @nb.njit(parallel=True, nogil=True, cache=True)
 def _get_reference_par(regions, out_offsets, reference, ref_offsets, pad_char, out):
     for i in nb.prange(len(regions)):
-        _get_reference_row(i, regions, out_offsets, reference, ref_offsets, pad_char, out)
+        _get_reference_row(
+            i, regions, out_offsets, reference, ref_offsets, pad_char, out
+        )
     return out
 
 
 @nb.njit(nogil=True, cache=True)
 def _get_reference_ser(regions, out_offsets, reference, ref_offsets, pad_char, out):
     for i in range(len(regions)):
-        _get_reference_row(i, regions, out_offsets, reference, ref_offsets, pad_char, out)
+        _get_reference_row(
+            i, regions, out_offsets, reference, ref_offsets, pad_char, out
+        )
     return out
 
 

--- a/python/genvarloader/_threads.py
+++ b/python/genvarloader/_threads.py
@@ -1,0 +1,42 @@
+"""Cgroup-aware numba thread cap + a per-thread dispatch predicate.
+
+numba.get_num_threads() reports host logical CPUs, not the cgroup allocation
+(e.g. 208 reported vs. 52 allocated). Forking the misdetected count makes
+parallel=True regions pay a flat ~37 ms fork-join for trivial work. We cap the
+worker count down to the real allocation once at import, and route copy kernels
+to a serial variant unless there is enough work to amortize the fork-join.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numba
+
+# Parallel only pays off when each worker gets at least this many bytes to copy.
+# Below `num_threads * _MIN_BYTES_PER_THREAD` total, the serial kernel wins.
+_MIN_BYTES_PER_THREAD = 1 << 20  # 1 MiB
+
+
+def _resolve_num_threads() -> int:
+    hard_max = numba.get_num_threads()
+    env = os.environ.get("GVL_NUM_THREADS")
+    if env:
+        return max(1, min(int(env), hard_max))
+    try:
+        real = len(os.sched_getaffinity(0))  # respects cgroup cpuset (Linux)
+    except AttributeError:
+        real = os.cpu_count() or 1  # non-Linux fallback
+    return max(1, min(real, hard_max))
+
+
+def cap_numba_threads() -> int:
+    """Cap numba's parallel worker count to the resolved value. Idempotent."""
+    n = _resolve_num_threads()
+    numba.set_num_threads(n)
+    return n
+
+
+def should_parallelize(total_bytes: int) -> bool:
+    """True iff a copy of `total_bytes` is large enough to justify fork-join."""
+    return total_bytes >= numba.get_num_threads() * _MIN_BYTES_PER_THREAD

--- a/python/genvarloader/_threads.py
+++ b/python/genvarloader/_threads.py
@@ -22,7 +22,12 @@ def _resolve_num_threads() -> int:
     hard_max = numba.get_num_threads()
     env = os.environ.get("GVL_NUM_THREADS")
     if env:
-        return max(1, min(int(env), hard_max))
+        try:
+            return max(1, min(int(env), hard_max))
+        except ValueError:
+            # A malformed override (e.g. "auto") must not break `import
+            # genvarloader`; fall through to cgroup detection instead.
+            pass
     try:
         real = len(os.sched_getaffinity(0))  # respects cgroup cpuset (Linux)
     except AttributeError:

--- a/tests/dataset/test_flat_flanks.py
+++ b/tests/dataset/test_flat_flanks.py
@@ -708,6 +708,36 @@ def test_dummy_variant_windows_fill_empty_region_all_unk(snap_dataset):
         assert vals.tolist() == [4] * (ploidy * (2 * L + 1))
 
 
+def test_variant_windows_single_fetch_per_decode(snap_dataset, monkeypatch):
+    """ref=window, alt=window decode must call Reference.fetch exactly once."""
+    import genvarloader._dataset._reference as refmod
+    from genvarloader._dataset._flat_variants import VarWindowOpt
+
+    calls = {"n": 0}
+    orig = refmod.Reference.fetch
+
+    def spy(self, *a, **k):
+        calls["n"] += 1
+        return orig(self, *a, **k)
+
+    monkeypatch.setattr(refmod.Reference, "fetch", spy)
+
+    ds = (
+        snap_dataset.with_tracks(False)
+        .with_output_format("flat")
+        .with_seqs(
+            "variant-windows",
+            VarWindowOpt(flank_length=4, token_alphabet=b"ACGT", unknown_token=4),
+        )
+    )
+    calls["n"] = 0
+    out = ds[[0, 1, 2], [0, 1, 2]]
+    assert out.ref_window is not None and out.alt_window is not None
+    assert calls["n"] == 1, (
+        f"expected 1 reference.fetch for both-window decode, got {calls['n']}"
+    )
+
+
 def test_no_awkward_on_dummy_window_hot_path(snap_dataset, monkeypatch):
     import awkward as ak
 

--- a/tests/unit/dataset/test_ref_fetch_dispatch.py
+++ b/tests/unit/dataset/test_ref_fetch_dispatch.py
@@ -1,7 +1,12 @@
 import numpy as np
 from seqpro.rag import lengths_to_offsets
 
-from genvarloader._dataset._reference import _fetch_impl_ser, _fetch_impl_par
+from genvarloader._dataset._reference import (
+    _fetch_impl_ser,
+    _fetch_impl_par,
+    _get_reference_ser,
+    _get_reference_par,
+)
 
 
 def _run(kernel, c_idxs, starts, ends, reference, ref_offsets, pad_char):
@@ -21,4 +26,22 @@ def test_serial_and_parallel_kernels_agree():
     pad = ord("N")
     ser = _run(_fetch_impl_ser, c_idxs, starts, ends, reference, ref_offsets, pad)
     par = _run(_fetch_impl_par, c_idxs, starts, ends, reference, ref_offsets, pad)
+    np.testing.assert_array_equal(ser, par)
+
+
+def test_get_reference_kernels_agree():
+    rng = np.random.default_rng(1)
+    reference = rng.integers(65, 85, size=500, dtype=np.uint8)
+    ref_offsets = np.array([0, 200, 500], dtype=np.int64)
+    # regions: (c_idx, start, end, strand)
+    regions = np.array(
+        [[0, -5, 10, 1], [1, 10, 30, 1], [0, 190, 205, 1], [1, 0, 300, 1]],
+        dtype=np.int64,
+    )
+    out_offsets = lengths_to_offsets(regions[:, 2] - regions[:, 1])
+    pad = ord("N")
+    ser = np.empty(int(out_offsets[-1]), np.uint8)
+    par = np.empty(int(out_offsets[-1]), np.uint8)
+    _get_reference_ser(regions, out_offsets, reference, ref_offsets, pad, ser)
+    _get_reference_par(regions, out_offsets, reference, ref_offsets, pad, par)
     np.testing.assert_array_equal(ser, par)

--- a/tests/unit/dataset/test_ref_fetch_dispatch.py
+++ b/tests/unit/dataset/test_ref_fetch_dispatch.py
@@ -1,0 +1,24 @@
+import numpy as np
+from seqpro.rag import lengths_to_offsets
+
+from genvarloader._dataset._reference import _fetch_impl_ser, _fetch_impl_par
+
+
+def _run(kernel, c_idxs, starts, ends, reference, ref_offsets, pad_char):
+    out_offsets = lengths_to_offsets(ends - starts)
+    out = np.empty(int(out_offsets[-1]), np.uint8)
+    kernel(c_idxs, starts, ends, reference, ref_offsets, pad_char, out, out_offsets)
+    return out
+
+
+def test_serial_and_parallel_kernels_agree():
+    rng = np.random.default_rng(0)
+    reference = rng.integers(65, 85, size=500, dtype=np.uint8)  # ascii A..T
+    ref_offsets = np.array([0, 200, 500], dtype=np.int64)  # 2 contigs
+    c_idxs = np.array([0, 1, 0, 1], dtype=np.int64)
+    starts = np.array([-5, 10, 190, 0], dtype=np.int64)  # includes OOB left
+    ends = np.array([10, 30, 205, 300], dtype=np.int64)  # includes OOB right
+    pad = ord("N")
+    ser = _run(_fetch_impl_ser, c_idxs, starts, ends, reference, ref_offsets, pad)
+    par = _run(_fetch_impl_par, c_idxs, starts, ends, reference, ref_offsets, pad)
+    np.testing.assert_array_equal(ser, par)

--- a/tests/unit/test_threads.py
+++ b/tests/unit/test_threads.py
@@ -26,6 +26,14 @@ def test_resolve_uses_cgroup_affinity(monkeypatch):
     assert th._resolve_num_threads() == 52
 
 
+def test_resolve_malformed_env_falls_back_to_affinity(monkeypatch):
+    # a non-integer override must not break import; fall through to detection
+    monkeypatch.setenv("GVL_NUM_THREADS", "auto")
+    monkeypatch.setattr(numba, "get_num_threads", lambda: 208)
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: set(range(52)))
+    assert th._resolve_num_threads() == 52
+
+
 def test_should_parallelize_threshold(monkeypatch):
     monkeypatch.setattr(numba, "get_num_threads", lambda: 4)
     thresh = 4 * th._MIN_BYTES_PER_THREAD

--- a/tests/unit/test_threads.py
+++ b/tests/unit/test_threads.py
@@ -1,0 +1,33 @@
+import os
+
+import numba
+
+import genvarloader._threads as th
+
+
+def test_resolve_honors_env_override(monkeypatch):
+    monkeypatch.setenv("GVL_NUM_THREADS", "7")
+    # env wins, clamped to >= 1 and <= numba hard max
+    monkeypatch.setattr(numba, "get_num_threads", lambda: 64)
+    assert th._resolve_num_threads() == 7
+
+
+def test_resolve_env_clamped_to_numba_max(monkeypatch):
+    monkeypatch.setenv("GVL_NUM_THREADS", "9999")
+    monkeypatch.setattr(numba, "get_num_threads", lambda: 64)
+    assert th._resolve_num_threads() == 64
+
+
+def test_resolve_uses_cgroup_affinity(monkeypatch):
+    monkeypatch.delenv("GVL_NUM_THREADS", raising=False)
+    # host reports 208 logical CPUs, cgroup allows 52 -> min wins
+    monkeypatch.setattr(numba, "get_num_threads", lambda: 208)
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: set(range(52)))
+    assert th._resolve_num_threads() == 52
+
+
+def test_should_parallelize_threshold(monkeypatch):
+    monkeypatch.setattr(numba, "get_num_threads", lambda: 4)
+    thresh = 4 * th._MIN_BYTES_PER_THREAD
+    assert th.should_parallelize(thresh - 1) is False
+    assert th.should_parallelize(thresh) is True


### PR DESCRIPTION
## Summary

Eliminates two sources of overhead in the `variant-windows` reference read path so `Reference.fetch` scales with bytes copied instead of dominating the decode (issue #221):

- **Numba thread cap** — `numba.get_num_threads()` reports host logical CPUs, not the cgroup allocation (e.g. 208 reported vs. 52 allocated), so `parallel=True` regions paid a flat ~37 ms fork-join for trivial work. New `_threads.py` caps the worker count to the cgroup-aware core count once at import (overridable via `GVL_NUM_THREADS`).
- **Serial/parallel kernel dispatch** — the two reference-copy kernels (`_fetch_impl` in `Reference.fetch`, and `get_reference`) now route to a serial njit below a per-thread byte threshold and a parallel njit above it, via `should_parallelize(total_bytes)`. Both kernels share an `inline="always"` row body, so serial and parallel are byte-identical by construction.
- **Fetch fusion (3 → 1)** — the `variant-windows` flank builders in `_flat_flanks.py` now do a single `[start−L, end+L)` read and slice `f5`/`f3` internally. The both-window decode is routed through the fused `compute_windows` (1 fetch instead of 2). Public signatures are unchanged, so the existing oracle tests act as byte-identity guards.

## Test Plan

- [x] `pixi run -e dev pytest tests/dataset/ tests/unit/dataset/ tests/unit/test_threads.py` → 294 passed, 4 skipped, 2 xfailed
- [x] Kernel-agreement tests (`_fetch_impl_ser`/`_par`, `_get_reference_ser`/`_par`) confirm serial ≡ parallel, incl. OOB-left/right regions
- [x] Existing `_oracle_*` / split-equivalence tests confirm the fused fetch is byte-identical to the old separate-fetch path
- [x] New `test_variant_windows_single_fetch_per_decode` pins the both-window decode to exactly 1 `Reference.fetch` call (down from 3)
- [x] `ruff check python/` clean; `pyrefly` 0 errors
- [ ] Production confirmation against `gvf-germ-som` per #221 acceptance criteria

Closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
