### PR TITLE
feat: gvl.update, write annot_tracks, parallel writing

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -47,13 +47,18 @@
 
 ### Feat
 
-- **write**: `gvl.write` gains `annot_tracks=` — sample-independent annotation tracks written to `<path>/annot_intervals/<name>/`; accepts a path to an interval table or bigWig, or a polars DataFrame/LazyFrame with BED-like columns (`chrom`, `chromStart`, `chromEnd`, `score`). DataFrame/LazyFrame and table-file sources use the polars-bio overlap backend and require the `table` extra (`pip install genvarloader[table]`); bigWig path sources do not.
-- **write**: `gvl.write` now parallelizes over write categories — variants run first (serially), then per-sample `tracks` and `annot_tracks` run concurrently (joblib loky); `max_mem` is divided across the concurrently-running categories.
-- **update**: new `gvl.update(dataset, tracks=None, annot_tracks=None, *, overwrite=False, max_mem="4g")` adds tracks to an existing on-disk dataset. Accepts a path or an opened `Dataset`. Per-sample `tracks` require exact sample-set agreement (reordered to dataset order automatically); `annot_tracks` are sample-independent. Each track is published atomically; a live dataset can be read during update but won't see the new track until reopened. `overwrite=True` replaces a same-named existing track; default raises `FileExistsError`.
+- **write**: `gvl.write` gains `annot_tracks=` — sample-independent annotation tracks written to `<path>/annot_intervals/<name>/`
+  - accepts a path to an interval table or bigWig, or a polars DataFrame/LazyFrame with BED-like columns (`chrom`, `chromStart`, `chromEnd`, `score`)
+  - DataFrame/LazyFrame and table-file sources use the polars-bio overlap backend and require the `table` extra (`pip install genvarloader[table]`); bigWig path sources do not
+- **write**: `gvl.write` parallelizes over write categories — variants run first (serially), then per-sample `tracks` and `annot_tracks` run concurrently (joblib loky); `max_mem` is divided across the concurrently-running categories
+- **update**: new `gvl.update(dataset, tracks=None, annot_tracks=None, *, overwrite=False, max_mem="4g")` adds tracks to an existing on-disk dataset
+  - accepts a path or an opened `Dataset`; per-sample `tracks` require exact sample-set agreement (reordered to dataset order automatically); `annot_tracks` are sample-independent
+  - each track is published atomically; a live dataset can be read during update but won't see the new track until reopened
+  - `overwrite=True` replaces a same-named existing track; default raises `FileExistsError`
 
 ### Refactor
 
-- **update**: `Dataset.write_annot_tracks` removed; use `gvl.update(dataset, annot_tracks={"name": source})` or pass `annot_tracks=` to `gvl.write` at creation time.
+- **update**: `Dataset.write_annot_tracks` removed; use `gvl.update(dataset, annot_tracks={"name": source})` or pass `annot_tracks=` to `gvl.write` at creation time
 
 ## v0.31.0 (2026-06-15)
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -43,6 +43,18 @@
 # Changelog
 
 
+## v0.32.0 (unreleased)
+
+### Feat
+
+- **write**: `gvl.write` gains `annot_tracks=` — sample-independent annotation tracks written to `<path>/annot_intervals/<name>/`; accepts a path to an interval table or bigWig, or a polars DataFrame/LazyFrame with BED-like columns (`chrom`, `chromStart`, `chromEnd`, `score`). DataFrame/LazyFrame and table-file sources use the polars-bio overlap backend and require the `table` extra (`pip install genvarloader[table]`); bigWig path sources do not.
+- **write**: `gvl.write` now parallelizes over write categories — variants run first (serially), then per-sample `tracks` and `annot_tracks` run concurrently (joblib loky); `max_mem` is divided across the concurrently-running categories.
+- **update**: new `gvl.update(dataset, tracks=None, annot_tracks=None, *, overwrite=False, max_mem="4g")` adds tracks to an existing on-disk dataset. Accepts a path or an opened `Dataset`. Per-sample `tracks` require exact sample-set agreement (reordered to dataset order automatically); `annot_tracks` are sample-independent. Each track is published atomically; a live dataset can be read during update but won't see the new track until reopened. `overwrite=True` replaces a same-named existing track; default raises `FileExistsError`.
+
+### Refactor
+
+- **update**: `Dataset.write_annot_tracks` removed; use `gvl.update(dataset, annot_tracks={"name": source})` or pass `annot_tracks=` to `gvl.write` at creation time.
+
 ## v0.31.0 (2026-06-15)
 
 ### Feat

--- a/docs/superpowers/plans/2026-06-16-update-and-annot-tracks.md
+++ b/docs/superpowers/plans/2026-06-16-update-and-annot-tracks.md
@@ -1,0 +1,1121 @@
+# `gvl.update`, `annot_tracks` in `write`, and parallel writing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a top-level `gvl.update()` for adding tracks to an existing dataset on disk, give `gvl.write()` an `annot_tracks` parameter, parallelize `write` over variants/tracks/annot_tracks, and re-implement annotation extraction on polars-bio (DRY with `gvl.Table`).
+
+**Architecture:** Both `write` and `update` live in `_dataset/_write.py` and share leaf interval writers (`_write_track` for per-sample, `_write_annot_track` for sample-less). `write` builds the whole dataset in one `atomic_dir` temp dir and publishes once; `update` publishes each track subdir atomically into a live dataset via `atomic_dir`. Parallelism is process-based (joblib loky); because variants run first (serially) in `write`, the only parallel jobs are track/annot writers whose closures are picklable (no genoray readers).
+
+**Tech Stack:** Python, polars, polars-bio (optional `[table]` extra), joblib (loky backend), numpy memmaps, seqpro `Ragged`, pyBigWig via the Rust backend.
+
+## Global Constraints
+
+- **Conventional commits** (commitizen). Use `feat:`/`refactor:`/`test:`/`docs:` prefixes.
+- All dev commands run under pixi: `pixi run -e dev <cmd>`. Run a single test with
+  `pixi run -e dev pytest <path>::<name> -v`.
+- **E501 (line length) is ignored** by ruff; do not reflow for line length.
+- **polars-bio is gated**: any code path that imports polars-bio must go through
+  `genvarloader._table._import_polars_bio` (raises the `pip install genvarloader[table]`
+  error when missing) and emit `genvarloader._table.ExperimentalWarning`. Tests touching
+  polars-bio are skipped unless `GVL_TEST_EXPERIMENTAL=1` (see `tests/unit/test_table.py`).
+- **Public API change**: removing `Dataset.write_annot_tracks` and adding `gvl.update`
+  requires updating `skills/genvarloader/SKILL.md` and `docs/source/changelog.md`
+  (per `CLAUDE.md`).
+- **Atomicity**: never write track data directly into a live dataset dir; build into an
+  `atomic_dir` temp and let it `os.replace` into place. The temp/aside siblings are named
+  `<name>.tmp.<pid>-<hex>`, `<name>.old.<hex>`, and a `<name>.lock` file lives in the same
+  parent.
+- annot source column convention is **BED-like**: `chrom`, `chromStart`, `chromEnd`,
+  `score` (matches the current `write_annot_tracks` / `_annot_to_intervals` contract).
+  Paths are read with `seqpro.bed.read`.
+
+## File Structure
+
+- `python/genvarloader/_dataset/_write.py` — `write` (+ `annot_tracks` + parallel
+  orchestration), new `update`, new leaf writers `_write_annot_track` /
+  `_write_ragged_intervals`, refactored `_write_track(out_dir, ...)`, new `_run_jobs`
+  helper, new `_annot_intervals` dispatcher.
+- `python/genvarloader/_table.py` — new module-level `annot_overlap(regions, annot)`
+  helper (polars-bio overlap → sample-less `RaggedIntervals`), reusing
+  `_import_polars_bio` + `ExperimentalWarning`.
+- `python/genvarloader/_dataset/_impl.py` — remove `Dataset.write_annot_tracks`; delete
+  `_annot_to_intervals`.
+- `python/genvarloader/_dataset/_tracks.py` — make `Tracks.from_path` ignore
+  non-directories and `.tmp.`/`.old.`/`.lock` siblings.
+- `python/genvarloader/__init__.py` — export `update`.
+- `tests/unit/test_write_annot.py` (new) — annot extraction unit tests.
+- `tests/integration/tracks/test_update.py` (new) — `gvl.update` integration tests.
+- `tests/integration/tracks/test_annot_tracks.py` — migrate to `gvl.update`.
+- `tests/integration/test_write_parallel.py` (new) — parallel-write equivalence.
+- `skills/genvarloader/SKILL.md`, `docs/source/changelog.md` — docs.
+
+---
+
+### Task 1: Refactor `_write_track` to take an explicit output dir + extract `_write_ragged_intervals`
+
+Decouples the leaf writers from "compute `path/intervals/<name>` internally" so both
+`write` (into a temp dataset) and `update` (into an `atomic_dir` temp) can drive them.
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_write.py` (`_write_track` at ~902; its caller in
+  `write` at ~286-289)
+- Test: existing `pixi run -e dev pytest tests/integration -k track` must still pass.
+
+**Interfaces:**
+- Produces: `_write_track(out_dir: Path, bed: pl.DataFrame, track: IntervalTrack, samples: list[str] | None, max_mem: int) -> None` — writes `intervals.npy` + `offsets.npy` directly into `out_dir`.
+- Produces: `_write_ragged_intervals(out_dir: Path, itvs: RaggedIntervals) -> None`.
+
+- [ ] **Step 1: Add `_write_ragged_intervals` helper**
+
+Add to `_write.py` (near `_write_track`):
+
+```python
+def _write_ragged_intervals(out_dir: Path, itvs: "RaggedIntervals") -> None:
+    """Write a RaggedIntervals (values/starts/ends share offsets) to out_dir as
+    intervals.npy + offsets.npy. Single-chunk writer used for annotation tracks."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = np.memmap(
+        out_dir / "intervals.npy",
+        dtype=INTERVAL_DTYPE,
+        mode="w+",
+        shape=itvs.values.data.shape,
+    )
+    out["start"] = itvs.starts.data
+    out["end"] = itvs.ends.data
+    out["value"] = itvs.values.data
+    out.flush()
+
+    offsets = itvs.values.offsets
+    out = np.memmap(
+        out_dir / "offsets.npy",
+        dtype=offsets.dtype,
+        mode="w+",
+        shape=len(offsets),
+    )
+    out[:] = offsets
+    out.flush()
+```
+
+(`RaggedIntervals` is imported lazily inside functions today; add
+`from .._ragged import RaggedIntervals` under the existing `TYPE_CHECKING` block for the
+annotation only, and import the concrete class inside functions that build one.)
+
+- [ ] **Step 2: Change `_write_track` signature to accept `out_dir`**
+
+In `_write_track`, delete the internal `out_dir = path / "intervals" / track.name` line
+(~970-971) and rename the parameter `path` → `out_dir`. Add `out_dir.mkdir(parents=True,
+exist_ok=True)` where the old `mkdir` was. Leave the rest of the body unchanged.
+
+```python
+def _write_track(
+    out_dir: Path,
+    bed: pl.DataFrame,
+    track: "IntervalTrack",
+    samples: list[str] | None,
+    max_mem: int,
+):
+    ...
+    # (was: out_dir = path / "intervals" / track.name)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ...
+```
+
+- [ ] **Step 3: Update the caller in `write`**
+
+In `write` (~286-289) change:
+
+```python
+            if tracks is not None:
+                logger.info("Writing track intervals.")
+                for tr in tracks:
+                    _write_track(path / "intervals" / tr.name, gvl_bed, tr, samples, max_mem)
+```
+
+- [ ] **Step 4: Run the existing track tests**
+
+Run: `pixi run -e dev pytest tests/integration -k "track" -v`
+Expected: PASS (pure refactor; on-disk output unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_write.py
+rtk git commit -m "refactor: _write_track takes explicit out_dir; add _write_ragged_intervals"
+```
+
+---
+
+### Task 2: polars-bio annotation extraction (`annot_overlap`) + `_annot_intervals` dispatcher
+
+Re-implements sample-less annotation extraction on polars-bio (table/DataFrame sources)
+and the Rust BigWigs backend (bigwig sources), replacing the pyranges `_annot_to_intervals`.
+
+**Files:**
+- Modify: `python/genvarloader/_table.py` (add `annot_overlap`)
+- Modify: `python/genvarloader/_dataset/_write.py` (add `_annot_intervals`,
+  `_write_annot_track`)
+- Test: `tests/unit/test_write_annot.py` (new)
+
+**Interfaces:**
+- Consumes: `genvarloader._dataset._impl._annot_to_intervals(regions, annot)` (the existing pyranges impl — still present until Task 6; used here only as the regression oracle in the test).
+- Produces: `genvarloader._table.annot_overlap(regions: pl.DataFrame, annot: pl.DataFrame) -> RaggedIntervals` — polars-bio overlap, sample-less `(n_regions, None)`; emits `ExperimentalWarning`, requires `[table]`.
+- Produces: `_annot_intervals(regions: pl.DataFrame, source, max_mem: int) -> RaggedIntervals` in `_write.py` — dispatches on source type.
+- Produces: `_write_annot_track(out_dir: Path, regions: pl.DataFrame, source, max_mem: int) -> None`.
+
+- [ ] **Step 1: Write the failing test (polars-bio path, env-gated)**
+
+Create `tests/unit/test_write_annot.py`:
+
+```python
+import os
+
+import numpy as np
+import polars as pl
+import pytest
+
+# polars-bio is gated exactly like gvl.Table (see tests/unit/test_table.py).
+if not os.environ.get("GVL_TEST_EXPERIMENTAL"):
+    pytest.skip(
+        "annot polars-bio path is experimental; set GVL_TEST_EXPERIMENTAL=1 to run.",
+        allow_module_level=True,
+    )
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore::genvarloader._table.ExperimentalWarning"
+)
+
+
+def _regions():
+    return pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr2"],
+            "chromStart": [0, 50, 0],
+            "chromEnd": [100, 150, 100],
+        }
+    )
+
+
+def _annot():
+    return pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1", "chr2"],
+            "chromStart": [10, 60, 90, 5],
+            "chromEnd": [20, 70, 95, 15],
+            "score": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+
+def test_annot_overlap_matches_pyranges_oracle():
+    from genvarloader._dataset._impl import _annot_to_intervals  # pyranges oracle
+    from genvarloader._table import annot_overlap
+
+    regions, annot = _regions(), _annot()
+    got = annot_overlap(regions, annot)
+    want = _annot_to_intervals(regions, annot)
+
+    # same per-region counts and the same multiset of intervals per region
+    np.testing.assert_array_equal(got.values.offsets, want.values.offsets)
+    for r in range(regions.height):
+        gs, ge, gv = got.starts[r], got.ends[r], got.values[r]
+        ws, we, wv = want.starts[r], want.ends[r], want.values[r]
+        go = np.lexsort((gv, ge, gs))
+        wo = np.lexsort((wv, we, ws))
+        np.testing.assert_array_equal(np.asarray(gs)[go], np.asarray(ws)[wo])
+        np.testing.assert_array_equal(np.asarray(ge)[go], np.asarray(we)[wo])
+        np.testing.assert_allclose(np.asarray(gv)[go], np.asarray(wv)[wo])
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `GVL_TEST_EXPERIMENTAL=1 pixi run -e dev pytest tests/unit/test_write_annot.py -v`
+Expected: FAIL with `ImportError: cannot import name 'annot_overlap'`.
+
+- [ ] **Step 3: Implement `annot_overlap` in `_table.py`**
+
+Add to `python/genvarloader/_table.py` (module level, after `Table`):
+
+```python
+def annot_overlap(regions: pl.DataFrame, annot: pl.DataFrame) -> "RaggedIntervals":
+    """Sample-less interval overlap of `regions` (chrom/chromStart/chromEnd) against a
+    BED-like `annot` (chrom/chromStart/chromEnd/score), via polars-bio. Returns a
+    RaggedIntervals of shape (n_regions, None) ordered by (region, start). Experimental:
+    requires the `table` extra and emits ExperimentalWarning."""
+    import numpy as np
+    from seqpro.rag import Ragged
+
+    from ._ragged import RaggedIntervals
+    from ._utils import lengths_to_offsets, normalize_contig_name
+
+    warnings.warn(_TABLE_EXPERIMENTAL_MSG, ExperimentalWarning, stacklevel=2)
+    pb = _import_polars_bio()
+    pb.set_option("datafusion.bio.coordinate_system_check", "false")
+    pb.set_option("datafusion.bio.coordinate_system_zero_based", True)
+
+    # normalize annot contig names to the region naming (e.g. "1" -> "chr1")
+    reg_c = regions["chrom"].unique().to_list()
+    renamer = {
+        c: nc
+        for c in annot["chrom"].unique().to_list()
+        if (nc := normalize_contig_name(c, reg_c)) is not None
+    }
+    annot = annot.with_columns(chrom=pl.col("chrom").replace(renamer))
+
+    n_regions = regions.height
+    q = regions.with_row_index("_q").select(
+        "chrom",
+        pl.col("chromStart").alias("start"),
+        pl.col("chromEnd").alias("end"),
+        "_q",
+    )
+    db = annot.select(
+        "chrom",
+        pl.col("chromStart").alias("start"),
+        pl.col("chromEnd").alias("end"),
+        "score",
+    )
+    joined = pb.overlap(
+        q,
+        db,
+        cols1=["chrom", "start", "end"],
+        cols2=["chrom", "start", "end"],
+        output_type="polars.DataFrame",
+    )
+
+    shape = (n_regions, None)
+    if joined.height == 0:
+        offsets = lengths_to_offsets(np.zeros(n_regions, np.int32))
+        empty_i = np.empty(0, np.int32)
+        empty_f = np.empty(0, np.float32)
+        return RaggedIntervals(
+            Ragged.from_offsets(empty_i, shape, offsets),
+            Ragged.from_offsets(empty_i, shape, offsets),
+            Ragged.from_offsets(empty_f, shape, offsets),
+        )
+
+    # polars-bio suffixes query cols with _1 and database cols with _2 (see Table).
+    q_idx = joined["_q_1"].to_numpy()
+    j_starts = joined["start_2"].to_numpy()
+    order = np.lexsort((j_starts, q_idx))  # primary key = q_idx, then start
+    q_idx = q_idx[order]
+
+    counts = np.zeros(n_regions, np.int32)
+    uniq, cnt = np.unique(q_idx, return_counts=True)
+    counts[uniq] = cnt
+    offsets = lengths_to_offsets(counts)
+
+    starts = j_starts[order].astype(np.int32, copy=False)
+    ends = joined["end_2"].to_numpy()[order].astype(np.int32, copy=False)
+    values = joined["score_2"].to_numpy()[order].astype(np.float32, copy=False)
+    return RaggedIntervals(
+        Ragged.from_offsets(starts, shape, offsets),
+        Ragged.from_offsets(ends, shape, offsets),
+        Ragged.from_offsets(values, shape, offsets),
+    )
+```
+
+Add `from ._ragged import RaggedIntervals` to the `TYPE_CHECKING` block (already present)
+so the annotation resolves.
+
+- [ ] **Step 4: Run the polars-bio test**
+
+Run: `GVL_TEST_EXPERIMENTAL=1 pixi run -e dev pytest tests/unit/test_write_annot.py::test_annot_overlap_matches_pyranges_oracle -v`
+Expected: PASS. (If polars-bio is not installed, it skips — install with the `table`
+extra to actually exercise it.)
+
+- [ ] **Step 5: Add the bigwig-annot test (runs in CI — no polars-bio)**
+
+The module-level skip above gates the whole file. Move the bigwig test into a separate,
+ungated file `tests/unit/test_write_annot_bigwig.py`:
+
+```python
+from pathlib import Path
+
+import numpy as np
+
+from genvarloader._dataset._write import _annot_intervals
+
+
+def test_annot_intervals_from_bigwig(tmp_path):
+    import polars as pl
+
+    data_dir = Path(__file__).parent.parent / "data" / "bigwig"
+    bw = data_dir / "sample_0.bw"
+    # a region known to overlap intervals in the fixture bigwig
+    regions = pl.DataFrame(
+        {"chrom": ["chr1"], "chromStart": [0], "chromEnd": [1000]}
+    )
+    itvs = _annot_intervals(regions, bw, max_mem=2**30)
+    # shape (regions, None), one region
+    assert itvs.values.offsets.shape == (2,)
+    assert itvs.starts.data.dtype == np.int32
+```
+
+(Confirm `tests/data/bigwig/sample_0.bw` exists — it is used by
+`tests/test_interval_track.py`. Adjust the relative path / contig / region if the fixture
+differs.)
+
+- [ ] **Step 6: Implement `_annot_intervals` + `_write_annot_track` in `_write.py`**
+
+```python
+def _annot_intervals(
+    regions: pl.DataFrame,
+    source: "str | Path | pl.DataFrame | pl.LazyFrame",
+    max_mem: int,
+) -> "RaggedIntervals":
+    """Build a sample-less RaggedIntervals (n_regions, None) from an annotation source.
+
+    - bigwig path -> Rust per-region extraction (BigWigs), squeezed sample-less.
+    - table path / DataFrame / LazyFrame (BED-like: chrom, chromStart, chromEnd, score)
+      -> polars-bio overlap (experimental, requires the `table` extra).
+    """
+    from .._ragged import RaggedIntervals
+
+    if isinstance(source, (str, Path)) and Path(source).suffix.lower() in (
+        ".bw",
+        ".bigwig",
+    ):
+        return _annot_intervals_from_bigwig(regions, Path(source), max_mem)
+
+    if isinstance(source, pl.LazyFrame):
+        annot = source.collect()
+    elif isinstance(source, pl.DataFrame):
+        annot = source
+    else:
+        annot = sp.bed.read(str(source))
+
+    from .._table import annot_overlap
+
+    return annot_overlap(regions, annot)
+
+
+def _annot_intervals_from_bigwig(
+    regions: pl.DataFrame, path: Path, max_mem: int
+) -> "RaggedIntervals":
+    from seqpro.rag import Ragged
+
+    from .._bigwig import BigWigs
+    from .._ragged import RaggedIntervals
+
+    # single pseudo-sample; collapse its sample axis to produce a sample-less track
+    bw = BigWigs(name="__annot__", paths={"__annot__": str(path)})
+    out_starts, out_ends, out_values, lengths = [], [], [], []
+    for (contig,), part in regions.partition_by(
+        "chrom", as_dict=True, maintain_order=True
+    ).items():
+        contig = cast(str, contig)
+        starts = part["chromStart"].to_numpy()
+        ends = part["chromEnd"].to_numpy()
+        # (regions, 1)
+        itvs = bw.intervals(contig, starts, ends, sample="__annot__")
+        for r in range(part.height):
+            s = itvs.starts[r, 0]
+            out_starts.append(np.asarray(s, dtype=np.int32))
+            out_ends.append(np.asarray(itvs.ends[r, 0], dtype=np.int32))
+            out_values.append(np.asarray(itvs.values[r, 0], dtype=np.float32))
+            lengths.append(len(s))
+    flat_starts = (
+        np.concatenate(out_starts) if out_starts else np.empty(0, np.int32)
+    )
+    flat_ends = np.concatenate(out_ends) if out_ends else np.empty(0, np.int32)
+    flat_values = (
+        np.concatenate(out_values) if out_values else np.empty(0, np.float32)
+    )
+    offsets = lengths_to_offsets(np.asarray(lengths, np.int32))
+    shape = (regions.height, None)
+    return RaggedIntervals(
+        Ragged.from_offsets(flat_starts, shape, offsets),
+        Ragged.from_offsets(flat_ends, shape, offsets),
+        Ragged.from_offsets(flat_values, shape, offsets),
+    )
+
+
+def _write_annot_track(
+    out_dir: Path,
+    regions: pl.DataFrame,
+    source: "str | Path | pl.DataFrame | pl.LazyFrame",
+    max_mem: int,
+) -> None:
+    itvs = _annot_intervals(regions, source, max_mem)
+    _write_ragged_intervals(out_dir, itvs)
+```
+
+> Note: `regions` here is the BED-3 frame in the dataset's on-disk row order, produced by
+> `regions_to_bed(np.load(path / "regions.npy"), contigs)` (matches today's
+> `write_annot_tracks`, which uses `regions_to_bed(self._full_regions, self.contigs)`).
+> The bigwig partition_by preserves on-disk order via `maintain_order=True`, so per-region
+> rows align with `regions.npy`.
+
+- [ ] **Step 7: Run both annot test files**
+
+Run: `pixi run -e dev pytest tests/unit/test_write_annot_bigwig.py -v`
+Expected: PASS.
+Run: `GVL_TEST_EXPERIMENTAL=1 pixi run -e dev pytest tests/unit/test_write_annot.py -v`
+Expected: PASS (or skip without the `table` extra).
+
+- [ ] **Step 8: Commit**
+
+```bash
+rtk git add python/genvarloader/_table.py python/genvarloader/_dataset/_write.py tests/unit/test_write_annot.py tests/unit/test_write_annot_bigwig.py
+rtk git commit -m "feat: polars-bio annotation extraction + bigwig annot source"
+```
+
+---
+
+### Task 3: `gvl.write(annot_tracks=...)` (sequential, no parallelism yet)
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_write.py` (`write` signature + body)
+- Test: `tests/integration/tracks/test_annot_tracks.py` (add a write-based test;
+  the existing test still uses the soon-removed `Dataset.write_annot_tracks` — leave it
+  for now, it is migrated in Task 6)
+
+**Interfaces:**
+- Produces: `write(..., annot_tracks: dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None = None)` writing each into `<path>/annot_intervals/<name>/`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/integration/tracks/test_annot_tracks.py`:
+
+```python
+def test_write_with_annot_tracks(phased_vcf, ref_fasta, tmp_path):
+    import genvarloader as gvl
+    import polars as pl
+
+    out = tmp_path / "ds"
+    bed = pl.DataFrame(
+        {"chrom": ["chr1"], "chromStart": [0], "chromEnd": [64]}
+    )
+    annot = bed.with_columns(chromEnd=pl.col("chromStart") + 1, score=pl.lit(1.0))
+    gvl.write(out, bed, variants=phased_vcf, annot_tracks={"5ss": annot})
+    ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated").with_tracks(
+        "5ss", "tracks"
+    )
+    assert "5ss" in ds.available_tracks
+```
+
+(Use whatever phased-VCF / ref fixtures the file already imports; mirror the existing
+`dataset` fixture's sources. The `score`/`chromEnd` annot mirrors the existing
+`test_annot_tracks` body. If the table source needs the `[table]` extra, gate this test
+behind `GVL_TEST_EXPERIMENTAL` like Task 2 — a DataFrame source uses polars-bio.)
+
+> If you want this test to run in CI without the `table` extra, use a **bigwig** annot
+> source instead of a DataFrame: `annot_tracks={"sig": tests/data/bigwig/sample_0.bw}`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pixi run -e dev pytest tests/integration/tracks/test_annot_tracks.py::test_write_with_annot_tracks -v`
+Expected: FAIL with `TypeError: write() got an unexpected keyword argument 'annot_tracks'`.
+
+- [ ] **Step 3: Add the parameter and the write step**
+
+In `write` add the parameter after `tracks`:
+
+```python
+def write(
+    path: str | Path,
+    bed: str | Path | pl.DataFrame,
+    variants: str | Path | Reader | None = None,
+    tracks: "IntervalTrack | Sequence[IntervalTrack] | None" = None,
+    annot_tracks: "dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None" = None,
+    samples: list[str] | None = None,
+    max_jitter: int | None = None,
+    overwrite: bool = False,
+    max_mem: int | str = "4g",
+    extend_to_length: bool = True,
+):
+```
+
+Update the "at least one input" guard:
+
+```python
+        if variants is None and tracks is None and annot_tracks is None:
+            raise ValueError(
+                "At least one of `variants`, `tracks`, or `annot_tracks` must be provided."
+            )
+```
+
+After the existing track-writing block (~286-289), add:
+
+```python
+            if annot_tracks is not None:
+                logger.info("Writing annotation tracks.")
+                annot_bed = regions_to_bed(
+                    np.load(path / "regions.npy"), contigs
+                ).select("chrom", "chromStart", "chromEnd")
+                for name, source in annot_tracks.items():
+                    _write_annot_track(
+                        path / "annot_intervals" / name, annot_bed, source, max_mem
+                    )
+```
+
+Add the import at the top of `_write.py`:
+
+```python
+from ._utils import bed_to_regions, regions_to_bed, splits_sum_le_value
+```
+
+(`regions_to_bed` lives in `python/genvarloader/_dataset/_utils.py`.) `_write_regions`
+must have already written `regions.npy` — it runs at ~284, before this block, so the
+read is valid. The annot extraction needs the **finalized** region ends (post-variant),
+which `regions.npy` reflects.
+
+- [ ] **Step 4: Document the parameter**
+
+Add to the `write` docstring, after the `tracks` entry:
+
+```
+    annot_tracks
+        Sample-independent annotation tracks, as a mapping of track name to source.
+        Each source is a path to an interval table, a path to a bigWig, or a polars
+        DataFrame/LazyFrame interpreted as a BED-like interval table (columns ``chrom``,
+        ``chromStart``, ``chromEnd``, ``score``). Table/DataFrame sources use the
+        polars-bio overlap backend and require the ``table`` extra
+        (``pip install genvarloader[table]``); they emit an ``ExperimentalWarning``.
+        bigWig sources do not. Written to ``<path>/annot_intervals/<name>/``.
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `pixi run -e dev pytest tests/integration/tracks/test_annot_tracks.py::test_write_with_annot_tracks -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_write.py tests/integration/tracks/test_annot_tracks.py
+rtk git commit -m "feat: gvl.write accepts annot_tracks"
+```
+
+---
+
+### Task 4: Parallelize `write` (variants first, then tracks ∥ annot_tracks)
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_write.py` (`write` body; new `_run_jobs` helper)
+- Test: `tests/integration/test_write_parallel.py` (new)
+
+**Interfaces:**
+- Produces: `_run_jobs(jobs: list[Callable[[int], None]], max_mem: int) -> None` — runs each `job(per_job_max_mem)`; ≤1 job runs inline, else joblib loky with `n_jobs=len(jobs)` and `max_mem // len(jobs)` apportioned per job.
+
+- [ ] **Step 1: Write the equivalence test**
+
+Create `tests/integration/test_write_parallel.py`:
+
+```python
+import numpy as np
+import polars as pl
+
+import genvarloader as gvl
+
+
+def _open_track(path, name):
+    return np.memmap(path / "intervals" / name / "intervals.npy", mode="r")
+
+
+def test_parallel_write_matches_sequential(phased_vcf, ref_fasta, bigwigs, tmp_path):
+    bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [0], "chromEnd": [64]})
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    gvl.write(a, bed, variants=phased_vcf, tracks=bigwigs)  # parallel path
+    # force the inline path for the oracle by writing categories one at a time
+    gvl.write(b, bed, variants=phased_vcf)
+    gvl.update(b, tracks=bigwigs)  # update is single-category -> inline
+
+    da = gvl.Dataset.open(a, ref_fasta).with_tracks(bigwigs.name)
+    db = gvl.Dataset.open(b, ref_fasta).with_tracks(bigwigs.name)
+    ha, ta = da[:]
+    hb, tb = db[:]
+    assert (np.asarray(ta.data) == np.asarray(tb.data)).all()
+```
+
+(Use the file's existing fixtures for `phased_vcf`, `ref_fasta`, and a `BigWigs`
+fixture named `bigwigs`. If no `bigwigs` fixture exists, build one from
+`tests/data/bigwig/sample_*.bw` whose samples match the VCF samples.)
+
+> This test depends on Task 5 (`gvl.update`). If executing strictly in order, write the
+> oracle inline instead: call the internal sequential writers directly, or compare the
+> parallel run against a known-good fixture. Prefer running Task 5 first if convenient;
+> otherwise stub the oracle with a single-track sequential `gvl.write` and compare track
+> bytes only.
+
+- [ ] **Step 2: Run to verify it fails / is red**
+
+Run: `pixi run -e dev pytest tests/integration/test_write_parallel.py -v`
+Expected: FAIL (parallel path not yet implemented or `update` missing).
+
+- [ ] **Step 3: Add `_run_jobs` and rewire `write`**
+
+Add the helper to `_write.py`:
+
+```python
+from collections.abc import Callable
+
+from joblib import Parallel, delayed
+
+
+def _run_jobs(jobs: "list[Callable[[int], None]]", max_mem: int) -> None:
+    """Run track/annot writer jobs. Each job is called with a per-job max_mem budget.
+    0/1 jobs run inline; otherwise jobs run concurrently on the loky backend with the
+    budget divided evenly so total peak stays under max_mem."""
+    jobs = [j for j in jobs if j is not None]
+    if len(jobs) <= 1:
+        for j in jobs:
+            j(max_mem)
+        return
+    per = max(max_mem // len(jobs), 1)
+    Parallel(n_jobs=len(jobs), backend="loky")(delayed(j)(per) for j in jobs)
+```
+
+Replace the sequential track / annot blocks in `write` with job construction. Variants
+still run first, serially (they finalize `gvl_bed` and write `regions.npy`):
+
+```python
+            # variants already written above; regions.npy is finalized here.
+            _write_regions(path, gvl_bed, contigs)
+
+            jobs: list[Callable[[int], None]] = []
+            if tracks is not None:
+                _tracks = list(tracks)
+                _bed = gvl_bed
+
+                def _tracks_job(mm: int, _tracks=_tracks, _bed=_bed):
+                    for tr in _tracks:
+                        _write_track(path / "intervals" / tr.name, _bed, tr, samples, mm)
+
+                jobs.append(_tracks_job)
+
+            if annot_tracks is not None:
+                annot_bed = regions_to_bed(
+                    np.load(path / "regions.npy"), contigs
+                ).select("chrom", "chromStart", "chromEnd")
+                _annots = dict(annot_tracks)
+
+                def _annot_job(mm: int, _annots=_annots, _bed=annot_bed):
+                    for name, source in _annots.items():
+                        _write_annot_track(
+                            path / "annot_intervals" / name, _bed, source, mm
+                        )
+
+                jobs.append(_annot_job)
+
+            if jobs:
+                logger.info(f"Writing {len(jobs)} track categor(ies).")
+                _run_jobs(jobs, max_mem)
+```
+
+Remove the now-superseded sequential `if tracks` / `if annot_tracks` blocks added in
+earlier tasks. Keep `_write_regions` exactly once.
+
+> Picklability: the job closures capture `path` (Path), `gvl_bed` (polars DataFrame),
+> `samples` (list[str]), `BigWigs`/`Table` (both picklable — `BigWigs.readers` is lazy
+> `None`; `Table` holds a polars DataFrame), and plain sources. They do **not** capture
+> genoray readers (variants run before fan-out), so loky pickling is safe.
+
+- [ ] **Step 4: Run the equivalence test**
+
+Run: `pixi run -e dev pytest tests/integration/test_write_parallel.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the broader write/track suite for regressions**
+
+Run: `pixi run -e dev pytest tests/integration -k "write or track" -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_write.py tests/integration/test_write_parallel.py
+rtk git commit -m "feat: parallelize gvl.write over track categories (variants first)"
+```
+
+---
+
+### Task 5: `gvl.update()` + robust `Tracks.from_path`
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_write.py` (new `update`)
+- Modify: `python/genvarloader/_dataset/_tracks.py` (`from_path` robustness)
+- Modify: `python/genvarloader/__init__.py` (export)
+- Test: `tests/integration/tracks/test_update.py` (new)
+
+**Interfaces:**
+- Consumes: `_write_track`, `_write_annot_track`, `_run_jobs` (Tasks 1, 2, 4), `Metadata` (in `_write.py`), `regions_to_bed`, `atomic_dir`.
+- Produces: `update(dataset: str | Path | Dataset, tracks=None, annot_tracks=None, *, overwrite=False, max_mem="4g") -> None`, exported as `gvl.update`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/integration/tracks/test_update.py`:
+
+```python
+import numpy as np
+import polars as pl
+import pytest
+
+import genvarloader as gvl
+
+
+def test_update_adds_sample_track(phased_vcf, ref_fasta, bigwigs, tmp_path):
+    out = tmp_path / "ds"
+    bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [0], "chromEnd": [64]})
+    gvl.write(out, bed, variants=phased_vcf)
+    gvl.update(out, tracks=bigwigs)
+    ds = gvl.Dataset.open(out, ref_fasta)
+    assert bigwigs.name in ds.available_tracks
+
+
+def test_update_accepts_dataset_object(phased_vcf, ref_fasta, bigwigs, tmp_path):
+    out = tmp_path / "ds"
+    bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [0], "chromEnd": [64]})
+    gvl.write(out, bed, variants=phased_vcf)
+    ds = gvl.Dataset.open(out, ref_fasta)
+    gvl.update(ds, tracks=bigwigs)  # extracts .path
+    assert bigwigs.name in gvl.Dataset.open(out, ref_fasta).available_tracks
+
+
+def test_update_rejects_extra_or_missing_samples(phased_vcf, ref_fasta, bigwigs, tmp_path):
+    out = tmp_path / "ds"
+    bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [0], "chromEnd": [64]})
+    gvl.write(out, bed, variants=phased_vcf, samples=bigwigs.samples[:-1])
+    with pytest.raises(ValueError, match="sample"):
+        gvl.update(out, tracks=bigwigs)  # bigwigs has an extra sample
+
+
+def test_update_overwrite(phased_vcf, ref_fasta, bigwigs, tmp_path):
+    out = tmp_path / "ds"
+    bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [0], "chromEnd": [64]})
+    gvl.write(out, bed, variants=phased_vcf)
+    gvl.update(out, tracks=bigwigs)
+    with pytest.raises(FileExistsError):
+        gvl.update(out, tracks=bigwigs)
+    gvl.update(out, tracks=bigwigs, overwrite=True)  # ok
+    assert not list((out / "intervals").glob("*.tmp.*"))
+```
+
+(Use the suite's existing fixtures; `bigwigs` is a `BigWigs` whose sample set equals the
+VCF's. For `test_update_rejects_extra_or_missing_samples`, the dataset is written with a
+strict subset of samples so the track has an extra one.)
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pixi run -e dev pytest tests/integration/tracks/test_update.py -v`
+Expected: FAIL with `AttributeError: module 'genvarloader' has no attribute 'update'`.
+
+- [ ] **Step 3: Implement `update` in `_write.py`**
+
+```python
+def update(
+    dataset: "str | Path | Dataset",
+    tracks: "IntervalTrack | Sequence[IntervalTrack] | None" = None,
+    annot_tracks: "dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None" = None,
+    *,
+    overwrite: bool = False,
+    max_mem: int | str = "4g",
+) -> None:
+    """Add tracks to an existing on-disk GVL dataset, analogous to :func:`write`.
+
+    Parameters
+    ----------
+    dataset
+        Path to a dataset directory, or an opened :class:`Dataset` (its ``.path`` is used).
+        A live dataset can be read while it is being updated; it will not observe the new
+        track until reopened.
+    tracks
+        Per-sample :class:`IntervalTrack` source(s) (:class:`BigWigs`, :class:`Table`),
+        written to ``<path>/intervals/<name>/``. The track's sample set must match the
+        dataset's exactly (no missing, no extra); samples are reordered to the dataset
+        order automatically.
+    annot_tracks
+        Sample-independent sources, identical to :func:`write`'s ``annot_tracks``, written
+        to ``<path>/annot_intervals/<name>/``.
+    overwrite
+        Replace a track of the same name if present; otherwise adding a duplicate name
+        raises ``FileExistsError``.
+    max_mem
+        Approximate memory budget, divided across concurrently-running categories.
+    """
+    warnings.simplefilter("ignore", RuntimeWarning)
+    try:
+        from ._impl import Dataset
+
+        path = Path(dataset.path if isinstance(dataset, Dataset) else dataset)
+        if not (path / "metadata.json").exists():
+            raise FileNotFoundError(f"{path} is not a GVL dataset (no metadata.json).")
+
+        meta = Metadata.model_validate_json((path / "metadata.json").read_text())
+        contigs = meta.contigs
+        ds_samples = meta.samples
+        max_mem_b = parse_memory(max_mem)
+
+        if tracks is not None and not isinstance(tracks, (list, tuple)):
+            tracks = [tracks]
+        _tracks = list(tracks) if tracks is not None else []
+
+        if tracks is None and annot_tracks is None:
+            raise ValueError("At least one of `tracks` or `annot_tracks` must be provided.")
+
+        # validate strict sample-set agreement for per-sample tracks
+        for tr in _tracks:
+            if set(tr.samples) != set(ds_samples):
+                missing = set(ds_samples) - set(tr.samples)
+                extra = set(tr.samples) - set(ds_samples)
+                raise ValueError(
+                    f"Track {tr.name!r} samples must exactly match the dataset's. "
+                    f"missing={missing or '{}'} extra={extra or '{}'}"
+                )
+
+        bed = regions_to_bed(np.load(path / "regions.npy"), contigs)
+        sample_bed = bed.select("chrom", "chromStart", "chromEnd")
+        annot_bed = sample_bed
+
+        jobs: list[Callable[[int], None]] = []
+
+        if _tracks:
+            (path / "intervals").mkdir(exist_ok=True)
+
+            def _tracks_job(mm: int, _tracks=_tracks, _bed=sample_bed):
+                for tr in _tracks:
+                    with atomic_dir(
+                        path / "intervals" / tr.name, overwrite=overwrite
+                    ) as tmp:
+                        _write_track(tmp, _bed, tr, ds_samples, mm)
+
+            jobs.append(_tracks_job)
+
+        if annot_tracks is not None:
+            (path / "annot_intervals").mkdir(exist_ok=True)
+            _annots = dict(annot_tracks)
+
+            def _annot_job(mm: int, _annots=_annots, _bed=annot_bed):
+                for name, source in _annots.items():
+                    with atomic_dir(
+                        path / "annot_intervals" / name, overwrite=overwrite
+                    ) as tmp:
+                        _write_annot_track(tmp, _bed, source, mm)
+
+            jobs.append(_annot_job)
+
+        _run_jobs(jobs, max_mem_b)
+    finally:
+        warnings.simplefilter("default")
+```
+
+> `_write_track` is given `ds_samples` (the dataset's stored sample order). It already
+> raises on samples missing from the track; the exact-set check above additionally
+> rejects extras. Passing `ds_samples` performs the reorder-to-dataset-order.
+
+- [ ] **Step 4: Make `Tracks.from_path` robust to in-flight `atomic_dir` siblings**
+
+In `python/genvarloader/_dataset/_tracks.py` `from_path`, both scan loops currently do
+`for p in strack_dir.iterdir(): if len(list(p.iterdir())) == 0: ...`. A concurrent
+`update` leaves `<name>.tmp.<pid>-<hex>`, `<name>.old.<hex>` dirs and a `<name>.lock`
+file in the same parent; the latter is a file and `p.iterdir()` on it raises. Guard both
+loops:
+
+```python
+        def _is_track_dir(p: Path) -> bool:
+            return (
+                p.is_dir()
+                and ".tmp." not in p.name
+                and ".old." not in p.name
+                and not p.name.endswith(".lock")
+            )
+
+        available_tracks: list[str] = []
+        if strack_dir.exists():
+            for p in strack_dir.iterdir():
+                if not _is_track_dir(p):
+                    continue
+                if len(list(p.iterdir())) == 0:
+                    p.rmdir()
+                else:
+                    available_tracks.append(p.name)
+            available_tracks.sort()
+```
+
+Apply the same `_is_track_dir` guard to the `available_annots` loop. Define
+`_is_track_dir` once at the top of `from_path`.
+
+- [ ] **Step 5: Export `update`**
+
+In `python/genvarloader/__init__.py`:
+
+```python
+from ._dataset._write import get_splice_bed, update, write
+```
+
+and add `"update",` to `__all__` (keep it alphabetized).
+
+- [ ] **Step 6: Run the update tests**
+
+Run: `pixi run -e dev pytest tests/integration/tracks/test_update.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_write.py python/genvarloader/_dataset/_tracks.py python/genvarloader/__init__.py tests/integration/tracks/test_update.py
+rtk git commit -m "feat: add gvl.update for atomic post-hoc track addition"
+```
+
+---
+
+### Task 6: Remove `Dataset.write_annot_tracks`, migrate its test, delete `_annot_to_intervals`
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_impl.py` (delete method + `_annot_to_intervals`)
+- Modify: `tests/integration/tracks/test_annot_tracks.py` (migrate to `gvl.update`)
+
+**Interfaces:**
+- Removes: `Dataset.write_annot_tracks`, `genvarloader._dataset._impl._annot_to_intervals`.
+- The Task 2 regression test imported `_annot_to_intervals` as an oracle; that test has
+  served its purpose. Update it to assert against a hand-computed expectation instead (see
+  Step 3) so deleting the oracle does not break the suite.
+
+- [ ] **Step 1: Migrate the existing `test_annot_tracks` test**
+
+Replace the body of `test_annot_tracks` in `tests/integration/tracks/test_annot_tracks.py`
+so it writes the annot via `gvl.update` rather than `dataset.write_annot_tracks`:
+
+```python
+def test_annot_tracks(phased_vcf, ref_fasta, tmp_path):
+    import genvarloader as gvl
+    import polars as pl
+
+    out = tmp_path / "ds"
+    bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [0], "chromEnd": [64]})
+    gvl.write(out, bed, variants=phased_vcf)
+    ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated")
+    annots = ds.regions.with_columns(
+        chromEnd=pl.col("chromStart") + 1, score=pl.lit(1.0)
+    )
+    gvl.update(out, annot_tracks={"5ss": annots})
+    annot_ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated").with_tracks(
+        "5ss", "tracks"
+    )
+    haps, tracks = annot_ds[:]
+    mask = haps.ref_coords == ak.Array(
+        annot_ds.regions["chromStart"].to_numpy()[:, None, None]
+    )
+    assert ak.all(tracks[:, :, 0][mask] == 1)
+```
+
+> A DataFrame annot source uses polars-bio, so gate this test with the
+> `GVL_TEST_EXPERIMENTAL` module skip (mirror `tests/unit/test_table.py`), since
+> `test_annot_tracks.py` would otherwise pull polars-bio into CI. If keeping it in CI is
+> required, switch the source to a bigWig fixture.
+
+- [ ] **Step 2: Delete `Dataset.write_annot_tracks`**
+
+Remove the whole method `Dataset.write_annot_tracks` (`_impl.py` ~1548-1613).
+
+- [ ] **Step 3: Delete `_annot_to_intervals` and update the Task-2 oracle test**
+
+Remove `_annot_to_intervals` (`_impl.py` ~1871-1898). Then in
+`tests/unit/test_write_annot.py` replace the oracle comparison with a hand-computed
+expectation so the test no longer imports the deleted function:
+
+```python
+def test_annot_overlap_explicit():
+    from genvarloader._table import annot_overlap
+
+    regions, annot = _regions(), _annot()
+    got = annot_overlap(regions, annot)
+    # region 0 [chr1:0-100] overlaps the 3 chr1 annots; region 1 [chr1:50-150] overlaps
+    # the chr1 annots at 60-70 and 90-95; region 2 [chr2:0-100] overlaps the chr2 annot.
+    np.testing.assert_array_equal(
+        np.diff(got.values.offsets), np.array([3, 2, 1])
+    )
+    # region 2's single interval is the chr2 annot 5-15 with score 4.0
+    np.testing.assert_array_equal(np.asarray(got.starts[2]), [5])
+    np.testing.assert_array_equal(np.asarray(got.ends[2]), [15])
+    np.testing.assert_allclose(np.asarray(got.values[2]), [4.0])
+```
+
+Delete the now-stale `test_annot_overlap_matches_pyranges_oracle`.
+
+- [ ] **Step 4: Grep for stragglers**
+
+Run: `pixi run -e dev python -c "import genvarloader"` (import sanity)
+Run: `rtk grep -rn "write_annot_tracks\|_annot_to_intervals" python/ tests/`
+Expected: no references except possibly in `docs/` (handled in Task 7). Fix any code hits.
+
+- [ ] **Step 5: Run the affected tests**
+
+Run: `GVL_TEST_EXPERIMENTAL=1 pixi run -e dev pytest tests/integration/tracks/test_annot_tracks.py tests/unit/test_write_annot.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_impl.py tests/integration/tracks/test_annot_tracks.py tests/unit/test_write_annot.py
+rtk git commit -m "refactor: remove Dataset.write_annot_tracks and _annot_to_intervals"
+```
+
+---
+
+### Task 7: Docs — SKILL.md, changelog
+
+**Files:**
+- Modify: `skills/genvarloader/SKILL.md`
+- Modify: `docs/source/changelog.md`
+
+- [ ] **Step 1: Update the skill**
+
+In `skills/genvarloader/SKILL.md`:
+- Add `gvl.update(dataset, tracks=, annot_tracks=, *, overwrite=, max_mem=)` to the public
+  API section, describing: accepts a path or `Dataset`; per-sample `tracks` need exact
+  sample-set agreement; `annot_tracks` are sample-less (path to table / path to bigWig /
+  DataFrame/LazyFrame, BED-like columns); table/DataFrame annot sources need the `table`
+  extra and are experimental; atomic per-track publish; live datasets don't auto-discover
+  updates.
+- Add `annot_tracks=` to the `gvl.write` signature and notes.
+- Note `gvl.write` now parallelizes over variants/tracks/annot_tracks (variants first,
+  then tracks ∥ annot_tracks; `max_mem` divided across concurrent categories).
+- Remove `Dataset.write_annot_tracks` from the API surface and the gotchas table; point
+  readers to `gvl.update(..., annot_tracks=)`.
+
+- [ ] **Step 2: Update the changelog**
+
+Add an entry to `docs/source/changelog.md` under the current unreleased/next version:
+
+```
+- **write/update**: `gvl.write` gains `annot_tracks=` and parallelizes over
+  variants/tracks/annot_tracks. New `gvl.update(dataset, tracks=, annot_tracks=)` adds
+  tracks to an existing dataset with atomic per-track publish. `Dataset.write_annot_tracks`
+  removed (use `gvl.update`). Annotation extraction now uses the polars-bio backend
+  (table/DataFrame sources require the `table` extra; bigWig sources do not).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+rtk git add skills/genvarloader/SKILL.md docs/source/changelog.md
+rtk git commit -m "docs: document gvl.update, write annot_tracks, parallel writing"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full track/write/update suite:
+  `GVL_TEST_EXPERIMENTAL=1 pixi run -e dev pytest tests/integration -k "track or write or update or annot" -v`
+- [ ] Run ruff + typecheck:
+  `pixi run -e dev ruff check python/` and `pixi run -e dev typecheck`
+- [ ] Import sanity: `pixi run -e dev python -c "import genvarloader as gvl; gvl.update; gvl.write"`
+
+## Self-review notes (spec coverage)
+
+- annot DRY-with-Table via polars-bio → Tasks 2, 6 (retire pyranges).
+- annot accepts path/DataFrame/LazyFrame/bigwig (not Table/BigWigs objects) → Task 2/3.
+- `write` gains `annot_tracks` → Task 3.
+- `write` parallel, per-category, variants-first, `max_mem` divided → Task 4.
+- `gvl.update` top-level, path-or-Dataset, atomic per-track, sample-set agreement,
+  parallel → Task 5.
+- per-source polars-bio gating + `ExperimentalWarning` → Tasks 2, 3, 5 (warning emitted in
+  `annot_overlap`; `Table` warns on its own construction).
+- remove `Dataset.write_annot_tracks`; leave `write_transformed_track` stub untouched →
+  Task 6 (stub never referenced).
+- docs/skill/changelog → Task 7.
+- reader-during-update robustness (`.tmp.`/`.old.`/`.lock` siblings) → Task 5 Step 4.

--- a/docs/superpowers/specs/2026-06-16-update-and-annot-tracks-design.md
+++ b/docs/superpowers/specs/2026-06-16-update-and-annot-tracks-design.md
@@ -6,11 +6,11 @@ Date: 2026-06-16
 
 Three related changes to the dataset writing/updating surface:
 
-1. Add a unified `genvarloader.experimental.update(path_or_dataset, ...)` function for
-   adding tracks to an existing dataset on disk, analogous to `gvl.write()`. It
-   replaces `Dataset.write_annot_tracks` and adds post-hoc per-sample track addition.
-   It lives under `genvarloader.experimental` (alongside `Table`) because its annot
-   extraction depends on the polars-bio backend (see gating below).
+1. Add a unified top-level `gvl.update(path_or_dataset, ...)` function for adding
+   tracks to an existing dataset on disk, analogous to `gvl.write()`. It replaces
+   `Dataset.write_annot_tracks` and adds post-hoc per-sample track addition. It is a
+   public, top-level symbol symmetric with `gvl.write` — the polars-bio dependency is
+   gated per-source (see gating below), not by hiding the whole function.
 2. Make `gvl.write()` accept `annot_tracks` (sample-independent annotation tracks)
    in addition to the existing `tracks` (per-sample).
 3. Parallelize `gvl.write()` over its `variants`, `tracks`, and `annot_tracks`
@@ -107,9 +107,9 @@ path is core.
   temp dir is published atomically at the end. No per-track atomic rename inside
   `write`.
 
-### `genvarloader.experimental.update()`
+### `gvl.update()`
 
-Signature (exported from `genvarloader.experimental`, **not** the top-level namespace):
+Signature (public, exported as top-level `gvl.update`, symmetric with `gvl.write`):
 
 ```python
 def update(
@@ -122,7 +122,10 @@ def update(
 ) -> None:
 ```
 
-- Emits `ExperimentalWarning` on call (consistent with `gvl.Table`).
+- `update` does **not** itself emit `ExperimentalWarning`; the warning is per-source,
+  exactly as in `write`: a `Table` passed as a per-sample `tracks` source warns on its
+  own construction, and a table/DataFrame `annot_tracks` source warns via the shared
+  polars-bio annot extractor. A pure `BigWigs`/bigwig-only `update` warns nowhere.
 - Accepts a path **or** a `Dataset` (extracts `.path`); does not require a live
   `Dataset` to be opened for use.
 - Reads the dataset's already-finalized region ends from disk (`input_regions.arrow` /
@@ -143,8 +146,7 @@ def update(
 
 ### Removed / unchanged API
 
-- **Removed:** `Dataset.write_annot_tracks` (subsumed by
-  `genvarloader.experimental.update(..., annot_tracks=)`).
+- **Removed:** `Dataset.write_annot_tracks` (subsumed by `gvl.update(..., annot_tracks=)`).
 - **Unchanged / out of scope:** `Dataset.write_transformed_track` and
   `Tracks.write_transformed_track` remain as the existing `NotImplementedError` stub.
 
@@ -157,30 +159,26 @@ Leaf writers shared by `write` and `update`:
 `write` calls these into its `atomic_dir` temp dataset; `update` calls them into a
 per-track temp dir and atomic-renames into the live dataset. A small orchestration
 helper encapsulates "run these category jobs with loky, dividing `max_mem`" and is
-shared by both. `update` itself lives in `experimental/` and calls these shared
-writers; `write` stays in `_dataset/_write.py`.
+shared by both. Both `write` and `update` live in `_dataset/_write.py` and call these
+shared writers.
 
 ## Affected files
 
 - `python/genvarloader/_dataset/_write.py` — `write` gains `annot_tracks` + parallel
-  orchestration; new `_write_annot_track`; shared job-runner helper. The annot
-  table-source extraction routes through the polars-bio guard in `_table.py`.
-- `python/genvarloader/experimental/__init__.py` (or a new
-  `python/genvarloader/experimental/_update.py`) — `update` lives here; add to the
-  experimental `__all__`.
+  orchestration; new `_write_annot_track`; new `update`; shared job-runner helper. The
+  annot table-source extraction routes through the polars-bio guard in `_table.py`.
 - `python/genvarloader/_dataset/_impl.py` — remove `Dataset.write_annot_tracks`;
   retire `_annot_to_intervals` (replaced by polars-bio extraction).
 - `python/genvarloader/_table.py` — reuse/extract its polars-bio overlap helper +
   `_import_polars_bio`/`ExperimentalWarning` guard for the annot table path (avoid
   duplicating overlap setup or the gating).
-- `python/genvarloader/__init__.py` — `update` is **not** added to the top-level
-  `__all__` (it stays under `experimental`).
-- `skills/genvarloader/SKILL.md` — document `genvarloader.experimental.update`,
-  `write`'s `annot_tracks`, the `[table]`-extra gating of table-source annots, and the
-  removal of `Dataset.write_annot_tracks`.
+- `python/genvarloader/__init__.py` — export `update` (add to the top-level `__all__`),
+  symmetric with `write`.
+- `skills/genvarloader/SKILL.md` — document `gvl.update`, `write`'s `annot_tracks`, the
+  `[table]`-extra gating of table-source annots, and the removal of
+  `Dataset.write_annot_tracks`.
 - `docs/source/changelog.md` — note the API change.
-- `tests/integration/tracks/test_annot_tracks.py` — migrate to
-  `genvarloader.experimental.update(...)`.
+- `tests/integration/tracks/test_annot_tracks.py` — migrate to `gvl.update(...)`.
 
 ## Testing
 
@@ -202,10 +200,10 @@ writers; `write` stays in `_dataset/_write.py`.
 
 - polars-bio overlap is the same backend flagged as intermittently segfaulting
   (issue #395, tracked in memory). Annot extraction for table/DataFrame sources now
-  depends on it, and is therefore gated behind the `[table]` extra +
-  `ExperimentalWarning` (same guard as `gvl.Table`), with `update` living entirely
-  under `genvarloader.experimental`. The bigwig and per-sample (`BigWigs`) paths do not
-  touch polars-bio.
+  depends on it, and is therefore gated per-source behind the `[table]` extra +
+  `ExperimentalWarning` (same guard as `gvl.Table`). Both `write` and `update` are
+  public top-level symbols; the gating is on the source, not the function. The bigwig
+  and per-sample (`BigWigs`) paths do not touch polars-bio.
 - loky + memmap writing across processes: each job writes its own subdir, so there is
   no shared-state hazard, but child processes must reconstruct readers (genoray /
   pyBigWig / polars-bio) independently. Confirm picklability of the job closures and

--- a/docs/superpowers/specs/2026-06-16-update-and-annot-tracks-design.md
+++ b/docs/superpowers/specs/2026-06-16-update-and-annot-tracks-design.md
@@ -6,9 +6,11 @@ Date: 2026-06-16
 
 Three related changes to the dataset writing/updating surface:
 
-1. Add a unified `gvl.update(path_or_dataset, ...)` function for adding tracks to an
-   existing dataset on disk, analogous to `gvl.write()`. It replaces
-   `Dataset.write_annot_tracks` and adds post-hoc per-sample track addition.
+1. Add a unified `genvarloader.experimental.update(path_or_dataset, ...)` function for
+   adding tracks to an existing dataset on disk, analogous to `gvl.write()`. It
+   replaces `Dataset.write_annot_tracks` and adds post-hoc per-sample track addition.
+   It lives under `genvarloader.experimental` (alongside `Table`) because its annot
+   extraction depends on the polars-bio backend (see gating below).
 2. Make `gvl.write()` accept `annot_tracks` (sample-independent annotation tracks)
    in addition to the existing `tracks` (per-sample).
 3. Parallelize `gvl.write()` over its `variants`, `tracks`, and `annot_tracks`
@@ -69,10 +71,19 @@ A new leaf writer `_write_annot_track` produces a sample-less `RaggedIntervals`
 
 - table/DataFrame/LazyFrame source → **polars-bio** overlap against the dataset's
   region bed (the same machinery `gvl.Table` uses). Replaces and retires
-  `_annot_to_intervals` (pyranges).
+  `_annot_to_intervals` (pyranges). This path is **gated like `gvl.Table`**: it lazily
+  imports polars-bio via `_table._import_polars_bio` (raising the helpful
+  `pip install genvarloader[table]` error when missing) and emits
+  `ExperimentalWarning`. So a table/DataFrame annot source requires the `[table]`
+  extra and is experimental.
 - bigwig path source → **Rust per-region interval extraction** via the existing
   `BigWigs` backend (bigwig queries are already region-scoped, so no join is needed),
-  collapsed into a single sample-less interval set.
+  collapsed into a single sample-less interval set. This path is **not** gated — it
+  does not touch polars-bio and is fully supported core functionality.
+
+So in `gvl.write`, `annot_tracks` itself is a public, supported parameter, but the
+table/DataFrame source path is experimental + needs `[table]`, while the bigwig source
+path is core.
 
 ### `gvl.write()` parallelization
 
@@ -96,9 +107,9 @@ A new leaf writer `_write_annot_track` produces a sample-less `RaggedIntervals`
   temp dir is published atomically at the end. No per-track atomic rename inside
   `write`.
 
-### `gvl.update()`
+### `genvarloader.experimental.update()`
 
-Signature (public, exported as `gvl.update`):
+Signature (exported from `genvarloader.experimental`, **not** the top-level namespace):
 
 ```python
 def update(
@@ -111,6 +122,7 @@ def update(
 ) -> None:
 ```
 
+- Emits `ExperimentalWarning` on call (consistent with `gvl.Table`).
 - Accepts a path **or** a `Dataset` (extracts `.path`); does not require a live
   `Dataset` to be opened for use.
 - Reads the dataset's already-finalized region ends from disk (`input_regions.arrow` /
@@ -131,7 +143,8 @@ def update(
 
 ### Removed / unchanged API
 
-- **Removed:** `Dataset.write_annot_tracks` (subsumed by `gvl.update(..., annot_tracks=)`).
+- **Removed:** `Dataset.write_annot_tracks` (subsumed by
+  `genvarloader.experimental.update(..., annot_tracks=)`).
 - **Unchanged / out of scope:** `Dataset.write_transformed_track` and
   `Tracks.write_transformed_track` remain as the existing `NotImplementedError` stub.
 
@@ -144,21 +157,30 @@ Leaf writers shared by `write` and `update`:
 `write` calls these into its `atomic_dir` temp dataset; `update` calls them into a
 per-track temp dir and atomic-renames into the live dataset. A small orchestration
 helper encapsulates "run these category jobs with loky, dividing `max_mem`" and is
-shared by both.
+shared by both. `update` itself lives in `experimental/` and calls these shared
+writers; `write` stays in `_dataset/_write.py`.
 
 ## Affected files
 
 - `python/genvarloader/_dataset/_write.py` — `write` gains `annot_tracks` + parallel
-  orchestration; new `_write_annot_track`; new `update`; shared job-runner helper.
+  orchestration; new `_write_annot_track`; shared job-runner helper. The annot
+  table-source extraction routes through the polars-bio guard in `_table.py`.
+- `python/genvarloader/experimental/__init__.py` (or a new
+  `python/genvarloader/experimental/_update.py`) — `update` lives here; add to the
+  experimental `__all__`.
 - `python/genvarloader/_dataset/_impl.py` — remove `Dataset.write_annot_tracks`;
-  retire `_annot_to_intervals` (moved/replaced by polars-bio extraction).
-- `python/genvarloader/__init__.py` — export `update` (add to `__all__`).
-- `python/genvarloader/_table.py` — reuse/extract its polars-bio overlap helper for
-  the annot table path (avoid duplicating overlap setup).
-- `skills/genvarloader/SKILL.md` — document `gvl.update`, `annot_tracks`, removal of
-  `Dataset.write_annot_tracks`.
+  retire `_annot_to_intervals` (replaced by polars-bio extraction).
+- `python/genvarloader/_table.py` — reuse/extract its polars-bio overlap helper +
+  `_import_polars_bio`/`ExperimentalWarning` guard for the annot table path (avoid
+  duplicating overlap setup or the gating).
+- `python/genvarloader/__init__.py` — `update` is **not** added to the top-level
+  `__all__` (it stays under `experimental`).
+- `skills/genvarloader/SKILL.md` — document `genvarloader.experimental.update`,
+  `write`'s `annot_tracks`, the `[table]`-extra gating of table-source annots, and the
+  removal of `Dataset.write_annot_tracks`.
 - `docs/source/changelog.md` — note the API change.
-- `tests/integration/tracks/test_annot_tracks.py` — migrate to `gvl.update(...)`.
+- `tests/integration/tracks/test_annot_tracks.py` — migrate to
+  `genvarloader.experimental.update(...)`.
 
 ## Testing
 
@@ -179,10 +201,11 @@ shared by both.
 ## Risks
 
 - polars-bio overlap is the same backend flagged as intermittently segfaulting
-  (issue #395, tracked in memory). Annot extraction in `write`/`update` now depends on
-  it for table/DataFrame sources. The bigwig and per-sample (`BigWigs`) paths do not.
-  Consider whether annot table extraction should be behind the same opt-in/experimental
-  guard as `gvl.Table`, or gated to the `[table]` extra.
+  (issue #395, tracked in memory). Annot extraction for table/DataFrame sources now
+  depends on it, and is therefore gated behind the `[table]` extra +
+  `ExperimentalWarning` (same guard as `gvl.Table`), with `update` living entirely
+  under `genvarloader.experimental`. The bigwig and per-sample (`BigWigs`) paths do not
+  touch polars-bio.
 - loky + memmap writing across processes: each job writes its own subdir, so there is
   no shared-state hazard, but child processes must reconstruct readers (genoray /
   pyBigWig / polars-bio) independently. Confirm picklability of the job closures and

--- a/docs/superpowers/specs/2026-06-16-update-and-annot-tracks-design.md
+++ b/docs/superpowers/specs/2026-06-16-update-and-annot-tracks-design.md
@@ -1,0 +1,189 @@
+# Design: `gvl.update()`, `annot_tracks` in `gvl.write()`, and parallel writing
+
+Date: 2026-06-16
+
+## Goal
+
+Three related changes to the dataset writing/updating surface:
+
+1. Add a unified `gvl.update(path_or_dataset, ...)` function for adding tracks to an
+   existing dataset on disk, analogous to `gvl.write()`. It replaces
+   `Dataset.write_annot_tracks` and adds post-hoc per-sample track addition.
+2. Make `gvl.write()` accept `annot_tracks` (sample-independent annotation tracks)
+   in addition to the existing `tracks` (per-sample).
+3. Parallelize `gvl.write()` over its `variants`, `tracks`, and `annot_tracks`
+   inputs using background processes for a speedup when they are supplied together.
+4. Rework annotation-track extraction to be DRY with `gvl.Table`: use **polars-bio**
+   overlap for table/DataFrame sources (retiring the pyranges `_annot_to_intervals`
+   path).
+
+Out of scope:
+- Transformed-track writing (`Dataset.write_transformed_track` / `Tracks.write_transformed_track`)
+  remains a `NotImplementedError` stub, untouched.
+- Live (already-open) `Dataset` objects discovering that the on-disk dataset gained
+  a new track. Updates are written atomically so a live dataset can keep reading,
+  but it will not see new tracks until reopened.
+
+## Background (current state)
+
+- `gvl.write(path, bed, variants=, tracks=, ...)` writes a *complete* dataset into a
+  private temp dir via `atomic_dir` and publishes it with `os.replace`. `tracks` is
+  an `IntervalTrack` (`BigWigs`/`Table`) or a sequence; each is written per-sample to
+  `intervals/<name>/` by `_write_track`.
+- `Dataset.write_annot_tracks(tracks: dict[str, str|Path|pl.DataFrame])` adds
+  *sample-independent* BED annotations *post-hoc*, writing **directly into the live
+  dataset dir** (`annot_intervals/<name>/`) — not atomic. It uses the bespoke
+  `_annot_to_intervals` (seqpro/pyranges join), a different code path from how
+  `Table`/`BigWigs` extract intervals.
+- `metadata.json` does **not** enumerate tracks. Tracks are discovered by
+  `Tracks.from_path` scanning `intervals/` (kind `SAMPLE`) and `annot_intervals/`
+  (kind `ANNOT`). Adding a track is therefore purely additive — no metadata mutation.
+- On-disk offset shapes: sample tracks are offset over `(regions × samples)`; annot
+  tracks over `(regions)` only.
+- The variant pass mutates `gvl_bed.chromEnd`: each region's end is recomputed to the
+  furthest retained variant's end (`_region_end` / `_region_ends_from_list`), which can
+  exceed the input region end whenever a deletion straddles the edge. This happens
+  **regardless of `extend_to_length`**. Tracks are then written against the recomputed
+  bed.
+
+## Decisions
+
+### Source types
+
+- `gvl.write(..., tracks=)` and `gvl.update(..., tracks=)`: per-sample sources, i.e.
+  `IntervalTrack` objects (`BigWigs`, `Table`). Unchanged.
+- `annot_tracks` (in both `write` and `update`): a `dict[str, source]` where each
+  `source` is one of:
+  - a path to an interval table (`.csv/.tsv/.txt/.parquet/.arrow/.ipc`),
+  - a path to a bigwig,
+  - a `pl.DataFrame` or `pl.LazyFrame` interpreted as an interval table.
+
+  `annot_tracks` does **not** accept `Table`/`BigWigs` objects: those force a sample
+  name per source, which is redundant with the track `name` and confusing for a
+  sample-less annotation.
+
+### Annotation extraction (DRY with `gvl.Table`)
+
+A new leaf writer `_write_annot_track` produces a sample-less `RaggedIntervals`
+(`(regions, None)`) and writes `intervals.npy` + `offsets.npy`:
+
+- table/DataFrame/LazyFrame source → **polars-bio** overlap against the dataset's
+  region bed (the same machinery `gvl.Table` uses). Replaces and retires
+  `_annot_to_intervals` (pyranges).
+- bigwig path source → **Rust per-region interval extraction** via the existing
+  `BigWigs` backend (bigwig queries are already region-scoped, so no join is needed),
+  collapsed into a single sample-less interval set.
+
+### `gvl.write()` parallelization
+
+- New parameter `annot_tracks: dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None = None`.
+- Orchestration over up to 3 category jobs (one for variants, one running all
+  `tracks` sequentially, one running all `annot_tracks` sequentially):
+  - **If `variants` is provided:** run the variants job **first** (serially) so it
+    finalizes `gvl_bed.chromEnd`, then run **tracks ∥ annot_tracks** in parallel.
+  - **If `variants` is not provided:** run **tracks ∥ annot_tracks** in parallel.
+  - `extend_to_length` does **not** affect orchestration (decision B): the variant
+    pass can extend `chromEnd` even when `extend_to_length=False`, so tracks must
+    always be written against the finalized bed to preserve current coverage
+    semantics.
+- `max_mem` is divided across the jobs running concurrently so total peak stays under
+  the user's budget. (Variants runs alone in its phase and gets the full budget;
+  tracks+annot split the budget when they run together.)
+- Backend: joblib with the loky process backend (already the de-facto backend; the
+  existing `os.fork` polars `RuntimeWarning` suppression remains). All jobs write into
+  the single `atomic_dir` temp dataset directory (distinct subdirs: `genotypes/`,
+  `intervals/<name>/`, `annot_intervals/<name>/` — no write conflicts), and the entire
+  temp dir is published atomically at the end. No per-track atomic rename inside
+  `write`.
+
+### `gvl.update()`
+
+Signature (public, exported as `gvl.update`):
+
+```python
+def update(
+    dataset: str | Path | Dataset,
+    tracks: IntervalTrack | Sequence[IntervalTrack] | None = None,
+    annot_tracks: dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None = None,
+    *,
+    overwrite: bool = False,
+    max_mem: int | str = "4g",
+) -> None:
+```
+
+- Accepts a path **or** a `Dataset` (extracts `.path`); does not require a live
+  `Dataset` to be opened for use.
+- Reads the dataset's already-finalized region ends from disk (`input_regions.arrow` /
+  `regions.npy`). There is **no variant pass**, so there is no chromEnd coupling:
+  `tracks ∥ annot_tracks` run fully in parallel, `max_mem` divided across concurrent
+  jobs. Same loky backend as `write`.
+- `tracks` (per-sample): errors unless the track's sample set is in **exact agreement**
+  with the dataset's samples — no missing, no extra. Reordering the track's samples to
+  match the dataset order is allowed and performed automatically.
+- `annot_tracks`: sample-less, same source types and extraction as `write`.
+- `overwrite`: if `False`, adding a track whose name already exists raises; if `True`,
+  the existing track is replaced.
+- **Atomic per-track publish:** each track is built into a private temp dir and
+  `atomic_dir`-renamed into its final `intervals/<name>/` or `annot_intervals/<name>/`
+  location. This lets a dataset be read while it is being updated without contention.
+  (`atomic_dir` already implements temp-build → `os.replace`, including the
+  move-aside-then-rename path for `overwrite=True`.)
+
+### Removed / unchanged API
+
+- **Removed:** `Dataset.write_annot_tracks` (subsumed by `gvl.update(..., annot_tracks=)`).
+- **Unchanged / out of scope:** `Dataset.write_transformed_track` and
+  `Tracks.write_transformed_track` remain as the existing `NotImplementedError` stub.
+
+## Shared structure
+
+Leaf writers shared by `write` and `update`:
+- `_write_track(out_dir, bed, track, samples, max_mem)` — per-sample, existing.
+- `_write_annot_track(out_dir, region_bed, source, max_mem)` — new, sample-less.
+
+`write` calls these into its `atomic_dir` temp dataset; `update` calls them into a
+per-track temp dir and atomic-renames into the live dataset. A small orchestration
+helper encapsulates "run these category jobs with loky, dividing `max_mem`" and is
+shared by both.
+
+## Affected files
+
+- `python/genvarloader/_dataset/_write.py` — `write` gains `annot_tracks` + parallel
+  orchestration; new `_write_annot_track`; new `update`; shared job-runner helper.
+- `python/genvarloader/_dataset/_impl.py` — remove `Dataset.write_annot_tracks`;
+  retire `_annot_to_intervals` (moved/replaced by polars-bio extraction).
+- `python/genvarloader/__init__.py` — export `update` (add to `__all__`).
+- `python/genvarloader/_table.py` — reuse/extract its polars-bio overlap helper for
+  the annot table path (avoid duplicating overlap setup).
+- `skills/genvarloader/SKILL.md` — document `gvl.update`, `annot_tracks`, removal of
+  `Dataset.write_annot_tracks`.
+- `docs/source/changelog.md` — note the API change.
+- `tests/integration/tracks/test_annot_tracks.py` — migrate to `gvl.update(...)`.
+
+## Testing
+
+- annot extraction via polars-bio matches the previous pyranges output on the existing
+  fixtures (coordinate alignment assertion in `test_annot_tracks`).
+- `gvl.update` adds per-sample tracks and annot tracks to a written dataset; reopening
+  shows them via `with_tracks`.
+- `gvl.update` sample-set agreement: missing/extra samples raise; reordered samples are
+  accepted and aligned.
+- `gvl.update` atomicity: a track is built and published atomically (no partial
+  `intervals/<name>/` visible; no leftover temp dirs); `overwrite` semantics.
+- `gvl.write` with `variants` + `tracks` + `annot_tracks` together produces a dataset
+  byte-identical (or equivalent) to the pre-parallel sequential path, and track spans
+  match the variant-finalized bed.
+- `gvl.write` parallel `max_mem` division stays within budget.
+- bigwig-as-annot-source produces a sample-less annot track.
+
+## Risks
+
+- polars-bio overlap is the same backend flagged as intermittently segfaulting
+  (issue #395, tracked in memory). Annot extraction in `write`/`update` now depends on
+  it for table/DataFrame sources. The bigwig and per-sample (`BigWigs`) paths do not.
+  Consider whether annot table extraction should be behind the same opt-in/experimental
+  guard as `gvl.Table`, or gated to the `[table]` extra.
+- loky + memmap writing across processes: each job writes its own subdir, so there is
+  no shared-state hazard, but child processes must reconstruct readers (genoray /
+  pyBigWig / polars-bio) independently. Confirm picklability of the job closures and
+  reader objects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,13 @@ lint.ignore = ["E501"]
 
 [tool.pyrefly]
 project-includes = ["python/genvarloader", "tests"]
+# Resolve `genvarloader` to this checkout's `python/` source. Without an
+# explicit search-path, pyrefly's heuristics can resolve the package to a
+# different checkout (e.g. when this tree is a git worktree nested under the
+# main repo), type-checking stale sources and reporting phantom
+# unexpected-keyword/missing-attribute errors for newly added public API.
+search-path = ["python", "tests"]
+disable-search-path-heuristics = true
 # Heuristics disabled: pyrefly otherwise auto-excludes our maturin source dir
 # `python/` because the name collides with the site-packages heuristic.
 disable-project-excludes-heuristics = true

--- a/python/genvarloader/__init__.py
+++ b/python/genvarloader/__init__.py
@@ -27,7 +27,7 @@ from ._dataset._insertion_fill import (
 from ._dataset._rag_variants import RaggedVariants
 from ._dataset._reference import RefDataset, Reference
 from ._dataset._svar_link import migrate_svar_link
-from ._dataset._write import get_splice_bed, write
+from ._dataset._write import get_splice_bed, update, write
 from ._dummy import get_dummy_dataset
 from ._flat import _Flat as FlatRagged
 from ._flat import _FlatAnnotatedHaps as FlatAnnotatedHaps
@@ -72,6 +72,7 @@ __all__ = [
     "read_bedlike",
     "sites_vcf_to_table",
     "to_nested_tensor",
+    "update",
     "with_length",
     "write",
 ]

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -8,14 +8,12 @@ from typing import Generic, Literal, NoReturn, TypeVar, overload
 import awkward as ak
 import numpy as np
 import polars as pl
-import seqpro as sp
 from loguru import logger
 from numpy.typing import NDArray
 from seqpro.rag import Ragged
 from typing_extensions import Self, assert_never
 
 from .._ragged import (
-    INTERVAL_DTYPE,
     RaggedAnnotatedHaps,
     RaggedIntervals,
     RaggedSeqs,
@@ -23,10 +21,6 @@ from .._ragged import (
 )
 from .._torch import TORCH_AVAILABLE, TorchDataset, get_dataloader
 from .._types import AnnotatedHaps, Idx, StrIdx
-from .._utils import (
-    lengths_to_offsets,
-    normalize_contig_name,
-)
 from ._flat_variants import DummyVariant
 from ._indexing import DatasetIndexer, SpliceIndexer, is_str_arr
 from ._insertion_fill import InsertionFill
@@ -43,7 +37,6 @@ from ._reconstruct import (
 from ._flat_variants import VarWindowOpt
 from ._reference import Reference
 from ._splice import SpliceMap
-from ._utils import regions_to_bed
 
 if TORCH_AVAILABLE:
     import torch
@@ -1545,73 +1538,6 @@ class Dataset:
 
         return replace(self, _tracks=new_tracks)  # type: ignore[bad-return]  # dataclasses.replace returns Self but pyrefly widens to base Dataset union
 
-    def write_annot_tracks(
-        self, tracks: dict[str, str | Path | pl.DataFrame], overwrite: bool = False
-    ) -> Self:
-        """Write annotation tracks to the dataset. Returns a new dataset with the
-        tracks available. Activate them with :meth:`with_tracks()`.
-
-        Parameters
-        ----------
-        tracks
-            Paths to the annotation tracks (or literal tables) in BED-like format.
-            Keys should be the track names and values should be the paths to the BED files
-            or polars.DataFrames.
-
-            .. note::
-                Only supports BED files for now.
-
-        overwrite
-            Whether to overwrite the existing tracks, by default False
-        """
-        if (
-            self.available_tracks is not None
-            and (exists := set(tracks) & set(self.available_tracks))
-            and not overwrite
-        ):
-            raise ValueError(f"Some tracks already exists in the dataset: {exists}")
-
-        for name, bedlike in tracks.items():
-            out_dir = self.path / "annot_intervals" / name
-            out_dir.mkdir(parents=True, exist_ok=True)
-
-            if isinstance(bedlike, str) or isinstance(bedlike, Path):
-                bedlike = sp.bed.read(bedlike)
-
-            # ensure the full_bed matches the order on-disk
-            full_bed = regions_to_bed(self._full_regions, self.contigs)
-            itvs = _annot_to_intervals(full_bed, bedlike)
-
-            out = np.memmap(
-                out_dir / "intervals.npy",
-                dtype=INTERVAL_DTYPE,
-                mode="w+",
-                shape=itvs.values.data.shape,
-            )
-            out["start"] = itvs.starts.data
-            out["end"] = itvs.ends.data
-            out["value"] = itvs.values.data
-            out.flush()
-
-            out = np.memmap(
-                out_dir / "offsets.npy",
-                dtype=itvs.values.offsets.dtype,
-                mode="w+",
-                shape=len(itvs.values.offsets),
-            )
-            out[:] = itvs.values.offsets
-            out.flush()
-
-        ds_tracks = Tracks.from_path(self.path, *self.full_shape).with_tracks(None)
-        # Re-activate the same tracks on the newly loaded ds_tracks object,
-        # then route through the factory to keep _recon consistent with view-state.
-        cur_active = self._tracks.active_tracks if self._tracks is not None else {}
-        new_tracks = (
-            ds_tracks.with_tracks(cur_active.keys()) if cur_active else ds_tracks
-        )
-        recon = _build_reconstructor(self._seqs, new_tracks, self._seqs_kind)
-        return replace(self, _tracks=ds_tracks, _recon=recon)
-
     def to_torch_dataset(
         self, return_indices: bool, transform: Callable | None
     ) -> TorchDataset:
@@ -1866,36 +1792,6 @@ def _lazy_load_dosages(dataset: Dataset, haps: Haps) -> Haps:
     rag_shape = (*shape[1:], None)
     dosages = Ragged.from_offsets(dosages_mm, rag_shape, offsets.reshape(2, -1))
     return replace(haps, dosages=dosages)
-
-
-def _annot_to_intervals(regions: pl.DataFrame, annot: pl.DataFrame) -> RaggedIntervals:
-    # normalize contig names
-    reg_c = regions["chrom"].unique()
-    annot_c = annot["chrom"].unique()
-    renamer = (normalize_contig_name(c, reg_c) for c in annot_c)
-    renamer = {c: new_c for c, new_c in zip(annot_c, renamer) if new_c is not None}
-    annot = annot.with_columns(chrom=pl.col("chrom").replace(renamer))
-
-    # find intersection
-    intersect = sp.bed.from_pyr(
-        sp.bed.to_pyr(annot).join(sp.bed.to_pyr(regions.with_row_index()))
-    ).sort("index", "chrom", "chromStart")
-
-    # compute offsets, considering regions with no overlaps
-    i, nonzero_counts = np.unique(intersect["index"], return_counts=True)
-    counts = np.zeros(regions.height, dtype=np.int32)
-    counts[i] = nonzero_counts
-    offsets = lengths_to_offsets(counts)
-    shape = (len(offsets) - 1, None)
-
-    # convert to numpy intervals
-    itvs = np.empty(intersect.height, dtype=INTERVAL_DTYPE)
-    starts = Ragged.from_offsets(intersect["chromStart"].to_numpy(), shape, offsets)
-    ends = Ragged.from_offsets(intersect["chromEnd"].to_numpy(), shape, offsets)
-    values = Ragged.from_offsets(intersect["score"].to_numpy(), shape, offsets)
-    itvs = RaggedIntervals(starts, ends, values)
-
-    return itvs
 
 
 SEQ = TypeVar("SEQ", NDArray[np.bytes_], AnnotatedHaps, RaggedVariants)

--- a/python/genvarloader/_dataset/_tracks.py
+++ b/python/genvarloader/_dataset/_tracks.py
@@ -473,9 +473,19 @@ class Tracks(Reconstructor[_T]):
         strack_dir = path / "intervals"
         atrack_dir = path / "annot_intervals"
 
+        def _is_track_dir(p: Path) -> bool:
+            return (
+                p.is_dir()
+                and ".tmp." not in p.name
+                and ".old." not in p.name
+                and not p.name.endswith(".lock")
+            )
+
         available_tracks: list[str] = []
         if strack_dir.exists():
             for p in strack_dir.iterdir():
+                if not _is_track_dir(p):
+                    continue
                 if len(list(p.iterdir())) == 0:
                     p.rmdir()
                 else:
@@ -485,6 +495,8 @@ class Tracks(Reconstructor[_T]):
         available_annots: list[str] = []
         if atrack_dir.exists():
             for p in atrack_dir.iterdir():
+                if not _is_track_dir(p):
+                    continue
                 if len(list(p.iterdir())) == 0:
                     p.rmdir()
                 else:

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -39,6 +39,8 @@ from ._utils import bed_to_regions, regions_to_bed, splits_sum_le_value
 
 
 DATASET_FORMAT_VERSION = SemanticVersion.parse("1.0.0")
+"""On-disk layout version for a gvl.write dataset directory. Bump MAJOR only when
+an existing dataset can no longer be read correctly by new code."""
 
 
 def _run_jobs(jobs: "list[Callable[[int], None]]", max_mem: int) -> None:
@@ -55,8 +57,6 @@ def _run_jobs(jobs: "list[Callable[[int], None]]", max_mem: int) -> None:
         return
     per = max(max_mem // len(jobs), 1)
     Parallel(n_jobs=len(jobs), backend="loky")(delayed(j)(per) for j in jobs)
-"""On-disk layout version for a gvl.write dataset directory. Bump MAJOR only when
-an existing dataset can no longer be read correctly by new code."""
 
 
 class Metadata(BaseModel, arbitrary_types_allowed=True):

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -926,6 +926,88 @@ def _write_ragged_intervals(out_dir: Path, itvs: "RaggedIntervals") -> None:
     out.flush()
 
 
+def _annot_intervals(
+    regions: pl.DataFrame,
+    source: "str | Path | pl.DataFrame | pl.LazyFrame",
+    max_mem: int,
+) -> "RaggedIntervals":
+    """Build a sample-less RaggedIntervals (n_regions, None) from an annotation source.
+
+    - bigwig path -> Rust per-region extraction (BigWigs), squeezed sample-less.
+    - table path / DataFrame / LazyFrame (BED-like: chrom, chromStart, chromEnd, score)
+      -> polars-bio overlap (experimental, requires the `table` extra).
+    """
+    from .._ragged import RaggedIntervals
+
+    if isinstance(source, (str, Path)) and Path(source).suffix.lower() in (
+        ".bw",
+        ".bigwig",
+    ):
+        return _annot_intervals_from_bigwig(regions, Path(source), max_mem)
+
+    if isinstance(source, pl.LazyFrame):
+        annot = source.collect()
+    elif isinstance(source, pl.DataFrame):
+        annot = source
+    else:
+        annot = sp.bed.read(str(source))
+
+    from .._table import annot_overlap
+
+    return annot_overlap(regions, annot)
+
+
+def _annot_intervals_from_bigwig(
+    regions: pl.DataFrame, path: Path, max_mem: int
+) -> "RaggedIntervals":
+    from seqpro.rag import Ragged
+
+    from .._bigwig import BigWigs
+    from .._ragged import RaggedIntervals
+
+    # single pseudo-sample; collapse its sample axis to produce a sample-less track
+    bw = BigWigs(name="__annot__", paths={"__annot__": str(path)})
+    out_starts, out_ends, out_values, lengths = [], [], [], []
+    for (contig,), part in regions.partition_by(
+        "chrom", as_dict=True, maintain_order=True
+    ).items():
+        contig = cast(str, contig)
+        starts = part["chromStart"].to_numpy()
+        ends = part["chromEnd"].to_numpy()
+        # (regions, 1)
+        itvs = bw.intervals(contig, starts, ends, sample="__annot__")
+        for r in range(part.height):
+            s = itvs.starts[r, 0]
+            out_starts.append(np.asarray(s, dtype=np.int32))
+            out_ends.append(np.asarray(itvs.ends[r, 0], dtype=np.int32))
+            out_values.append(np.asarray(itvs.values[r, 0], dtype=np.float32))
+            lengths.append(len(s))
+    flat_starts = (
+        np.concatenate(out_starts) if out_starts else np.empty(0, np.int32)
+    )
+    flat_ends = np.concatenate(out_ends) if out_ends else np.empty(0, np.int32)
+    flat_values = (
+        np.concatenate(out_values) if out_values else np.empty(0, np.float32)
+    )
+    offsets = lengths_to_offsets(np.asarray(lengths, np.int32))
+    shape = (regions.height, None)
+    return RaggedIntervals(
+        Ragged.from_offsets(flat_starts, shape, offsets),
+        Ragged.from_offsets(flat_ends, shape, offsets),
+        Ragged.from_offsets(flat_values, shape, offsets),
+    )
+
+
+def _write_annot_track(
+    out_dir: Path,
+    regions: pl.DataFrame,
+    source: "str | Path | pl.DataFrame | pl.LazyFrame",
+    max_mem: int,
+) -> None:
+    itvs = _annot_intervals(regions, source, max_mem)
+    _write_ragged_intervals(out_dir, itvs)
+
+
 def _write_track(
     out_dir: Path,
     bed: pl.DataFrame,

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from .._types import IntervalTrack
     from .._ragged import RaggedIntervals
+    from ._impl import Dataset
 
 import awkward as ak
 import numpy as np
@@ -346,6 +347,99 @@ def write(
                 f.write(_metadata.model_dump_json())
 
         logger.info("Finished writing.")
+    finally:
+        warnings.simplefilter("default")
+
+
+def update(
+    dataset: "str | Path | Dataset",
+    tracks: "IntervalTrack | Sequence[IntervalTrack] | None" = None,
+    annot_tracks: "dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None" = None,
+    *,
+    overwrite: bool = False,
+    max_mem: int | str = "4g",
+) -> None:
+    """Add tracks to an existing on-disk GVL dataset, analogous to :func:`write`.
+
+    Parameters
+    ----------
+    dataset
+        Path to a dataset directory, or an opened :class:`Dataset` (its ``.path`` is used).
+        A live dataset can be read while it is being updated; it will not observe the new
+        track until reopened.
+    tracks
+        Per-sample :class:`IntervalTrack` source(s) (:class:`BigWigs`, :class:`Table`),
+        written to ``<path>/intervals/<name>/``. The track's sample set must match the
+        dataset's exactly (no missing, no extra); samples are reordered to the dataset
+        order automatically.
+    annot_tracks
+        Sample-independent sources, identical to :func:`write`'s ``annot_tracks``, written
+        to ``<path>/annot_intervals/<name>/``.
+    overwrite
+        Replace a track of the same name if present; otherwise adding a duplicate name
+        raises ``FileExistsError``.
+    max_mem
+        Approximate memory budget, divided across concurrently-running categories.
+    """
+    warnings.simplefilter("ignore", RuntimeWarning)
+    try:
+        from ._impl import Dataset
+
+        path = Path(dataset.path if isinstance(dataset, Dataset) else dataset)
+        if not (path / "metadata.json").exists():
+            raise FileNotFoundError(f"{path} is not a GVL dataset (no metadata.json).")
+
+        if tracks is None and annot_tracks is None:
+            raise ValueError("At least one of `tracks` or `annot_tracks` must be provided.")
+
+        meta = Metadata.model_validate_json((path / "metadata.json").read_text())
+        contigs = meta.contigs
+        ds_samples = meta.samples
+        max_mem_b = parse_memory(max_mem)
+
+        if tracks is not None and not isinstance(tracks, (list, tuple)):
+            tracks = [tracks]
+        _tracks = list(tracks) if tracks is not None else []
+
+        # validate strict sample-set agreement for per-sample tracks
+        for tr in _tracks:
+            if set(tr.samples) != set(ds_samples):
+                missing = set(ds_samples) - set(tr.samples)
+                extra = set(tr.samples) - set(ds_samples)
+                raise ValueError(
+                    f"Track {tr.name!r} samples must exactly match the dataset's. "
+                    f"missing={missing or '{}'} extra={extra or '{}'}"
+                )
+
+        bed = regions_to_bed(np.load(path / "regions.npy"), contigs)
+        sample_bed = bed.select("chrom", "chromStart", "chromEnd")
+        annot_bed = sample_bed
+
+        jobs: list[Callable[[int], None]] = []
+
+        if _tracks:
+            (path / "intervals").mkdir(exist_ok=True)
+            _tr = _tracks
+
+            def _tracks_job(mm: int, _tr: list = _tr, _bed: pl.DataFrame = sample_bed) -> None:
+                for tr in _tr:
+                    with atomic_dir(path / "intervals" / tr.name, overwrite=overwrite) as tmp:
+                        _write_track(tmp, _bed, tr, ds_samples, mm)
+
+            jobs.append(_tracks_job)
+
+        if annot_tracks is not None:
+            (path / "annot_intervals").mkdir(exist_ok=True)
+            _annots = dict(annot_tracks)
+
+            def _annot_job(mm: int, _annots: dict = _annots, _bed: pl.DataFrame = annot_bed) -> None:
+                for name, source in _annots.items():
+                    with atomic_dir(path / "annot_intervals" / name, overwrite=overwrite) as tmp:
+                        _write_annot_track(tmp, _bed, source, mm)
+
+            jobs.append(_annot_job)
+
+        _run_jobs(jobs, max_mem_b)
     finally:
         warnings.simplefilter("default")
 

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -958,8 +958,6 @@ def _annot_intervals(
     - table path / DataFrame / LazyFrame (BED-like: chrom, chromStart, chromEnd, score)
       -> polars-bio overlap (experimental, requires the `table` extra).
     """
-    from .._ragged import RaggedIntervals
-
     if isinstance(source, (str, Path)) and Path(source).suffix.lower() in (
         ".bw",
         ".bigwig",

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -318,9 +318,13 @@ def write(
                 _tracks = list(tracks)
                 _bed = gvl_bed
 
-                def _tracks_job(mm: int, _tracks: list = _tracks, _bed: pl.DataFrame = _bed) -> None:
+                def _tracks_job(
+                    mm: int, _tracks: list = _tracks, _bed: pl.DataFrame = _bed
+                ) -> None:
                     for tr in _tracks:
-                        _write_track(path / "intervals" / tr.name, _bed, tr, samples, mm)
+                        _write_track(
+                            path / "intervals" / tr.name, _bed, tr, samples, mm
+                        )
 
                 jobs.append(_tracks_job)
 
@@ -330,7 +334,9 @@ def write(
                 ).select("chrom", "chromStart", "chromEnd")
                 _annots = dict(annot_tracks)
 
-                def _annot_job(mm: int, _annots: dict = _annots, _bed: pl.DataFrame = annot_bed) -> None:
+                def _annot_job(
+                    mm: int, _annots: dict = _annots, _bed: pl.DataFrame = annot_bed
+                ) -> None:
                     for name, source in _annots.items():
                         _write_annot_track(
                             path / "annot_intervals" / name, _bed, source, mm
@@ -390,7 +396,9 @@ def update(
             raise FileNotFoundError(f"{path} is not a GVL dataset (no metadata.json).")
 
         if tracks is None and annot_tracks is None:
-            raise ValueError("At least one of `tracks` or `annot_tracks` must be provided.")
+            raise ValueError(
+                "At least one of `tracks` or `annot_tracks` must be provided."
+            )
 
         meta = Metadata.model_validate_json((path / "metadata.json").read_text())
         contigs = meta.contigs
@@ -427,9 +435,13 @@ def update(
             (path / "intervals").mkdir(exist_ok=True)
             _tr = _tracks
 
-            def _tracks_job(mm: int, _tr: list = _tr, _bed: pl.DataFrame = sample_bed) -> None:
+            def _tracks_job(
+                mm: int, _tr: list = _tr, _bed: pl.DataFrame = sample_bed
+            ) -> None:
                 for tr in _tr:
-                    with atomic_dir(path / "intervals" / tr.name, overwrite=overwrite) as tmp:
+                    with atomic_dir(
+                        path / "intervals" / tr.name, overwrite=overwrite
+                    ) as tmp:
                         _write_track(tmp, _bed, tr, ds_samples, mm)
 
             jobs.append(_tracks_job)
@@ -438,9 +450,13 @@ def update(
             (path / "annot_intervals").mkdir(exist_ok=True)
             _annots = dict(annot_tracks)
 
-            def _annot_job(mm: int, _annots: dict = _annots, _bed: pl.DataFrame = annot_bed) -> None:
+            def _annot_job(
+                mm: int, _annots: dict = _annots, _bed: pl.DataFrame = annot_bed
+            ) -> None:
                 for name, source in _annots.items():
-                    with atomic_dir(path / "annot_intervals" / name, overwrite=overwrite) as tmp:
+                    with atomic_dir(
+                        path / "annot_intervals" / name, overwrite=overwrite
+                    ) as tmp:
                         _write_annot_track(tmp, _bed, source, mm)
 
             jobs.append(_annot_job)
@@ -1132,13 +1148,9 @@ def _annot_intervals_from_bigwig(
             out_ends.append(np.asarray(itvs.ends[r, 0], dtype=np.int32))
             out_values.append(np.asarray(itvs.values[r, 0], dtype=np.float32))
             lengths.append(len(s))
-    flat_starts = (
-        np.concatenate(out_starts) if out_starts else np.empty(0, np.int32)
-    )
+    flat_starts = np.concatenate(out_starts) if out_starts else np.empty(0, np.int32)
     flat_ends = np.concatenate(out_ends) if out_ends else np.empty(0, np.int32)
-    flat_values = (
-        np.concatenate(out_values) if out_values else np.empty(0, np.float32)
-    )
+    flat_values = np.concatenate(out_values) if out_values else np.empty(0, np.float32)
     offsets = lengths_to_offsets(np.asarray(lengths, np.int32))
     shape = (regions.height, None)
     return RaggedIntervals(

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from .._types import IntervalTrack
+    from .._ragged import RaggedIntervals
 
 import awkward as ak
 import numpy as np
@@ -286,7 +287,7 @@ def write(
             if tracks is not None:
                 logger.info("Writing track intervals.")
                 for tr in tracks:
-                    _write_track(path, gvl_bed, tr, samples, max_mem)
+                    _write_track(path / "intervals" / tr.name, gvl_bed, tr, samples, max_mem)
 
             _metadata = Metadata(**metadata)
             with open(path / "metadata.json", "w") as f:
@@ -899,8 +900,34 @@ def _write_phased_variants_chunk(
     return v_idx_memmap_offset, offsets_memmap_offset, last_offset
 
 
+def _write_ragged_intervals(out_dir: Path, itvs: "RaggedIntervals") -> None:
+    """Write a RaggedIntervals (values/starts/ends share offsets) to out_dir as
+    intervals.npy + offsets.npy. Single-chunk writer used for annotation tracks."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = np.memmap(
+        out_dir / "intervals.npy",
+        dtype=INTERVAL_DTYPE,
+        mode="w+",
+        shape=itvs.values.data.shape,
+    )
+    out["start"] = itvs.starts.data
+    out["end"] = itvs.ends.data
+    out["value"] = itvs.values.data
+    out.flush()
+
+    offsets = itvs.values.offsets
+    out = np.memmap(
+        out_dir / "offsets.npy",
+        dtype=offsets.dtype,
+        mode="w+",
+        shape=len(offsets),
+    )
+    out[:] = offsets
+    out.flush()
+
+
 def _write_track(
-    path: Path,
+    out_dir: Path,
     bed: pl.DataFrame,
     track: "IntervalTrack",
     samples: list[str] | None,
@@ -967,7 +994,6 @@ def _write_track(
     pbar.close()
     bed = bed.with_columns(chunk=pl.lit(chunk_labels))
 
-    out_dir = path / "intervals" / track.name
     out_dir.mkdir(parents=True, exist_ok=True)
 
     interval_offset = 0

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -1,7 +1,7 @@
 import gc
 import json
 import warnings
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from importlib.metadata import version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -20,6 +20,7 @@ from genoray._svar import dense2sparse
 from genoray._svar import _dense2sparse_with_length  # type: ignore[missing-module-attribute]
 from genoray._types import V_IDX_TYPE
 from genoray._utils import ContigNormalizer, format_memory, parse_memory
+from joblib import Parallel, delayed
 from loguru import logger
 from more_itertools import mark_ends
 from natsort import natsorted
@@ -38,6 +39,22 @@ from ._utils import bed_to_regions, regions_to_bed, splits_sum_le_value
 
 
 DATASET_FORMAT_VERSION = SemanticVersion.parse("1.0.0")
+
+
+def _run_jobs(jobs: "list[Callable[[int], None]]", max_mem: int) -> None:
+    """Run track/annot writer jobs, each called with a per-job max_mem budget.
+
+    0/1 real jobs run inline; otherwise jobs run concurrently on the loky
+    backend with the budget divided evenly so total peak stays under max_mem.
+    None entries in *jobs* are silently filtered out.
+    """
+    jobs = [j for j in jobs if j is not None]
+    if len(jobs) <= 1:
+        for j in jobs:
+            j(max_mem)
+        return
+    per = max(max_mem // len(jobs), 1)
+    Parallel(n_jobs=len(jobs), backend="loky")(delayed(j)(per) for j in jobs)
 """On-disk layout version for a gvl.write dataset directory. Bump MAJOR only when
 an existing dataset can no longer be read correctly by new code."""
 
@@ -295,20 +312,34 @@ def write(
 
             _write_regions(path, gvl_bed, contigs)
 
+            jobs: list[Callable[[int], None]] = []
             if tracks is not None:
-                logger.info("Writing track intervals.")
-                for tr in tracks:
-                    _write_track(path / "intervals" / tr.name, gvl_bed, tr, samples, max_mem)
+                _tracks = list(tracks)
+                _bed = gvl_bed
+
+                def _tracks_job(mm: int, _tracks: list = _tracks, _bed: pl.DataFrame = _bed) -> None:
+                    for tr in _tracks:
+                        _write_track(path / "intervals" / tr.name, _bed, tr, samples, mm)
+
+                jobs.append(_tracks_job)
 
             if annot_tracks is not None:
-                logger.info("Writing annotation tracks.")
                 annot_bed = regions_to_bed(
                     np.load(path / "regions.npy"), contigs
                 ).select("chrom", "chromStart", "chromEnd")
-                for name, source in annot_tracks.items():
-                    _write_annot_track(
-                        path / "annot_intervals" / name, annot_bed, source, max_mem
-                    )
+                _annots = dict(annot_tracks)
+
+                def _annot_job(mm: int, _annots: dict = _annots, _bed: pl.DataFrame = annot_bed) -> None:
+                    for name, source in _annots.items():
+                        _write_annot_track(
+                            path / "annot_intervals" / name, _bed, source, mm
+                        )
+
+                jobs.append(_annot_job)
+
+            if jobs:
+                logger.info(f"Writing {len(jobs)} track categor(ies).")
+                _run_jobs(jobs, max_mem)
 
             _metadata = Metadata(**metadata)
             with open(path / "metadata.json", "w") as f:

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -34,7 +34,7 @@ from .._ragged import INTERVAL_DTYPE
 from .._utils import lengths_to_offsets, normalize_contig_name
 from .._variants._utils import path_is_pgen, path_is_vcf
 from ._svar_link import SvarLink
-from ._utils import bed_to_regions, splits_sum_le_value
+from ._utils import bed_to_regions, regions_to_bed, splits_sum_le_value
 
 
 DATASET_FORMAT_VERSION = SemanticVersion.parse("1.0.0")
@@ -62,6 +62,7 @@ def write(
     bed: str | Path | pl.DataFrame,
     variants: str | Path | Reader | None = None,
     tracks: "IntervalTrack | Sequence[IntervalTrack] | None" = None,
+    annot_tracks: "dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None" = None,
     samples: list[str] | None = None,
     max_jitter: int | None = None,
     overwrite: bool = False,
@@ -89,6 +90,14 @@ def write(
         An :class:`IntervalTrack` (e.g. :class:`BigWigs`, :class:`Table`) or a
         sequence of them. Each track must have a unique ``name``; the on-disk
         layout writes to ``<path>/intervals/<track.name>/``.
+    annot_tracks
+        Sample-independent annotation tracks, as a mapping of track name to source.
+        Each source is a path to an interval table, a path to a bigWig, or a polars
+        DataFrame/LazyFrame interpreted as a BED-like interval table (columns ``chrom``,
+        ``chromStart``, ``chromEnd``, ``score``). Table/DataFrame sources use the
+        polars-bio overlap backend and require the ``table`` extra
+        (``pip install genvarloader[table]``); they emit an ``ExperimentalWarning``.
+        bigWig sources do not. Written to ``<path>/annot_intervals/<name>/``.
     samples
         Samples to include in the dataset
     max_jitter
@@ -126,8 +135,10 @@ def write(
     # ignore polars warning about os.fork which is caused by using joblib's loky backend
     warnings.simplefilter("ignore", RuntimeWarning)
     try:
-        if variants is None and tracks is None:
-            raise ValueError("At least one of `variants` or `tracks` must be provided.")
+        if variants is None and tracks is None and annot_tracks is None:
+            raise ValueError(
+                "At least one of `variants`, `tracks`, or `annot_tracks` must be provided."
+            )
 
         if tracks is not None and not isinstance(tracks, (list, tuple)):
             tracks = [tracks]
@@ -288,6 +299,16 @@ def write(
                 logger.info("Writing track intervals.")
                 for tr in tracks:
                     _write_track(path / "intervals" / tr.name, gvl_bed, tr, samples, max_mem)
+
+            if annot_tracks is not None:
+                logger.info("Writing annotation tracks.")
+                annot_bed = regions_to_bed(
+                    np.load(path / "regions.npy"), contigs
+                ).select("chrom", "chromStart", "chromEnd")
+                for name, source in annot_tracks.items():
+                    _write_annot_track(
+                        path / "annot_intervals" / name, annot_bed, source, max_mem
+                    )
 
             _metadata = Metadata(**metadata)
             with open(path / "metadata.json", "w") as f:

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -401,6 +401,12 @@ def update(
             tracks = [tracks]
         _tracks = list(tracks) if tracks is not None else []
 
+        names = [tr.name for tr in _tracks]
+        if len(set(names)) != len(names):
+            raise ValueError(
+                f"Duplicate track names: {names}. Each track must have a unique `name`."
+            )
+
         # validate strict sample-set agreement for per-sample tracks
         for tr in _tracks:
             if set(tr.samples) != set(ds_samples):

--- a/python/genvarloader/_table.py
+++ b/python/genvarloader/_table.py
@@ -358,3 +358,81 @@ class Table:
         if missing := set(samples) - set(self.samples):
             raise ValueError(f"Sample(s) {missing} not found in Table.")
         return samples
+
+
+def annot_overlap(regions: pl.DataFrame, annot: pl.DataFrame) -> "RaggedIntervals":
+    """Sample-less interval overlap of `regions` (chrom/chromStart/chromEnd) against a
+    BED-like `annot` (chrom/chromStart/chromEnd/score), via polars-bio. Returns a
+    RaggedIntervals of shape (n_regions, None) ordered by (region, start). Experimental:
+    requires the `table` extra and emits ExperimentalWarning."""
+    import numpy as np
+    from seqpro.rag import Ragged
+
+    from ._ragged import RaggedIntervals
+    from ._utils import lengths_to_offsets, normalize_contig_name
+
+    warnings.warn(_TABLE_EXPERIMENTAL_MSG, ExperimentalWarning, stacklevel=2)
+    pb = _import_polars_bio()
+    pb.set_option("datafusion.bio.coordinate_system_check", "false")
+    pb.set_option("datafusion.bio.coordinate_system_zero_based", True)
+
+    # normalize annot contig names to the region naming (e.g. "1" -> "chr1")
+    reg_c = regions["chrom"].unique().to_list()
+    renamer = {
+        c: nc
+        for c in annot["chrom"].unique().to_list()
+        if (nc := normalize_contig_name(c, reg_c)) is not None
+    }
+    annot = annot.with_columns(chrom=pl.col("chrom").replace(renamer))
+
+    n_regions = regions.height
+    q = regions.with_row_index("_q").select(
+        "chrom",
+        pl.col("chromStart").alias("start"),
+        pl.col("chromEnd").alias("end"),
+        "_q",
+    )
+    db = annot.select(
+        "chrom",
+        pl.col("chromStart").alias("start"),
+        pl.col("chromEnd").alias("end"),
+        "score",
+    )
+    joined = pb.overlap(
+        q,
+        db,
+        cols1=["chrom", "start", "end"],
+        cols2=["chrom", "start", "end"],
+        output_type="polars.DataFrame",
+    )
+
+    shape = (n_regions, None)
+    if joined.height == 0:
+        offsets = lengths_to_offsets(np.zeros(n_regions, np.int32))
+        empty_i = np.empty(0, np.int32)
+        empty_f = np.empty(0, np.float32)
+        return RaggedIntervals(
+            Ragged.from_offsets(empty_i, shape, offsets),
+            Ragged.from_offsets(empty_i, shape, offsets),
+            Ragged.from_offsets(empty_f, shape, offsets),
+        )
+
+    # polars-bio suffixes query cols with _1 and database cols with _2 (see Table).
+    q_idx = joined["_q_1"].to_numpy()
+    j_starts = joined["start_2"].to_numpy()
+    order = np.lexsort((j_starts, q_idx))  # primary key = q_idx, then start
+    q_idx = q_idx[order]
+
+    counts = np.zeros(n_regions, np.int32)
+    uniq, cnt = np.unique(q_idx, return_counts=True)
+    counts[uniq] = cnt
+    offsets = lengths_to_offsets(counts)
+
+    starts = j_starts[order].astype(np.int32, copy=False)
+    ends = joined["end_2"].to_numpy()[order].astype(np.int32, copy=False)
+    values = joined["score_2"].to_numpy()[order].astype(np.float32, copy=False)
+    return RaggedIntervals(
+        Ragged.from_offsets(starts, shape, offsets),
+        Ragged.from_offsets(ends, shape, offsets),
+        Ragged.from_offsets(values, shape, offsets),
+    )

--- a/skills/genvarloader/SKILL.md
+++ b/skills/genvarloader/SKILL.md
@@ -88,6 +88,7 @@ gvl.write(
     bed,
     variants=None,
     tracks=None,
+    annot_tracks=None,
     samples=None,
     max_jitter=None,
     overwrite=False,
@@ -99,15 +100,43 @@ gvl.write(
 Notable:
 - `bed`: path or polars DataFrame with `chrom, chromStart, chromEnd` (0-based). Optional `strand` (`+`/`-`/`.`) controls reverse-complement on read. Extra columns are preserved on `Dataset.regions`.
 - `tracks`: a `gvl.BigWigs` (or a list of them), or the experimental `genvarloader.experimental.Table`. Each must have a unique `.name`. BigWigs need a sample→path mapping (dict or table with `sample`, `path` columns; see `BigWigs.from_table`).
+- `annot_tracks`: `dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None` — sample-independent annotation tracks, written to `<path>/annot_intervals/<name>/`. Each value is either a path to an interval table/bigWig file, or a polars DataFrame/LazyFrame with BED-like columns (`chrom`, `chromStart`, `chromEnd`, `score`). DataFrame/LazyFrame and table-file sources use the polars-bio overlap backend and require the `table` extra (`pip install genvarloader[table]`), and emit an `ExperimentalWarning`. BigWig path sources do NOT require the `table` extra. Annotation tracks are sample-independent and can be read without a per-sample variant source.
 - `max_jitter`: max read-time jitter; pads stored data on both sides of every region by this many bases so `Dataset.with_settings(jitter=j)` works for any `j <= max_jitter`.
 - `extend_to_length=True` keeps reading past the BED end until every haplotype is ≥ the region length (matters when deletions would shorten output); set `False` for faster writes if shorter haps are acceptable.
 - Inner-joins samples across `variants` and all `tracks`.
+
+**Parallelism:** `gvl.write` now parallelizes over write categories. Variants are processed first (serially). Then per-sample `tracks` and `annot_tracks` run concurrently (joblib loky backend). The `max_mem` budget is divided across the concurrently-running categories.
 
 Source: `python/genvarloader/_dataset/_write.py`.
 
 **Atomic creation:** `gvl.write` builds into a private sibling temp directory and publishes via an atomic `os.replace`. A best-effort `filelock` avoids redundant rebuilds when parallel jobs share the same destination, but correctness relies on the rename — the lock is advisory only. **Datasets do not auto-rebuild**; if the on-disk artifact is missing or corrupt, re-run `gvl.write`.
 
 **Out-of-scope:** `genoray` `.gvi` index files and `pysam` `.fai`/`.gzi` index files are created by those libraries and are **not** covered by gvl's atomic/locked creation. Concurrent jobs that trigger index creation for those files depend on the upstream libraries' behavior.
+
+## `gvl.update` — add tracks to an existing dataset
+
+```python
+gvl.update(
+    dataset,          # str | Path | Dataset
+    tracks=None,      # IntervalTrack | Sequence[IntervalTrack] | None
+    annot_tracks=None,  # dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None
+    *,
+    overwrite=False,
+    max_mem="4g",
+) -> None
+```
+
+Adds tracks to an **existing** on-disk GVL dataset without rewriting it from scratch.
+
+- `dataset`: path to a dataset directory, or an opened `Dataset` (its `.path` is used). A live dataset can be read during `update`; it will not observe the new track until reopened.
+- `tracks`: per-sample `IntervalTrack` sources (`BigWigs`, experimental `Table`). The track's sample set must match the dataset's **exactly** (no missing, no extra); samples are reordered to dataset order automatically. Written to `<path>/intervals/<name>/`.
+- `annot_tracks`: sample-independent sources, identical to `gvl.write`'s `annot_tracks` (path to interval table, path to bigWig, or polars DataFrame/LazyFrame with BED-like columns). DataFrame/LazyFrame and table-file sources require the `table` extra and emit `ExperimentalWarning`; bigWig path sources do not. Written to `<path>/annot_intervals/<name>/`.
+- `overwrite=True`: replace a same-named existing track; `False` (default) raises `FileExistsError` if the name already exists.
+- `max_mem`: approximate memory budget, divided across concurrently-running categories.
+
+Each track subdirectory is published **atomically** (built into a temp sibling, then `os.replace`d into place), so a reader can never see a half-written track.
+
+Source: `python/genvarloader/_dataset/_write.py`.
 
 ## `Dataset.open` — key arguments
 
@@ -326,11 +355,12 @@ Full list lives in `python/genvarloader/__init__.py` `__all__`.
 
 ```
 ds.gvl/
-├── metadata.json          # version, samples, contigs, ploidy, max_jitter, svar_link?
-├── input_regions.arrow    # BED + region index map
-├── genotypes/             # variant_idxs.npy, dosages.npy, variants.arrow
-│                          # (absent when sourced from .svar; see svar_link)
-└── intervals/<track>/     # per-track interval data
+├── metadata.json              # version, samples, contigs, ploidy, max_jitter, svar_link?
+├── input_regions.arrow        # BED + region index map
+├── genotypes/                 # variant_idxs.npy, dosages.npy, variants.arrow
+│                              # (absent when sourced from .svar; see svar_link)
+├── intervals/<track>/         # per-sample track data (BigWigs / Table)
+└── annot_intervals/<track>/   # sample-independent annotation track data
 ```
 
 See `docs/source/format.md` for the full schema, versioning, and SVAR-link details.
@@ -347,6 +377,7 @@ See `docs/source/format.md` for the full schema, versioning, and SVAR-link detai
 | On-disk format + SVAR resolution      | `docs/source/format.md`                                |
 | FAQ (`with_*` design, typing)         | `docs/source/faq.md`                                   |
 | Auto-generated reference              | `docs/source/api.md` → https://genvarloader.readthedocs.io |
+| `gvl.write` / `gvl.update` internals  | `python/genvarloader/_dataset/_write.py`               |
 | Track re-alignment internals          | `python/genvarloader/_dataset/_tracks.py`, `_reconstruct.py` |
 | Insertion fill internals              | `python/genvarloader/_dataset/_insertion_fill.py`      |
 | SVAR back-reference / migration       | `python/genvarloader/_dataset/_svar_link.py`           |
@@ -356,6 +387,9 @@ See `docs/source/format.md` for the full schema, versioning, and SVAR-link detai
 
 ## Common gotchas
 
+- **`gvl.update` does not hot-reload open datasets.** A `Dataset` instance that was opened before `gvl.update` ran will not see the new track; reopen the dataset to pick it up. The update itself is safe to run while readers are active — each track is published atomically so a reader never sees a half-written track.
+- **`Dataset.write_annot_tracks` has been removed.** Use `gvl.update(dataset, annot_tracks={"name": source})` instead, or pass `annot_tracks=` to `gvl.write` at creation time.
+- **`annot_tracks` DataFrame/LazyFrame sources require the `table` extra.** `pip install genvarloader[table]` (pulls in `polars-bio`). BigWig path sources do **not** require this extra.
 - **Symbolic / breakend variants are rejected, not skipped.** Remove them before `gvl.write` — e.g. `bcftools view -e 'ALT~"<" || ALT~"\["'` (drop SVs and breakends), or construct the genoray reader with `filter=genoray.exprs.is_biallelic & ~genoray.exprs.is_symbolic & ~genoray.exprs.is_breakend`. SVAR inputs must be built from an already-filtered source, since gvl validates but cannot re-filter a materialized `.svar`.
 - Opening a genotypes-only dataset without a `reference=` defaults to the `"variants"` view (`RaggedVariants`), not `"haplotypes"`. Only `"variants"` is available without a reference; `with_seqs("haplotypes" | "annotated" | "reference")` raises `ValueError` if no reference was provided.
 - `with_insertion_fill` raises unless the dataset has both haplotypes AND tracks active.

--- a/skills/genvarloader/SKILL.md
+++ b/skills/genvarloader/SKILL.md
@@ -118,7 +118,7 @@ Source: `python/genvarloader/_dataset/_write.py`.
 ```python
 gvl.update(
     dataset,          # str | Path | Dataset
-    tracks=None,      # IntervalTrack | Sequence[IntervalTrack] | None
+    tracks=None,      # BigWigs | Table | Sequence[BigWigs | Table] | None
     annot_tracks=None,  # dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None
     *,
     overwrite=False,
@@ -129,7 +129,7 @@ gvl.update(
 Adds tracks to an **existing** on-disk GVL dataset without rewriting it from scratch.
 
 - `dataset`: path to a dataset directory, or an opened `Dataset` (its `.path` is used). A live dataset can be read during `update`; it will not observe the new track until reopened.
-- `tracks`: per-sample `IntervalTrack` sources (`BigWigs`, experimental `Table`). The track's sample set must match the dataset's **exactly** (no missing, no extra); samples are reordered to dataset order automatically. Written to `<path>/intervals/<name>/`.
+- `tracks`: per-sample `BigWigs` or experimental `Table` sources. The track's sample set must match the dataset's **exactly** (no missing, no extra); samples are reordered to dataset order automatically. Written to `<path>/intervals/<track>/`.
 - `annot_tracks`: sample-independent sources, identical to `gvl.write`'s `annot_tracks` (path to interval table, path to bigWig, or polars DataFrame/LazyFrame with BED-like columns). DataFrame/LazyFrame and table-file sources require the `table` extra and emit `ExperimentalWarning`; bigWig path sources do not. Written to `<path>/annot_intervals/<name>/`.
 - `overwrite=True`: replace a same-named existing track; `False` (default) raises `FileExistsError` if the name already exists.
 - `max_mem`: approximate memory budget, divided across concurrently-running categories.

--- a/tests/integration/test_write_parallel.py
+++ b/tests/integration/test_write_parallel.py
@@ -1,0 +1,120 @@
+"""Integration test: parallel gvl.write (tracks ∥ annot_tracks) matches sequential.
+
+Proof of correctness: write the same data via the parallel path (2 job categories →
+loky) and independently via two single-category inline writes, then compare the raw
+interval bytes on disk.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pyBigWig
+import pytest
+from genoray import VCF
+
+import genvarloader as gvl
+
+
+# ---------------------------------------------------------------------------
+# Fixture: per-sample BigWigs whose sample set is {s0, s1, s2} (matching the
+# filtered_source.vcf.gz fixture).  Written into tmp_path so they are
+# function-scoped and do not interfere across tests.
+# ---------------------------------------------------------------------------
+
+VCF_SAMPLES = ["s0", "s1", "s2"]
+CONTIG_SIZES = [("chr1", 2_000_000), ("chr2", 2_000_000)]
+
+# Use chr1:100-200 — overlaps the first cluster of VCF variants (~POS 111).
+# The bigwig entries at chr1:[1-5) and chr1:[100-105) sit inside this window.
+BED = pl.DataFrame(
+    {"chrom": ["chr1"], "chromStart": [100], "chromEnd": [200]}
+)
+
+
+@pytest.fixture()
+def bigwigs(tmp_path: Path) -> gvl.BigWigs:
+    """BigWigs with one bw per VCF sample, covering chr1:100-200."""
+    bw_paths: dict[str, str] = {}
+    for i, sample in enumerate(VCF_SAMPLES):
+        bw_path = tmp_path / f"{sample}.bw"
+        with pyBigWig.open(str(bw_path), "w") as bw:
+            bw.addHeader(CONTIG_SIZES, maxZooms=0)
+            # one entry inside the query window
+            value = float(i + 1)
+            bw.addEntries(["chr1"], [100], ends=[110], values=[value])
+        bw_paths[sample] = str(bw_path)
+    return gvl.BigWigs("signal", bw_paths)
+
+
+@pytest.fixture()
+def annot_bw(tmp_path: Path) -> Path:
+    """A single sample-less bigwig for annotation (also covers chr1:100-200)."""
+    bw_path = tmp_path / "annot.bw"
+    with pyBigWig.open(str(bw_path), "w") as bw:
+        bw.addHeader(CONTIG_SIZES, maxZooms=0)
+        bw.addEntries(["chr1"], [105], ends=[115], values=[7.0])
+    return bw_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_intervals(ds_path: Path, subdir: str, name: str) -> np.ndarray:
+    """Load intervals.npy from ``ds_path/<subdir>/<name>/intervals.npy``."""
+    return np.array(
+        np.memmap(ds_path / subdir / name / "intervals.npy", mode="r")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_write_matches_sequential(
+    bigwigs: gvl.BigWigs,
+    annot_bw: Path,
+    vcf_dir: Path,
+    ref_fasta: Path,
+    tmp_path: Path,
+) -> None:
+    """Parallel write (tracks ∥ annot_tracks, loky) must produce bytes equal to
+    two independent single-category inline writes."""
+    vcf = VCF(vcf_dir / "filtered_source.vcf.gz")
+
+    a_dir = tmp_path / "a"  # parallel: tracks + annot_tracks → 2 jobs → loky
+    b_dir = tmp_path / "b"  # tracks only → 1 job → inline
+    c_dir = tmp_path / "c"  # annot_tracks only → 1 job → inline
+
+    gvl.write(
+        a_dir,
+        BED,
+        variants=vcf,
+        tracks=bigwigs,
+        annot_tracks={"ann": annot_bw},
+    )
+
+    vcf2 = VCF(vcf_dir / "filtered_source.vcf.gz")
+    gvl.write(b_dir, BED, variants=vcf2, tracks=bigwigs)
+
+    vcf3 = VCF(vcf_dir / "filtered_source.vcf.gz")
+    gvl.write(c_dir, BED, variants=vcf3, annot_tracks={"ann": annot_bw})
+
+    # --- compare track bytes ---
+    a_track = _load_intervals(a_dir, "intervals", "signal")
+    b_track = _load_intervals(b_dir, "intervals", "signal")
+    assert np.array_equal(a_track, b_track), (
+        f"Track intervals differ between parallel (a) and sequential (b):\n"
+        f"a={a_track}\nb={b_track}"
+    )
+
+    # --- compare annot bytes ---
+    a_annot = _load_intervals(a_dir, "annot_intervals", "ann")
+    c_annot = _load_intervals(c_dir, "annot_intervals", "ann")
+    assert np.array_equal(a_annot, c_annot), (
+        f"Annot intervals differ between parallel (a) and sequential (c):\n"
+        f"a={a_annot}\nc={c_annot}"
+    )

--- a/tests/integration/test_write_parallel.py
+++ b/tests/integration/test_write_parallel.py
@@ -27,9 +27,7 @@ CONTIG_SIZES = [("chr1", 2_000_000), ("chr2", 2_000_000)]
 
 # Use chr1:100-200 — overlaps the first cluster of VCF variants (~POS 111).
 # The bigwig entries at chr1:[1-5) and chr1:[100-105) sit inside this window.
-BED = pl.DataFrame(
-    {"chrom": ["chr1"], "chromStart": [100], "chromEnd": [200]}
-)
+BED = pl.DataFrame({"chrom": ["chr1"], "chromStart": [100], "chromEnd": [200]})
 
 
 @pytest.fixture()
@@ -64,9 +62,7 @@ def annot_bw(tmp_path: Path) -> Path:
 
 def _load_intervals(ds_path: Path, subdir: str, name: str) -> np.ndarray:
     """Load intervals.npy from ``ds_path/<subdir>/<name>/intervals.npy``."""
-    return np.array(
-        np.memmap(ds_path / subdir / name / "intervals.npy", mode="r")
-    )
+    return np.array(np.memmap(ds_path / subdir / name / "intervals.npy", mode="r"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/tracks/test_annot_tracks.py
+++ b/tests/integration/tracks/test_annot_tracks.py
@@ -1,6 +1,7 @@
 import awkward as ak
 import genvarloader as gvl
 import polars as pl
+from genoray import VCF
 from genvarloader._ragged import RaggedAnnotatedHaps
 from pytest import fixture
 
@@ -8,6 +9,18 @@ from pytest import fixture
 @fixture
 def dataset(phased_vcf_gvl, ref_fasta):
     return gvl.Dataset.open(phased_vcf_gvl, ref_fasta).with_seqs("annotated")
+
+
+def test_write_with_annot_tracks(vcf_dir, bigwig_dir, ref_fasta, tmp_path):
+    out = tmp_path / "ds"
+    # chr1:100-200 overlaps the first variant at POS 111
+    bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [100], "chromEnd": [200]})
+    vcf = VCF(vcf_dir / "filtered_source.vcf.gz")
+    # pyrefly: ignore [unexpected-keyword]
+    gvl.write(out, bed, variants=vcf, annot_tracks={"sig": str(bigwig_dir / "sample_0.bw")})
+    ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated").with_tracks("sig", "tracks")
+    assert ds.available_tracks is not None
+    assert "sig" in ds.available_tracks
 
 
 def test_annot_tracks(dataset: gvl.RaggedDataset[RaggedAnnotatedHaps, None]):

--- a/tests/integration/tracks/test_annot_tracks.py
+++ b/tests/integration/tracks/test_annot_tracks.py
@@ -1,14 +1,10 @@
+import os
+
 import awkward as ak
 import genvarloader as gvl
 import polars as pl
+import pytest
 from genoray import VCF
-from genvarloader._ragged import RaggedAnnotatedHaps
-from pytest import fixture
-
-
-@fixture
-def dataset(phased_vcf_gvl, ref_fasta):
-    return gvl.Dataset.open(phased_vcf_gvl, ref_fasta).with_seqs("annotated")
 
 
 def test_write_with_annot_tracks(vcf_dir, bigwig_dir, ref_fasta, tmp_path):
@@ -22,11 +18,21 @@ def test_write_with_annot_tracks(vcf_dir, bigwig_dir, ref_fasta, tmp_path):
     assert "sig" in ds.available_tracks
 
 
-def test_annot_tracks(dataset: gvl.RaggedDataset[RaggedAnnotatedHaps, None]):
-    annots = dataset.regions.with_columns(
+@pytest.mark.skipif(
+    not os.environ.get("GVL_TEST_EXPERIMENTAL"),
+    reason="annot DataFrame source uses polars-bio; set GVL_TEST_EXPERIMENTAL=1",
+)
+def test_annot_tracks(vcf_dir, ref_fasta, tmp_path):
+    out = tmp_path / "ds"
+    bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [100], "chromEnd": [200]})
+    vcf = VCF(vcf_dir / "filtered_source.vcf.gz")
+    gvl.write(out, bed, variants=vcf)
+    ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated")
+    annots = ds.regions.with_columns(
         chromEnd=pl.col("chromStart") + 1, score=pl.lit(1.0)
     )
-    annot_ds = dataset.write_annot_tracks({"5ss": annots}, overwrite=True).with_tracks(
+    gvl.update(out, annot_tracks={"5ss": annots})
+    annot_ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated").with_tracks(
         "5ss", "tracks"
     )
     haps, tracks = annot_ds[:]

--- a/tests/integration/tracks/test_annot_tracks.py
+++ b/tests/integration/tracks/test_annot_tracks.py
@@ -14,7 +14,6 @@ def test_write_with_annot_tracks(vcf_dir, bigwig_dir, ref_fasta, tmp_path):
     vcf = VCF(vcf_dir / "filtered_source.vcf.gz")
     gvl.write(out, bed, variants=vcf, annot_tracks={"sig": str(bigwig_dir / "sample_0.bw")})
     ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated").with_tracks("sig", "tracks")
-    assert ds.available_tracks is not None
     assert "sig" in ds.available_tracks
 
 

--- a/tests/integration/tracks/test_annot_tracks.py
+++ b/tests/integration/tracks/test_annot_tracks.py
@@ -16,7 +16,6 @@ def test_write_with_annot_tracks(vcf_dir, bigwig_dir, ref_fasta, tmp_path):
     # chr1:100-200 overlaps the first variant at POS 111
     bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [100], "chromEnd": [200]})
     vcf = VCF(vcf_dir / "filtered_source.vcf.gz")
-    # pyrefly: ignore [unexpected-keyword]
     gvl.write(out, bed, variants=vcf, annot_tracks={"sig": str(bigwig_dir / "sample_0.bw")})
     ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated").with_tracks("sig", "tracks")
     assert ds.available_tracks is not None

--- a/tests/integration/tracks/test_annot_tracks.py
+++ b/tests/integration/tracks/test_annot_tracks.py
@@ -12,8 +12,14 @@ def test_write_with_annot_tracks(vcf_dir, bigwig_dir, ref_fasta, tmp_path):
     # chr1:100-200 overlaps the first variant at POS 111
     bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [100], "chromEnd": [200]})
     vcf = VCF(vcf_dir / "filtered_source.vcf.gz")
-    gvl.write(out, bed, variants=vcf, annot_tracks={"sig": str(bigwig_dir / "sample_0.bw")})
-    ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated").with_tracks("sig", "tracks")
+    gvl.write(
+        out, bed, variants=vcf, annot_tracks={"sig": str(bigwig_dir / "sample_0.bw")}
+    )
+    ds = (
+        gvl.Dataset.open(out, ref_fasta)
+        .with_seqs("annotated")
+        .with_tracks("sig", "tracks")
+    )
     assert "sig" in ds.available_tracks
 
 
@@ -31,8 +37,10 @@ def test_annot_tracks(vcf_dir, ref_fasta, tmp_path):
         chromEnd=pl.col("chromStart") + 1, score=pl.lit(1.0)
     )
     gvl.update(out, annot_tracks={"5ss": annots})
-    annot_ds = gvl.Dataset.open(out, ref_fasta).with_seqs("annotated").with_tracks(
-        "5ss", "tracks"
+    annot_ds = (
+        gvl.Dataset.open(out, ref_fasta)
+        .with_seqs("annotated")
+        .with_tracks("5ss", "tracks")
     )
     haps, tracks = annot_ds[:]
     mask = haps.ref_coords == ak.Array(

--- a/tests/integration/tracks/test_update.py
+++ b/tests/integration/tracks/test_update.py
@@ -69,6 +69,13 @@ def test_update_rejects_extra_or_missing_samples(phased_vcf, ref_fasta, bigwigs,
     with pytest.raises(ValueError, match="sample"):
         gvl.update(out, tracks=bigwigs)
 
+    # Write dataset with ALL 3 samples; bigwigs with 2 → missing sample
+    out2 = tmp_path / "ds2"
+    gvl.write(out2, BED, variants=phased_vcf)
+    subset_bw = gvl.BigWigs(bigwigs.name, {s: bigwigs.paths[s] for s in bigwigs.samples[:-1]})
+    with pytest.raises(ValueError, match="sample"):
+        gvl.update(out2, tracks=subset_bw)
+
 
 def test_update_overwrite(phased_vcf, ref_fasta, bigwigs, tmp_path):
     out = tmp_path / "ds"

--- a/tests/integration/tracks/test_update.py
+++ b/tests/integration/tracks/test_update.py
@@ -62,7 +62,9 @@ def test_update_accepts_dataset_object(phased_vcf, ref_fasta, bigwigs, tmp_path)
     assert bigwigs.name in gvl.Dataset.open(out, ref_fasta).available_tracks
 
 
-def test_update_rejects_extra_or_missing_samples(phased_vcf, ref_fasta, bigwigs, tmp_path):
+def test_update_rejects_extra_or_missing_samples(
+    phased_vcf, ref_fasta, bigwigs, tmp_path
+):
     out = tmp_path / "ds"
     # Write dataset with only 2 samples; bigwigs has 3 → extra sample
     gvl.write(out, BED, variants=phased_vcf, samples=list(bigwigs.samples[:-1]))
@@ -72,7 +74,9 @@ def test_update_rejects_extra_or_missing_samples(phased_vcf, ref_fasta, bigwigs,
     # Write dataset with ALL 3 samples; bigwigs with 2 → missing sample
     out2 = tmp_path / "ds2"
     gvl.write(out2, BED, variants=phased_vcf)
-    subset_bw = gvl.BigWigs(bigwigs.name, {s: bigwigs.paths[s] for s in bigwigs.samples[:-1]})
+    subset_bw = gvl.BigWigs(
+        bigwigs.name, {s: bigwigs.paths[s] for s in bigwigs.samples[:-1]}
+    )
     with pytest.raises(ValueError, match="sample"):
         gvl.update(out2, tracks=subset_bw)
 

--- a/tests/integration/tracks/test_update.py
+++ b/tests/integration/tracks/test_update.py
@@ -1,0 +1,80 @@
+"""Integration tests for gvl.update — post-hoc track addition to an existing dataset."""
+
+from __future__ import annotations
+
+import pytest
+import pyBigWig
+import polars as pl
+from genoray import VCF
+
+import genvarloader as gvl
+
+
+@pytest.fixture
+def phased_vcf(vcf_dir):
+    """Opened VCF fixture (samples s0, s1, s2)."""
+    return VCF(vcf_dir / "filtered_source.vcf.gz")
+
+
+@pytest.fixture
+def bigwigs(tmp_path):
+    """A BigWigs track whose sample set exactly matches the VCF (s0, s1, s2).
+
+    BigWig intervals are written under tmp_path/bw/; tests should use a
+    distinct subdir (tmp_path/ds/) for their dataset output to avoid
+    path collisions.
+    """
+    bw_dir = tmp_path / "bw"
+    bw_dir.mkdir()
+    contig_sizes = [("chr1", 2_000_000)]
+    bw_paths: dict[str, str] = {}
+    for i, sample in enumerate(["s0", "s1", "s2"]):
+        bw_path = bw_dir / f"{sample}.bw"
+        with pyBigWig.open(str(bw_path), "w") as bw:
+            bw.addHeader(contig_sizes, maxZooms=0)
+            bw.addEntries(
+                ["chr1"],
+                [110],
+                ends=[150],
+                values=[float(i + 1)],
+            )
+        bw_paths[sample] = str(bw_path)
+    return gvl.BigWigs("signal", bw_paths)
+
+
+# BED region that overlaps the first VCF variant on chr1 (POS=111)
+BED = pl.DataFrame({"chrom": ["chr1"], "chromStart": [100], "chromEnd": [200]})
+
+
+def test_update_adds_sample_track(phased_vcf, ref_fasta, bigwigs, tmp_path):
+    out = tmp_path / "ds"
+    gvl.write(out, BED, variants=phased_vcf)
+    gvl.update(out, tracks=bigwigs)
+    ds = gvl.Dataset.open(out, ref_fasta)
+    assert bigwigs.name in ds.available_tracks
+
+
+def test_update_accepts_dataset_object(phased_vcf, ref_fasta, bigwigs, tmp_path):
+    out = tmp_path / "ds"
+    gvl.write(out, BED, variants=phased_vcf)
+    ds = gvl.Dataset.open(out, ref_fasta)
+    gvl.update(ds, tracks=bigwigs)  # extracts .path
+    assert bigwigs.name in gvl.Dataset.open(out, ref_fasta).available_tracks
+
+
+def test_update_rejects_extra_or_missing_samples(phased_vcf, ref_fasta, bigwigs, tmp_path):
+    out = tmp_path / "ds"
+    # Write dataset with only 2 samples; bigwigs has 3 → extra sample
+    gvl.write(out, BED, variants=phased_vcf, samples=list(bigwigs.samples[:-1]))
+    with pytest.raises(ValueError, match="sample"):
+        gvl.update(out, tracks=bigwigs)
+
+
+def test_update_overwrite(phased_vcf, ref_fasta, bigwigs, tmp_path):
+    out = tmp_path / "ds"
+    gvl.write(out, BED, variants=phased_vcf)
+    gvl.update(out, tracks=bigwigs)
+    with pytest.raises(FileExistsError):
+        gvl.update(out, tracks=bigwigs)
+    gvl.update(out, tracks=bigwigs, overwrite=True)  # ok
+    assert not list((out / "intervals").glob("*.tmp.*"))

--- a/tests/unit/dataset/test_run_jobs.py
+++ b/tests/unit/dataset/test_run_jobs.py
@@ -25,8 +25,12 @@ def test_run_jobs_two_jobs_loky_path(tmp_path: Path) -> None:
 
     assert file0.exists(), "job0 did not write its file"
     assert file1.exists(), "job1 did not write its file"
-    assert int(file0.read_text()) == 500, f"job0 got {file0.read_text()!r}, expected 500"
-    assert int(file1.read_text()) == 500, f"job1 got {file1.read_text()!r}, expected 500"
+    assert int(file0.read_text()) == 500, (
+        f"job0 got {file0.read_text()!r}, expected 500"
+    )
+    assert int(file1.read_text()) == 500, (
+        f"job1 got {file1.read_text()!r}, expected 500"
+    )
 
 
 def test_run_jobs_one_job_inline(tmp_path: Path) -> None:

--- a/tests/unit/dataset/test_run_jobs.py
+++ b/tests/unit/dataset/test_run_jobs.py
@@ -1,0 +1,63 @@
+"""Unit tests for _run_jobs (joblib loky parallelism helper)."""
+
+from pathlib import Path
+
+from genvarloader._dataset._write import _run_jobs
+
+
+# Module-level callable so loky can pickle it.
+def _record(mm: int, path: Path) -> None:
+    """Write the received per-job max_mem budget to *path*."""
+    path.write_text(str(mm))
+
+
+def test_run_jobs_two_jobs_loky_path(tmp_path: Path) -> None:
+    """2 jobs → loky backend; each receives max_mem // 2."""
+    file0 = tmp_path / "job0.txt"
+    file1 = tmp_path / "job1.txt"
+
+    from functools import partial
+
+    job0 = partial(_record, path=file0)
+    job1 = partial(_record, path=file1)
+
+    _run_jobs([job0, job1], max_mem=1000)
+
+    assert file0.exists(), "job0 did not write its file"
+    assert file1.exists(), "job1 did not write its file"
+    assert int(file0.read_text()) == 500, f"job0 got {file0.read_text()!r}, expected 500"
+    assert int(file1.read_text()) == 500, f"job1 got {file1.read_text()!r}, expected 500"
+
+
+def test_run_jobs_one_job_inline(tmp_path: Path) -> None:
+    """1 job → runs inline (no loky spawn); receives the full max_mem."""
+    file0 = tmp_path / "job0.txt"
+
+    from functools import partial
+
+    job0 = partial(_record, path=file0)
+
+    _run_jobs([job0], max_mem=1000)
+
+    assert file0.exists(), "job0 did not write its file"
+    assert int(file0.read_text()) == 1000, f"expected 1000, got {file0.read_text()!r}"
+
+
+def test_run_jobs_zero_jobs(tmp_path: Path) -> None:
+    """0 jobs → no-op, no errors."""
+    _run_jobs([], max_mem=1000)  # must not raise
+
+
+def test_run_jobs_none_jobs_filtered(tmp_path: Path) -> None:
+    """None entries are filtered out before dispatch."""
+    file0 = tmp_path / "job0.txt"
+
+    from functools import partial
+
+    job0 = partial(_record, path=file0)
+
+    # Pass a list with None — should be treated as 1 real job (inline path).
+    _run_jobs([None, job0], max_mem=1000)  # type: ignore[list-item]
+
+    assert file0.exists()
+    assert int(file0.read_text()) == 1000

--- a/tests/unit/test_write_annot.py
+++ b/tests/unit/test_write_annot.py
@@ -1,0 +1,57 @@
+import os
+
+import numpy as np
+import polars as pl
+import pytest
+
+# polars-bio is gated exactly like gvl.Table (see tests/unit/test_table.py).
+if not os.environ.get("GVL_TEST_EXPERIMENTAL"):
+    pytest.skip(
+        "annot polars-bio path is experimental; set GVL_TEST_EXPERIMENTAL=1 to run.",
+        allow_module_level=True,
+    )
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore::genvarloader._table.ExperimentalWarning"
+)
+
+
+def _regions():
+    return pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr2"],
+            "chromStart": [0, 50, 0],
+            "chromEnd": [100, 150, 100],
+        }
+    )
+
+
+def _annot():
+    return pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1", "chr2"],
+            "chromStart": [10, 60, 90, 5],
+            "chromEnd": [20, 70, 95, 15],
+            "score": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+
+def test_annot_overlap_matches_pyranges_oracle():
+    from genvarloader._dataset._impl import _annot_to_intervals  # pyranges oracle
+    from genvarloader._table import annot_overlap
+
+    regions, annot = _regions(), _annot()
+    got = annot_overlap(regions, annot)
+    want = _annot_to_intervals(regions, annot)
+
+    # same per-region counts and the same multiset of intervals per region
+    np.testing.assert_array_equal(got.values.offsets, want.values.offsets)
+    for r in range(regions.height):
+        gs, ge, gv = got.starts[r], got.ends[r], got.values[r]
+        ws, we, wv = want.starts[r], want.ends[r], want.values[r]
+        go = np.lexsort((gv, ge, gs))
+        wo = np.lexsort((wv, we, ws))
+        np.testing.assert_array_equal(np.asarray(gs)[go], np.asarray(ws)[wo])
+        np.testing.assert_array_equal(np.asarray(ge)[go], np.asarray(we)[wo])
+        np.testing.assert_allclose(np.asarray(gv)[go], np.asarray(wv)[wo])

--- a/tests/unit/test_write_annot.py
+++ b/tests/unit/test_write_annot.py
@@ -44,9 +44,7 @@ def test_annot_overlap_explicit():
     got = annot_overlap(regions, annot)
     # region 0 [chr1:0-100] overlaps the 3 chr1 annots; region 1 [chr1:50-150] overlaps
     # the chr1 annots at 60-70 and 90-95; region 2 [chr2:0-100] overlaps the chr2 annot.
-    np.testing.assert_array_equal(
-        np.diff(got.values.offsets), np.array([3, 2, 1])
-    )
+    np.testing.assert_array_equal(np.diff(got.values.offsets), np.array([3, 2, 1]))
     # region 2's single interval is the chr2 annot 5-15 with score 4.0
     np.testing.assert_array_equal(np.asarray(got.starts[2]), [5])
     np.testing.assert_array_equal(np.asarray(got.ends[2]), [15])

--- a/tests/unit/test_write_annot.py
+++ b/tests/unit/test_write_annot.py
@@ -37,21 +37,17 @@ def _annot():
     )
 
 
-def test_annot_overlap_matches_pyranges_oracle():
-    from genvarloader._dataset._impl import _annot_to_intervals  # pyranges oracle
+def test_annot_overlap_explicit():
     from genvarloader._table import annot_overlap
 
     regions, annot = _regions(), _annot()
     got = annot_overlap(regions, annot)
-    want = _annot_to_intervals(regions, annot)
-
-    # same per-region counts and the same multiset of intervals per region
-    np.testing.assert_array_equal(got.values.offsets, want.values.offsets)
-    for r in range(regions.height):
-        gs, ge, gv = got.starts[r], got.ends[r], got.values[r]
-        ws, we, wv = want.starts[r], want.ends[r], want.values[r]
-        go = np.lexsort((gv, ge, gs))
-        wo = np.lexsort((wv, we, ws))
-        np.testing.assert_array_equal(np.asarray(gs)[go], np.asarray(ws)[wo])
-        np.testing.assert_array_equal(np.asarray(ge)[go], np.asarray(we)[wo])
-        np.testing.assert_allclose(np.asarray(gv)[go], np.asarray(wv)[wo])
+    # region 0 [chr1:0-100] overlaps the 3 chr1 annots; region 1 [chr1:50-150] overlaps
+    # the chr1 annots at 60-70 and 90-95; region 2 [chr2:0-100] overlaps the chr2 annot.
+    np.testing.assert_array_equal(
+        np.diff(got.values.offsets), np.array([3, 2, 1])
+    )
+    # region 2's single interval is the chr2 annot 5-15 with score 4.0
+    np.testing.assert_array_equal(np.asarray(got.starts[2]), [5])
+    np.testing.assert_array_equal(np.asarray(got.ends[2]), [15])
+    np.testing.assert_allclose(np.asarray(got.values[2]), [4.0])

--- a/tests/unit/test_write_annot_bigwig.py
+++ b/tests/unit/test_write_annot_bigwig.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import numpy as np
+
+from genvarloader._dataset._write import _annot_intervals
+
+
+def test_annot_intervals_from_bigwig(tmp_path):
+    import polars as pl
+
+    data_dir = Path(__file__).parent.parent / "data" / "bigwig"
+    bw = data_dir / "sample_0.bw"
+    # a region known to overlap intervals in the fixture bigwig
+    regions = pl.DataFrame(
+        {"chrom": ["chr1"], "chromStart": [0], "chromEnd": [1000]}
+    )
+    itvs = _annot_intervals(regions, bw, max_mem=2**30)
+    # shape (regions, None), one region
+    assert itvs.values.offsets.shape == (2,)
+    assert itvs.starts.data.dtype == np.int32

--- a/tests/unit/test_write_annot_bigwig.py
+++ b/tests/unit/test_write_annot_bigwig.py
@@ -11,9 +11,7 @@ def test_annot_intervals_from_bigwig(tmp_path):
     data_dir = Path(__file__).parent.parent / "data" / "bigwig"
     bw = data_dir / "sample_0.bw"
     # a region known to overlap intervals in the fixture bigwig
-    regions = pl.DataFrame(
-        {"chrom": ["chr1"], "chromStart": [0], "chromEnd": [1000]}
-    )
+    regions = pl.DataFrame({"chrom": ["chr1"], "chromStart": [0], "chromEnd": [1000]})
     itvs = _annot_intervals(regions, bw, max_mem=2**30)
     # shape (regions, None), one region
     assert itvs.values.offsets.shape == (2,)


### PR DESCRIPTION
## Summary

Adds a top-level `gvl.update()` for adding tracks to an existing on-disk dataset, gives `gvl.write()` an `annot_tracks=` parameter, parallelizes `write` over track categories, and re-implements annotation extraction on polars-bio (DRY with `gvl.Table`).

Executed task-by-task via subagent-driven development (each task individually spec+quality reviewed; whole-branch reviewed at the end).

## What changed

- **`gvl.update(dataset, tracks=, annot_tracks=, *, overwrite=, max_mem=)`** — adds tracks to an existing dataset. Accepts a path or an opened `Dataset`. Per-sample `tracks` need exact sample-set agreement (reordered to dataset order); `annot_tracks` are sample-less. Each track subdir is published **atomically** via `atomic_dir` (build into temp sibling, `os.replace` into place); `overwrite=True` replaces, else `FileExistsError`. A live dataset can be read during update but won't see the new track until reopened.
- **`gvl.write(..., annot_tracks=...)`** — mapping of name → source (interval-table path, bigWig path, or polars DataFrame/LazyFrame, BED-like `chrom`/`chromStart`/`chromEnd`/`score`). Table/DataFrame sources use the polars-bio backend (require the `table` extra, emit `ExperimentalWarning`); bigWig sources do not.
- **Parallel `write`** — variants run first (serially), then `tracks` ∥ `annot_tracks` run concurrently (joblib loky); `max_mem` divided across concurrent categories. New `_run_jobs` helper.
- **polars-bio annotation extraction** — `annot_overlap` in `_table.py` (DRY with `Table`) + `_annot_intervals` dispatcher; bigWig sources go through the Rust `BigWigs` backend (polars-bio-free).
- **Removed** `Dataset.write_annot_tracks` and the pyranges `_annot_to_intervals` (use `gvl.update(..., annot_tracks=)`).
- **`Tracks.from_path`** made robust to in-flight `atomic_dir` siblings (`.tmp.`/`.old.`/`.lock`).
- **pyproject** — added `[tool.pyrefly] search-path` so pyrefly resolves `genvarloader` to the local source (it was resolving to a different checkout in a nested worktree, emitting phantom errors).
- Docs: `skills/genvarloader/SKILL.md` + `docs/source/changelog.md`.

## Testing

- `ruff check` + `ruff format` clean; `pyrefly` 0 errors.
- New tests: `_run_jobs` unit test (real loky cross-process `max_mem` split), parallel-write equivalence, annot extraction (polars-bio + bigWig), `gvl.update` integration (sample-set rejection both directions, overwrite, atomic publish).
- polars-bio-dependent tests gated behind `GVL_TEST_EXPERIMENTAL=1`; bigWig paths run ungated in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)