### PR TITLE
Consume seqpro-core rlib; route to_padded through the shared Rust kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ dependencies = [
  "pyo3",
  "rayon",
  "rstest",
+ "seqpro-core",
 ]
 
 [[package]]
@@ -746,6 +747,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+ "rayon",
 ]
 
 [[package]]
@@ -1174,6 +1176,14 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seqpro-core"
+version = "0.1.0"
+dependencies = [
+ "ndarray",
+ "rayon",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,8 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 [[package]]
 name = "seqpro-core"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2828840fff2c76c199a75dc2ed705d1935c55f5755ab4b938d44924386b622d1"
 dependencies = [
  "ndarray",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ itertools = "0.14.0"
 ndarray = "0.17.2"
 numpy = "0.28.0"
 rayon = "1.12.0"
+seqpro-core = { path = "../seqpro/crates/seqpro-core" }
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.14.0"
 ndarray = "0.17.2"
 numpy = "0.28.0"
 rayon = "1.12.0"
-seqpro-core = { path = "../seqpro/crates/seqpro-core" }
+seqpro-core = "0.1"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -22,9 +22,11 @@ into Rust for everything else.
 - Eliminate the ~35 numba kernels scattered across the read/write paths, collapsing the
   bug surface.
 
-**Eventual scope:** seqpro (the `Ragged` data structure + rag ops) and genoray (VCF/PGEN
-variant & sparse-genotype IO) are sibling Python deps today. They are **in scope for the
-full Rust stack**, but sequenced last (Phase 6) and may graduate into their own roadmap.
+**Eventual scope:** seqpro's `Ragged` layout + ops are the **shared Rust ragged substrate**
+(`seqpro-core` rlib, pyo3-free) — GVL consumes them via a crate path-dep rather than
+reimplementing ragged primitives in-house (decision 2026-06-23, Phase 1). genoray
+(VCF/PGEN variant & sparse-genotype IO) remains in scope for the full Rust stack,
+sequenced last (Phase 6), and may graduate into its own roadmap.
 
 ### Target crate layout
 
@@ -33,7 +35,7 @@ Grown from today's `src/{lib,bigwig}.rs`:
 ```
 src/
 ├── lib.rs            # pymodule registration only
-├── ragged/           # ragged layout (offsets+data) + ops  ← Phase 1 beachhead
+├── ragged/           # bridge to seqpro-core (NOT a reimplementation)  ← Phase 1
 ├── genotypes/        # sparse genotype assembly
 ├── variants/         # variant gather, flat/windowed views
 ├── reconstruct/      # haplotype reconstruction
@@ -45,8 +47,10 @@ src/
 ```
 
 The crate is pure Rust + `ndarray`/`rayon`. `ffi/` is the seam where numpy arrays and
-`seqpro.Ragged` / `genoray` objects cross the boundary (zero-copy where possible). By
-Phase 6 the crate stops depending on Python seqpro/genoray entirely.
+`seqpro.Ragged` / `genoray` objects cross the boundary (zero-copy where possible).
+`src/ragged/` is a **bridge layer** to the `seqpro-core` rlib — it does not own the
+ragged implementation. By Phase 6 the crate stops depending on Python genoray for
+variant IO paths.
 
 ---
 
@@ -65,6 +69,10 @@ Every unit follows the same loop, so the work is repetitive and low-surprise:
 
 `main` stays shippable at all times; every step is reversible until parity is proven;
 numba deletion is continuous rather than a big-bang at the end.
+
+**Ragged substrate:** the ragged layout and core ops are **consumed from `seqpro-core`**
+(a pyo3-free rlib in the seqpro repo) via a Cargo path-dep, not reimplemented in GVL's
+own crate. GVL's `src/ragged/` is a bridge/adapter layer only.
 
 **Standing CI invariant (not a per-phase gate):** abi3 wheels must keep building across
 py310–313 × linux/macOS as the Rust surface grows.
@@ -122,20 +130,27 @@ _PR: —_
 
 **Checkpoint:** harness green; baselines recorded in this file.
 
-### Phase 1 — Ragged primitives + layout (beachhead) ⬜
-_PR: —_
+### Phase 1 — Ragged primitives + layout (beachhead) ✅
+_PRs: seqpro TBD, GVL TBD_
 
-The foundation everything sits on. Bottom-up.
+The foundation everything sits on. Realized via the `seqpro-core` shared substrate
+rather than a GVL-in-house reimplementation (see decision 2026-06-23). Bottom-up.
 
-- [ ] Define the native ragged layout in Rust (offsets + data buffers).
-- [ ] Implement the ops gvl uses: lengths/offsets, slice, gather, `to_padded`,
-      reverse-complement helpers.
-- [ ] Zero-copy interop with `seqpro.Ragged` at the boundary (construct-from / view-as).
-- [x] Remove `awkward` from the foundation layer. (Done at the Python level: GVL migrated onto seqpro's Rust-backed `_core.Ragged`; Rust-crate kernel rewrite is a separate pending step.)
-- [ ] Differential parity vs `_ragged.py` / current seqpro paths.
+- [x] Extract a pyo3-free `seqpro-core` rlib (crates/seqpro-core in the seqpro repo)
+      that owns the `Ragged` layout (offsets + data buffers) and its core ops.
+- [x] Port the last two numba ops to Rust inside `seqpro-core`: `to_padded` and
+      `reverse_complement`. seqpro's ragged layer is now numba-free.
+- [x] GVL consumes `seqpro-core` via a Cargo path-dep (editable; flip to
+      git/crates.io before shipping). `src/ragged/` is a bridge adapter, not a
+      reimplementation.
+- [x] Proof-point op (`to_padded`) rerouted through the shared `seqpro-core` kernel
+      in GVL with byte-identical parity confirmed.
+- [x] Remove `awkward` from the foundation layer. (GVL migrated onto seqpro's
+      Rust-backed `_core.Ragged`; `RaggedVariants` now wraps a single record
+      `seqpro.rag.Ragged`.)
 
-**Checkpoint:** parity green. Foundational — no perf gate, but record incidental wins.
-Relevant prior work: [[project_ragged_assembly_bottleneck]].
+**Checkpoint:** parity green (byte-identical `to_padded`). Foundational — no perf gate,
+but record incidental wins. Relevant prior work: [[project_ragged_assembly_bottleneck]].
 
 ### Phase 2 — Genotype assembly + variant gather ⬜
 _PR: —_
@@ -181,15 +196,16 @@ _PR: —_
 
 **Checkpoint:** core numba kernel count = 0; full perf re-baseline recorded here.
 
-### Phase 6 — Absorb seqpro / genoray (future) ⬜
+### Phase 6 — Absorb genoray (future) ⬜
 _PR: —_
 
 Sequenced last; a candidate to graduate into its own roadmap once Phases 0–5 land.
+seqpro-core remains the ragged substrate (decision 2026-06-23) — Phase 6 is
+narrowed to genoray (variant IO) only.
 
-- [ ] Bring ragged primitives fully in-house — drop the seqpro hot-path dependency.
 - [ ] Bring variant IO (genoray VCF/PGEN + sparse genotypes) into the Rust stack.
 
-**Checkpoint:** crate no longer depends on Python seqpro/genoray for core paths.
+**Checkpoint:** crate no longer depends on Python genoray for core variant IO paths.
 
 ---
 
@@ -229,3 +245,13 @@ Sequenced last; a candidate to graduate into its own roadmap once Phases 0–5 l
   genvarformer CPU 371 passed. Note: this was a Python-level migration onto seqpro's
   existing Rust-backed `_core.Ragged`; the Rust-crate rewrite of the ragged kernels
   themselves (Phase 1 beachhead) is still pending. PR: TBD
+- 2026-06-23: seqpro is the shared Rust ragged substrate. Extracted a pyo3-free
+  `seqpro-core` rlib (crates/seqpro-core) owning a borrowed `Ragged` layout +
+  ops; ported its last two numba kernels (`to_padded`, `reverse_complement`) to
+  Rust (seqpro rag layer now numba-free). Bumped seqpro's pymodule to pyo3 0.28 /
+  numpy 0.28 / ndarray 0.17 (hygiene; NOT required for the link — two pymodules
+  with different pyo3 versions coexist; the single-version rule is per-cdylib, and
+  the shared core is pyo3-free). GVL links seqpro-core via a path dep (editable;
+  flip to git/release before shipping) and routes its `to_padded` chokepoint
+  through the shared kernel (proof-point, byte-identical parity). Inverts Phase 6
+  (seqpro stays the substrate). PRs: seqpro TBD, GVL TBD.

--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -131,7 +131,7 @@ _PR: —_
 **Checkpoint:** harness green; baselines recorded in this file.
 
 ### Phase 1 — Ragged primitives + layout (beachhead) ✅
-_PRs: seqpro TBD, GVL TBD_
+_PRs: seqpro [ML4GLand/SeqPro#60](https://github.com/ML4GLand/SeqPro/pull/60), GVL [mcvickerlab/GenVarLoader#240](https://github.com/mcvickerlab/GenVarLoader/pull/240)_
 
 The foundation everything sits on. Realized via the `seqpro-core` shared substrate
 rather than a GVL-in-house reimplementation (see decision 2026-06-23). Bottom-up.
@@ -254,4 +254,4 @@ narrowed to genoray (variant IO) only.
   the shared core is pyo3-free). GVL links seqpro-core via a path dep (editable;
   flip to git/release before shipping) and routes its `to_padded` chokepoint
   through the shared kernel (proof-point, byte-identical parity). Inverts Phase 6
-  (seqpro stays the substrate). PRs: seqpro TBD, GVL TBD.
+  (seqpro stays the substrate). PRs: seqpro ML4GLand/SeqPro#60, GVL mcvickerlab/GenVarLoader#240.

--- a/docs/superpowers/specs/2026-06-23-seqpro-core-shared-ragged-crate-design.md
+++ b/docs/superpowers/specs/2026-06-23-seqpro-core-shared-ragged-crate-design.md
@@ -1,0 +1,177 @@
+# Design: shared `seqpro-core` Rust ragged crate (GVL Phase 1, realized)
+
+**Date:** 2026-06-23
+**Status:** approved, pending implementation plan
+**Repos touched:** `seqpro` (substrate) + `GenVarLoader` (first consumer)
+**Roadmap:** `docs/roadmaps/rust-migration.md` — this realizes Phase 1 and reframes Phases 1 & 6.
+
+---
+
+## Context
+
+The Rust-migration roadmap (2026-06-18) assumed GVL would build its **own** native ragged
+layout in Rust (Phase 1) and **absorb** seqpro/genoray last (Phase 6, "bring ragged
+primitives in-house — drop the seqpro hot-path dependency").
+
+Reality has moved past that framing:
+
+- `seqpro/src/ragged.rs` (~22 KB Rust) already implements ragged kernels — `validate`,
+  `select`, `nested_gather`, `nested_pack`, `pack`, `concat` — all rayon-parallel and
+  `#[pyfunction]`-registered.
+- seqpro's `Ragged` class (Python, `rag/_core.py`) is now subclass-preserving (0.18.0), and
+  **GVL's `RaggedVariants` subclasses it** (PR #239, merged to `main`).
+- Only **two** ragged ops remain on numba in seqpro: `_to_padded_copy` and
+  `_reverse_complement_ragged` (both in `rag/_ops.py`).
+- seqpro's crate is already `crate-type = ["cdylib", "rlib"]` — consumable as a Rust library.
+
+**Decision (owner of both repos):** seqpro owns the Rust ragged layout. GVL's crate consumes
+it rather than reimplementing. This inverts Phase 6 (seqpro becomes the shared substrate, not
+something to absorb away) and changes Phase 1 from "reimplement" to "consume."
+
+### Why a pyo3-free core (the key architectural move)
+
+Two pyo3 versions cannot link into a **single** cdylib (pyo3 owns one global interpreter
+binding). seqpro is on pyo3 0.20 / numpy 0.20; GVL is on pyo3 0.28 / numpy 0.28. So "GVL
+depends on seqpro's crate as-is" is a non-starter.
+
+The resolution: the shared substrate is a **pyo3-free `rlib`**. GVL links only pure Rust from
+it — zero pyo3 symbols cross over. Each pymodule does its own numpy↔core bridging. (seqpro's
+`.so` and GVL's `.so` already coexist as separate extension modules in one interpreter today;
+the single-version rule is per-cdylib, not per-process.)
+
+Independently, we **bump seqpro's pymodule to pyo3 0.28 / numpy 0.28** in this phase — it is
+not required for the shared-core link, but it is low-cost hygiene and keeps the two repos on
+the same pyo3 generation. `abi3-py39` is retained (do not narrow seqpro's Python support).
+
+---
+
+## Architecture
+
+```
+seqpro repo
+  crates/seqpro-core/          NEW — pure Rust, NO pyo3. Owns the Ragged layout + ops.
+    src/lib.rs                 Ragged layout type + ops + unit/proptest tests
+    Cargo.toml                 deps: ndarray, rayon (+ num-traits/thiserror as needed)
+  src/ (pymodule)              pyo3 0.28 / numpy 0.28; #[pyfunction]s now wrap seqpro-core
+  Cargo.toml                   [workspace]; seqpro-core = { path = "crates/seqpro-core" }
+
+GenVarLoader repo
+  src/ragged/                  NEW — pyo3 0.28 bridge: numpy → seqpro_core::Ragged → op → numpy
+  Cargo.toml                   seqpro-core = { path = "../seqpro/crates/seqpro-core" }  (local editable)
+```
+
+The shared substrate is a normal `rlib`. This *is* the roadmap's "native ragged layout in
+Rust" — it just lives in the repo that owns ragged. GVL's `src/ragged/` is a **bridge**, not a
+reimplementation.
+
+**Working mode:** develop against a local editable `seqpro-core` (path dep) until the seqpro
+changes are merged/released; then repoint GVL's dep to a git/crates.io release. (Mirrors the
+seqpro↔genoray editable→released coupling handled in prior PRs.)
+
+---
+
+## Components
+
+### 1. `seqpro-core` crate (pure Rust)
+
+- **`Ragged` layout type.** Borrowed form over `(offsets: ArrayView1<i64>, data: &[u8],
+  elem_size, ndim)` for zero-copy numpy input; ops produce owned output buffers. Ops are
+  byte-oriented with an element-size parameter (matching today's `ragged.rs` kernels); dtype
+  semantics stay at the Python edge.
+- **Ops** (methods / associated fns):
+  - Moved verbatim from `src/ragged.rs`, minus pyo3: `validate`, `select`, `nested_gather`,
+    `nested_pack`, `pack`, `concat`.
+  - **Newly ported from numba:** `to_padded` (takes a fill value; pad direction matches the
+    existing `_to_padded_copy` semantics) and `reverse_complement` (S1 / single-byte only).
+- **Tests:** the existing Rust unit tests in `ragged.rs` move with the code; add `proptest`
+  cases for the two ported ops.
+
+### 2. seqpro pymodule (pyo3 0.28)
+
+- **Bump** `pyo3` 0.20→0.28 and `numpy` 0.20→0.28 across `src/{lib,ragged,kshuffle,translate,
+  kmer_encode}.rs` (Bound API, GIL/text-signature changes). Retain `abi3-py39`.
+- **Rewire** `src/ragged.rs` `#[pyfunction]`s to thin wrappers over `seqpro_core` — identical
+  behavior, identical Python-visible signatures.
+- **Add** two `#[pyfunction]`s exposing the ported `to_padded` / `reverse_complement`.
+- **`rag/_ops.py`** swaps its two numba calls for the new Rust functions. seqpro's `rag` layer
+  becomes **numba-free**.
+
+### 3. GVL consumer beachhead (pyo3 0.28)
+
+- New `src/ragged/` module: bridges numpy ↔ `seqpro_core::Ragged` and exposes the op(s) GVL
+  needs via pyo3.
+- **Proof-point milestone (exactly one op):** reroute GVL's most-used ragged op,
+  `RaggedSeqs.to_padded()`, to call `seqpro_core` directly through the rlib (Rust→Rust, no
+  Python-seqpro round-trip). Everything else stays on the existing path.
+
+---
+
+## Data flow (proof-point op)
+
+```
+Dataset.__getitem__ → RaggedSeqs.to_padded()
+  Python: hand offsets+data numpy buffers to GVL's pyo3 bridge
+  GVL src/ragged/: construct seqpro_core::Ragged (borrowed, zero-copy) → .to_padded(fill)
+  return owned buffer → numpy → dense array
+```
+
+vs. legacy path (Python `seqpro` Ragged → numba `_to_padded_copy`). The two must be
+byte-identical.
+
+---
+
+## Testing & parity
+
+Scoped to this phase — **not** the full reusable Phase 0 harness.
+
+- **`seqpro-core`:** Rust unit tests (migrated) + proptest for `to_padded`/`reverse_complement`.
+- **seqpro Python differential:** new Rust `to_padded`/`reverse_complement` vs the **old numba**
+  as oracle, across the py310–313 × linux/macOS matrix. Delete the numba impls only once parity
+  holds.
+- **GVL differential:** rerouted `RaggedSeqs.to_padded()` (Rust-via-core) vs the existing
+  Python-seqpro path, byte-identical.
+- **Standing CI invariant:** abi3 wheels keep building for both repos across the py-matrix.
+- **No new perf baselines.** Phase 1 is foundational (no perf gate); record incidental wins
+  only. The full differential-test harness and write/getitem baselines remain deferred Phase 0
+  work.
+
+---
+
+## Roadmap edits (`docs/roadmaps/rust-migration.md`)
+
+- **Goal & end state / Phase 6:** drop "bring ragged primitives in-house — drop the seqpro
+  hot-path dependency." Invert: `seqpro-core` is the shared Rust substrate. Narrow Phase 6 to
+  genoray (variant IO) only; note seqpro stays as the ragged owner.
+- **Target crate layout:** GVL's `ragged/` is a **bridge** to `seqpro-core`, not a
+  reimplementation.
+- **Migration contract:** clarify that the ragged layer is consumed, not reimplemented.
+- **Phase 1:** reframe to "extract `seqpro-core`, port its last 2 numba ops, GVL consumes via
+  rlib." Mark awkward-removal done (already true).
+- **Notes & decisions log (2026-06-23):** record the pyo3-free-core decision; the pyo3/numpy
+  0.20→0.28 bump (in scope, hygiene, not required for the link and why); seqpro `rag` becomes
+  numba-free; GVL beachhead = `to_padded` proof-point.
+
+---
+
+## Scope boundaries (YAGNI)
+
+**In scope:** `seqpro-core` crate split; the 2 numba→Rust ports; seqpro pyo3/numpy 0.20→0.28
+bump; GVL `src/ragged/` bridge + exactly one consumer op (`to_padded`) with parity; roadmap
+refresh.
+
+**Out of scope:** the full reusable differential-test harness; write/getitem perf baselines;
+any GVL Phase 2–5 kernel; genoray; narrowing seqpro's abi3 target; additional GVL consumer ops
+beyond the single proof-point.
+
+---
+
+## Risks / open items for the plan
+
+- **pyo3 0.20→0.28 migration surface** in seqpro touches all `#[pyfunction]`s (Bound API). Land
+  the bump as its own reviewable step before/independent of the core extraction so a parity
+  failure is easy to localize.
+- **`Ragged` generics vs byte+elem-size.** Keep the existing byte-oriented kernel convention to
+  minimize the port surface; revisit generic typing only if a later phase needs it.
+- **Editable→released seqpro coupling** (path dep → git/crates.io) must be flipped before GVL
+  ships; mirror the prior seqpro↔genoray rebase/lock handling.
+- **`reverse_complement` is S1-only** — guard/assert dtype at the bridge.

--- a/python/genvarloader/_ragged.py
+++ b/python/genvarloader/_ragged.py
@@ -12,7 +12,7 @@ import seqpro.rag as spr
 from seqpro.rag import Ragged, is_rag_dtype
 from seqpro.rag import RDTYPE_co as RDTYPE
 from seqpro.rag import reverse_complement as _sp_reverse_complement
-from seqpro.rag import to_padded as _sp_to_padded
+from .genvarloader import ragged_to_padded
 
 from ._flat import _Flat
 from ._torch import TORCH_AVAILABLE
@@ -292,26 +292,39 @@ class RaggedAnnotatedHaps:
 
 
 def to_padded(rag: Ragged[RDTYPE], pad_value: Any) -> NDArray[RDTYPE]:
-    """Convert this Ragged array to a rectilinear array by right-padding each entry with a value.
-    The ragged axis will be padded to have the maximum length across all entries.
+    """Densify a Ragged into a right-padded array via GVL's seqpro-core Rust bridge.
 
-    Thin pass-through to :func:`seqpro.rag.to_padded` (seqpro 0.13+), a single-pass,
-    parallel flat-buffer densify-and-pad kernel. Output is byte-identical for every
-    dtype/pad gvl uses (S1, int32, float32); seqpro pads to the batch maximum
-    ``rag.lengths.max()`` when no explicit length is given.
-
-    Parameters
-    ----------
-    rag
-        Ragged array to pad.
-    pad_value
-        Value to pad the entries with.
-
-    Returns
-    -------
-        Padded array.
+    Byte-identical to :func:`seqpro.rag.to_padded`; the inner row-copy runs in
+    the shared seqpro-core kernel (Rust->Rust, no Python-seqpro round-trip).
     """
-    return _sp_to_padded(rag, pad_value)
+    if rag._is_record:
+        raise NotImplementedError(
+            "to_padded is not defined on record-layout Ragged arrays."
+        )
+    rag_dim = rag.rag_dim
+    if any(d is not None for d in rag.shape[rag_dim + 1 :]):
+        raise ValueError(
+            f"to_padded requires the ragged axis to be last, got shape {rag.shape}."
+        )
+    if not rag.is_contiguous:
+        rag = spr.to_packed(rag)
+
+    offsets = np.ascontiguousarray(rag.offsets, dtype=np.int64)
+    n_rows = offsets.shape[0] - 1
+    out_len = int(rag.lengths.max()) if n_rows else 0
+
+    rag_data: NDArray[Any] = rag.data  # record layout rejected above
+    dtype = rag_data.dtype
+    out = np.full((n_rows, out_len), pad_value, dtype=dtype)
+    if n_rows and out_len:
+        data_u1 = np.ascontiguousarray(rag_data).reshape(-1).view(np.uint8)
+        out_u1 = out.reshape(-1).view(np.uint8)
+        ragged_to_padded(data_u1, offsets, out_u1, dtype.itemsize, out_len)
+
+    leading = rag.shape[:rag_dim]
+    if leading:
+        out = out.reshape((*leading, out_len))  # pyrefly: ignore[no-matching-overload]
+    return out
 
 
 _COMP = np.frombuffer(bytes.maketrans(b"ACGT", b"TGCA"), np.uint8)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bigwig;
+pub mod ragged;
 pub mod tables;
 use numpy::{prelude::*, PyArray1, PyArray2, PyReadonlyArray1};
 use pyo3::prelude::*;
@@ -10,6 +11,7 @@ fn genvarloader(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(intervals, m)?)?;
     m.add_function(wrap_pyfunction!(bigwig_write_track, m)?)?;
     m.add_class::<tables::RustTable>()?;
+    m.add_function(wrap_pyfunction!(ragged::ragged_to_padded, m)?)?;
     Ok(())
 }
 

--- a/src/ragged/mod.rs
+++ b/src/ragged/mod.rs
@@ -1,0 +1,23 @@
+use numpy::{PyReadonlyArray1, PyReadwriteArray1};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+/// Copy each ragged row into a pre-filled (n_rows, out_len) uint8 buffer via
+/// the shared seqpro-core kernel. Mirrors seqpro's `_ragged_to_padded`.
+#[pyfunction]
+pub fn ragged_to_padded(
+    data: PyReadonlyArray1<u8>,
+    offsets: PyReadonlyArray1<i64>,
+    mut out: PyReadwriteArray1<u8>,
+    itemsize: usize,
+    out_len: usize,
+) -> PyResult<()> {
+    let data = data.as_slice()?;
+    let offsets = offsets.as_slice()?;
+    let out = out
+        .as_slice_mut()
+        .map_err(|_| PyValueError::new_err("out must be contiguous"))?;
+    seqpro_core::Ragged::new(offsets, data, itemsize)
+        .to_padded_into(out, itemsize, out_len)
+        .map_err(PyValueError::new_err)
+}

--- a/tests/unit/test_ragged_to_padded_rust.py
+++ b/tests/unit/test_ragged_to_padded_rust.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+from seqpro.rag import Ragged
+from seqpro.rag import to_padded as sp_to_padded
+from genvarloader._ragged import to_padded as gvl_to_padded
+
+
+@pytest.mark.parametrize("dtype,pad", [("S1", b"N"), ("i4", -1), ("f4", 0.0)])
+@pytest.mark.parametrize("rows", [[0, 1, 3, 2], [5], [0, 0, 4]])
+def test_gvl_to_padded_matches_seqpro(dtype, pad, rows):
+    offsets = np.concatenate([[0], np.cumsum(rows)]).astype(np.int64)
+    n = int(offsets[-1])
+    data = (
+        (np.arange(n, dtype=np.int64) % 4).astype(dtype)
+        if dtype != "S1"
+        else np.frombuffer(b"ACGT" * (n // 4 + 1), dtype="S1")[:n]
+    )
+    # S1 dtype uses (n_rows,) shape (rag_dim=0 via str_offsets path);
+    # numeric dtypes require an explicit None ragged dimension: (n_rows, None).
+    shape = (len(rows),) if dtype == "S1" else (len(rows), None)
+    rag = Ragged.from_offsets(np.ascontiguousarray(data), shape, offsets)
+    np.testing.assert_array_equal(gvl_to_padded(rag, pad), sp_to_padded(rag, pad))

--- a/tests/unit/test_ragged_to_padded_rust.py
+++ b/tests/unit/test_ragged_to_padded_rust.py
@@ -6,7 +6,7 @@ from genvarloader._ragged import to_padded as gvl_to_padded
 
 
 @pytest.mark.parametrize("dtype,pad", [("S1", b"N"), ("i4", -1), ("f4", 0.0)])
-@pytest.mark.parametrize("rows", [[0, 1, 3, 2], [5], [0, 0, 4]])
+@pytest.mark.parametrize("rows", [[0, 1, 3, 2], [5], [0, 0, 4], [0, 0, 0]])
 def test_gvl_to_padded_matches_seqpro(dtype, pad, rows):
     offsets = np.concatenate([[0], np.cumsum(rows)]).astype(np.int64)
     n = int(offsets[-1])


### PR DESCRIPTION
## Summary

Makes GenVarLoader link the new pyo3-free **`seqpro-core`** rlib and routes GVL's `to_padded` chokepoint through the shared Rust kernel (Rust→Rust, no Python-seqpro round-trip), with byte-identical parity. This is the GVL-side proof-point of the seqpro-core extraction.

Companion PR (must land first): **ML4GLand/SeqPro#60**.

## ⚠️ CI caveat — do not merge before seqpro-core is released

This branch uses an **editable path dependency**:

```toml
seqpro-core = { path = "../seqpro/crates/seqpro-core" }
```

CI has no sibling `seqpro` checkout, so **CI will fail to resolve this dep until it is flipped to a git/released `seqpro-core`** (after ML4GLand/SeqPro#60 lands and a release is cut). This is a tracked pre-ship step, intentionally not done here. The branch is reviewed Ready-to-merge on the code; the dep flip is the gate.

## What changed (4 commits)

1. **feat(rust)**: add the `seqpro-core` path dep + `src/ragged/mod.rs` bridge pyfunction `ragged_to_padded` (numpy↔slice → `seqpro_core::Ragged::to_padded_into`).
2. **feat(ragged)**: reroute `_ragged.py:to_padded` from delegating to seqpro → a GVL-owned orchestration calling the Rust bridge; add a differential parity test.
3. **docs(roadmap)**: Phase 1 realized; Phase 6 inverted (seqpro-core is the shared substrate, not absorbed).
4. **test(ragged)**: cover the `out_len==0` (all-empty-rows) path in the parity test.

## Guarantees

- **Byte-identical** to `seqpro.rag.to_padded` across S1/i4/f4 and varied row shapes — proven by a differential test (12/12) *and* structurally (the orchestration is a clone of seqpro's, calling the same Rust kernel).
- Single `ndarray 0.17.2`; `seqpro-core` pulls only ndarray/rayon (no pyo3/numpy leaks into GVL).
- No change to the `to_padded(rag, pad_value)` signature.

## Testing

Full tree `pixi run -e dev pytest tests`: **825 passed, 21 skipped, 4 xfailed** (= prior baseline + new parity cases). ruff + pyrefly clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)