### PR TITLE
perf(intervals): tracks-only raw-slice paint (Target 5)

### DIFF
--- a/docs/handoffs/2026-06-25-phase5-getitem-optimization.md
+++ b/docs/handoffs/2026-06-25-phase5-getitem-optimization.md
@@ -1,0 +1,326 @@
+# Handoff: Phase 5 — fully optimize `Dataset.__getitem__` (targets 5, 6, 7 + rayon)
+
+**Date:** 2026-06-25
+**Status:** Not started. Four parallel-ready workstreams.
+**Audience:** GenVarLoader maintainers / per-workstream sessions.
+**Roadmap:** `docs/roadmaps/rust-migration.md` — Phase 5 ⬜, "Optimization targets — round 2" (targets 5/6/7).
+**Base branch:** `zero-copy-scale-safe-readpath` (format 2.0 SoA + zero-copy FFI + sub-linear cache + uninit buffers; PR TBD). All four workstreams branch from here.
+
+## TL;DR
+
+Phase 3 profiling (de-noised `test_e2e.py` benchmark + `perf` on the Python process) left three
+single-thread deficits on the read path, then rayon batch parallelism as the capstone:
+
+| # | Workstream | What | Kind | Parallel? |
+|---|---|---|---|---|
+| **5** | tracks-only ndarray slicing | hoist `out.as_slice_mut()` in `intervals_to_tracks`, drop per-interval `SliceInfo` | rust-only, **byte-identical** | now |
+| **6** | strand reverse-complement | fold RC into **all** reconstruct/track kernels (incl. splice); delete `reverse_complement_ragged` | parity-gated (strand=-1) | now |
+| **7** | variant-windows assembly | replace the per-batch `_FlatWindow`/`_FlatAlleles` object graph with **one Rust call** returning flat `(data, offsets)` | parity-gated | now |
+| **rayon** | batch parallelism | `par_iter` over disjoint per-query slices in the fused kernels | parity-trivial (disjoint) | **after 5/6/7 merge** |
+
+**Run 5, 6, 7 concurrently. Rayon is blocked until 5+6+7 land** — the roadmap is explicit that
+parallelizing before the single-thread work just scales the numpy RC pass (6) and the ndarray
+slicing (5). Each workstream is its own branch + its own parity-gated PR.
+
+The measured starting point (branch `zero-copy-scale-safe-readpath`, `chr22_geuv.gvl`, `with_len(16384)`,
+BATCH=32, `NUMBA_NUM_THREADS=1`, Carter EPYC 7543), **min rust ÷ min numba** ms/batch:
+
+| Mode | rust ÷ numba | note |
+|---|---|---|
+| tracks-only | **0.63×** (rust slower) | target 5 fixes this |
+| tracks (seqs + read-depth) | 0.95× | shares the target-5 kernel |
+| haplotypes | 0.94× | target 6 is its biggest sink (~19% self / 28% incl RC) |
+| annotated | **1.68×** (rust faster) | already a win post-format-2.0 |
+
+---
+
+## Shared context (every session reads this first)
+
+### Where this sits
+
+Phases 0–3 ported the read path to Rust behind a per-kernel dispatch registry
+(`python/genvarloader/_dispatch.py`, default `rust`, `GVL_BACKEND=numba` override). The numba
+kernels are **retained as registered parity oracles** (deleted wholesale later in Phase 5 — NOT in
+these workstreams). The read path is fused: `__getitem__` → `QueryView.recon(...)` → one of the
+fused FFI kernels in `src/ffi/mod.rs`.
+
+### How to measure (use this, not py-spy `--native`)
+
+py-spy `--native` slows the deep-stack haplotype paths ~10× and times out. Use `perf` on the Python
+process — no sudo on Carter (`perf_event_paranoid=2`), near-zero overhead, resolves
+`genvarloader.abi3.so` Rust symbols:
+
+```bash
+NUMBA_NUM_THREADS=1 perf record -F 999 -o p.data -- .pixi/envs/dev/bin/python \
+    tests/benchmarks/profiling/profile.py --mode <mode> --n-batches 12000
+perf report --stdio --no-children -i p.data        # flat self-time, Rust symbols resolved
+```
+
+`profile.py --mode {haplotypes,annotated,tracks,tracks-seqs,variants,variant-windows}`. Run 8–25k
+batches so steady state drowns import/JIT. For the rust↔numba ratio use the de-noised
+`pytest-benchmark` harness in `tests/benchmarks/test_e2e.py`: `_bench_indexing` uses
+`benchmark.pedantic(iterations=10, rounds=50)` so per-batch OS jitter averages out — compare the
+**min** (cleanest CPU-bound estimate), not the mean. Build release first:
+`pixi run -e dev maturin develop --release`.
+
+### Parity (the landing gate)
+
+Every workstream lands only when output stays **byte-identical** to the numba oracle. The harness is
+`tests/parity/` (`_harness.py` run-both-assert-byte-identical, return-value + in-place variants) plus
+hypothesis property generators. The dataset-level backstop (`tests/parity/test_dataset_parity.py`)
+spies on the kernel to prove it actually runs on the live `__getitem__` path (guards against vacuous
+passes). Targets 5/7 are byte-identical by construction; target 6 is gated on **strand=-1** datasets
+(see its section). Run both backends:
+
+```bash
+pixi run -e dev pytest tests/parity -q                      # rust default
+GVL_BACKEND=numba pixi run -e dev pytest tests/parity -q    # oracle
+pixi run -e dev cargo-test                                  # rust unit tests
+```
+
+### Before pushing
+
+Per `CLAUDE.md`: run the **full tree** on both backends before any push that touches shared code
+(`pixi run -e dev pytest tests -q`, then `GVL_BACKEND=numba …`) — scoped runs skip `tests/unit/`.
+Lint/format/typecheck: `pixi run -e dev ruff check python/ tests/ && ruff format … && typecheck`.
+Update `docs/roadmaps/rust-migration.md` (tick the target, record the re-measured ratio, set the PR
+link) as part of the work.
+
+### Parallel-session coordination
+
+- **One branch per workstream**, all off `zero-copy-scale-safe-readpath`. Use a git worktree per
+  session to avoid stepping on each other's working tree.
+- **File-overlap map** (plan rebases around these):
+  - Target 5: `src/intervals.rs` only (+ its cargo tests). **No overlap** with 6/7.
+  - Target 6: `src/intervals.rs` (track reverse), `src/ffi/mod.rs` + the reconstruct/track cores
+    under `src/{reconstruct,tracks,intervals}/`, `python/genvarloader/_dataset/_query.py`,
+    `_reconstruct.py`. **Overlaps target 5 in `intervals.rs`** and target 7 in `_query.py` — see below.
+  - Target 7: `python/genvarloader/_dataset/_flat_variants.py`, `_flat_flanks.py`, new
+    `src/variants/` code + `src/ffi/mod.rs`. **Overlaps target 6 in `src/ffi/mod.rs`** (additive — new
+    pyfunctions, low conflict risk).
+- **Merge order:** 5 first (smallest, rust-only), then 6 and 7 in either order; rebase the later ones.
+  Rayon last, after all three are on the base branch.
+- **HPC gotcha:** dataset tests need pytest's tmp on the same filesystem as `tests/data`
+  (`--basetemp=$(pwd)/.pytest_tmp`) or the write path's `os.link` hardlink fails cross-device (Errno 18).
+
+### Don't regress the format-2.0 read path
+
+The base branch replaced per-batch `np.ascontiguousarray` on per-sample-scale memmaps with `_ffi_array`
+(cross zero-copy or raise loudly) and caches sub-linear per-variant arrays on `Haps.ffi_static`
+(`_HapsFfiStatic`). `tests/integration/test_scale_guard.py` fails if any per-batch
+`np.ascontiguousarray` materializes a sample-scale memmap. Keep that test green — do **not** reintroduce
+`ascontiguousarray` on `geno_v_idxs` / `itv_*` / genotype memmaps.
+
+---
+
+## Target 5 — tracks-only ndarray slicing (rust-only, byte-identical)
+
+**Goal:** close the **0.63×** tracks-only deficit — the one read path where rust is clearly slower than
+numba — and get rust ahead single-threaded on the cheapest read.
+
+**Evidence (`perf` flat self-time, tracks-only path):** `intervals_to_tracks` 31% + `ndarray::slice_mut`
+**11%** + `ndarray::do_slice` **9.5%** ≈ **20.5%** in ndarray slice machinery. Source: the per-interval
+`out.slice_mut(s![a..b]).fill(value)` and the `out.fill(0.0)` prelude in
+`src/intervals.rs:66` / `:27`. numba compiles `out[a:b] = value` to a direct memset and pays none of this.
+tracks-only is the cheapest path (~1.1–1.7 ms) so this fixed per-interval cost dominates with no
+sequence work to amortize it.
+
+**Fix:** the `out` buffer is contiguous. Hoist `let out_slice = out.as_slice_mut().unwrap();` once at the
+top, then write `out_slice[out_s + s as usize .. out_s + e as usize].fill(value)` and
+`out_slice.fill(0.0)` on the raw `&mut [f32]` — dropping per-interval `SliceInfo` construction +
+bounds-check. Keep the exact clamp/break semantics (start clamped ≥0, end ≤length, break on
+`start >= length`, no-op when `e <= s`) — see the docstring at `src/intervals.rs:3-15`. This kernel is
+shared by the combined **tracks** path too, so that improves with it.
+
+**Files:** `src/intervals.rs` (`intervals_to_tracks` + its cargo tests). Nothing Python-side changes.
+
+**Parity:** **byte-identical by construction** — same arithmetic, same write order, just a different way to
+address the contiguous buffer. The 8 existing cargo unit tests (`src/intervals.rs:72+`) plus the
+`intervals_to_tracks` hypothesis parity gate and the tracks dataset backstop must stay green. No oracle
+change.
+
+**Perf gate:** re-measure tracks-only via `test_e2e.py`; target rust ÷ numba ≥ 1.0 (was 0.63×). Record in
+the roadmap's re-measurement block.
+
+**Start your session here:**
+1. Branch `opt/target-5-intervals-slice` off `zero-copy-scale-safe-readpath`.
+2. Read `src/intervals.rs` end-to-end (it's ~220 lines).
+3. TDD: the cargo tests already pin the contract — refactor under them, then add a profiling re-measure.
+4. Gate: `cargo-test` + `pytest tests/parity -q` (both backends) + tracks-only `test_e2e` re-measure.
+
+---
+
+## Target 6 — fold strand reverse-complement into the kernels (delete the numpy post-pass)
+
+**Goal:** delete the `reverse_complement_ragged` post-pass entirely (incl. the spliced per-element path)
+by emitting negative-strand regions already reverse-complemented from the Rust kernels. This is the
+**largest single-thread throughput lever** left and it is **backend-agnostic** (numba pays it too) — it
+must go before rayon, else we parallelize a numpy pass.
+
+**Evidence (py-spy, no `--native`, self-time):** RC post-pass is haplotypes **~19% self / ~28% inclusive**,
+variants **~15% / ~16%**, tracks-only **~10%**. Every negative-strand region triggers a Python/numpy RC
+pass *after* reconstruction.
+
+**Current state:** `python/genvarloader/_dataset/_query.py`
+- unspliced: `_getitem_unspliced` computes `to_rc = view.full_regions[r_idx, 3] == -1` and does
+  `recon = tuple(reverse_complement_ragged(r, to_rc) for r in recon)` (~line 188–190).
+- spliced: `_getitem_spliced` builds a **permuted per-element** mask `to_rc_per_elem` via
+  `plan.permutation` (the spliced kernel writes pre-spliced bytes in permuted order) and applies the same
+  call (~line 259–280).
+- `reverse_complement_ragged` (~line 352–410) dispatches by output kind.
+
+**RC semantics per output kind (the contract to reproduce in-kernel):**
+
+| Output kind | Python today | In-kernel behavior |
+|---|---|---|
+| haplotypes `_Flat` (S1) | `reverse_masked(to_rc, comp=_COMP)` | reverse bytes **and** complement |
+| reference `_Flat` (S1) | same | reverse + complement |
+| annotated `_FlatAnnotatedHaps` | `reverse_masked(to_rc, _COMP)` | reverse+complement bytes **and reverse** the parallel `var_idxs`/`ref_coords` arrays (no complement on those — order only) |
+| tracks `_Flat` (f32) | `reverse_masked(to_rc, comp=None)` | **reverse only**, no complement |
+| variants `RaggedVariants` | `rc_(to_rc)` | reverse allele order within each row **and** complement allele bytes (ragged) |
+| variant-windows | no-op (returns unchanged) | **skip** — reference-oriented |
+| intervals | no-op | **skip** |
+
+`_COMP` is the complement LUT (find it in `_query.py` / seqpro). Confirm exact mapping (incl. `N`,
+IUPAC, lowercase if any) and reproduce it in Rust.
+
+**Kernels to thread a per-query `to_rc: &[bool]` through** (`src/ffi/mod.rs`):
+- `reconstruct_haplotypes_fused` (`:393`) — haplotypes
+- `reconstruct_annotated_haplotypes_fused` (`:604`) — bytes + parallel arrays
+- `reconstruct_haplotypes_spliced_fused` (`:521`) — **the hard one**, see below
+- `intervals_and_realign_track_fused` (`:848`) — tracks (reverse only)
+- `get_reference` (`:728`) — reference
+- the variants allele-gather path (`gather_alleles` in `src/variants/`) — `RaggedVariants` RC
+
+**Approach:** each kernel takes the per-query mask; when `to_rc[query]` is set, write that query's output
+slice **back-to-front** with complemented bytes (seqs) or plain reversed values (tracks). For annotated,
+reverse the parallel `var_idxs`/`ref_coords` slices in lockstep. Do the RC as the kernel writes (or as a
+final in-place pass over each query's just-written slice — simpler to get byte-identical first, optimize
+second). Mind the interaction with **insertion-fill** and **trailing-fill**: RC must apply to the final
+post-fill bytes (same as today, where RC runs after reconstruction completes).
+
+**The splice sub-case:** `reconstruct_haplotypes_spliced_fused` writes pre-spliced bytes in
+**permuted** order (`plan.permutation`), and today RC is applied per spliced **element** with
+`to_rc_per_elem`. In-kernel, pass the already-permuted per-element `to_rc` and reverse-complement each
+spliced element's byte range as it is finalized. Verify the element boundaries you reverse match
+`plan.group_offsets`. This is the part most likely to need careful TDD — start from the existing spliced
+parity fixtures and add strand=-1 coverage.
+
+**Delete after parity holds:** the `reverse_complement_ragged` calls in `_getitem_unspliced` /
+`_getitem_spliced`, the function itself, and the now-dead `to_rc` plumbing in `_query.py`. Confirm no other
+caller (`grep -rn reverse_complement_ragged python/`).
+
+**Parity:** byte-identical vs the current post-pass. The default parity fixtures use `max_jitter=0` and may
+be strand-agnostic — **add strand=-1 datasets** (mix of + and − regions) to the dataset parity backstop
+for every output kind incl. annotated and spliced. Gate both backends. This is the workstream where a
+vacuous pass is easiest, so assert the RC actually fires (regions with strand −1 produce RC'd bytes ≠ the
++ strand).
+
+**Perf gate:** re-measure haplotypes/variants/tracks via `test_e2e`; expect the RC self-time gone and the
+ratios up. Record in the roadmap.
+
+**Start your session here:**
+1. Branch `opt/target-6-kernel-rc` off `zero-copy-scale-safe-readpath`.
+2. Read `_query.py:152-410` (both getitem paths + `reverse_complement_ragged` + the `_COMP` LUT), then the
+   six kernels in `src/ffi/mod.rs` and their cores.
+3. TDD order: reference (simplest, no fill) → haplotypes → tracks (reverse-only) → variants → annotated →
+   **splice last**. Land each kind's in-kernel RC behind parity before deleting its post-pass branch.
+4. Gate: `cargo-test` + `pytest tests/parity -q` (both backends, with new strand=-1 fixtures) + full tree.
+
+---
+
+## Target 7 — variant-windows assembly in one Rust call
+
+**Goal:** kill the per-batch object churn on the `variant-windows` (and `variants`) flat-output path by
+assembling the token/window buffers in **one Rust call returning flat arrays**, eliminating the per-batch
+Python object graph. (This is the larger of the three; it effectively starts the windows half of the
+deferred single-big-kernel rewrite.)
+
+**Evidence (`perf` flat self-time, variant-windows):** no dominant Rust kernel — the cost is interpreter +
+allocator: `_PyEval_EvalFrameDefault` ~8.5%, GC (`gc_collect_main` + `deduce_unreachable` +
+`visit_reachable` + `dict_traverse`) **~14% combined**, dict/attr lookups, dynamic-symbol lookup
+(ctypes/cffi binding) ~2.3%. The flat-windows assembly allocates many small objects per batch
+(`_FlatWindow` / `_FlatVariants` / `_FlatAlleles` / scalar-field dataclasses).
+
+**Current state:** trace `profile.py --mode variant-windows` and `--mode variants` into
+`python/genvarloader/_dataset/_flat_variants.py` (`_FlatWindow` `:189`, `_FlatVariantWindows` `:270`,
+`_FlatVariants` `:344`) and `_flat_flanks.py` (`_make_window` / ref+alt window builders `:116–220`). These
+rebuild dicts of wrapper dataclasses, gather/fill via the `*_i32`/`*_f32` rust cores, and re-wrap, **every
+batch**. The Phase-2 rust gather/fill kernels already exist (`src/variants/`,
+`gather_rows`/`gather_alleles`/`compact_keep`/`fill_empty_*`) — the win here is collapsing the
+**orchestration** that allocates Python objects around them.
+
+**Approach:** add one (or a few) Rust pyfunction(s) in `src/ffi/mod.rs` that take the raw inputs the
+windows path needs (gathered v_idxs / alleles / scalar fields + flank/tokenize/LUT params) and return the
+final flat `(data, offsets)` token buffers directly — so the Python side constructs **one** `_Flat`/result
+wrapper instead of a graph of `_FlatWindow`/`_FlatAlleles`. Reuse the existing `src/variants/` cores
+internally. Inventory exactly which fields/windows the consumer actually reads downstream (in
+`_query.py` reshape/pad and the flat-output assembly) so the Rust call returns precisely those, no more.
+
+**Files:** new code in `src/variants/` + `src/ffi/mod.rs`; rewrite the assembly in
+`_dataset/_flat_variants.py` / `_flat_flanks.py` to call it; keep the public output type
+(`_FlatVariants` / `_FlatVariantWindows`) identical from the caller's view.
+
+**Parity:** byte-identical token buffers + offsets vs the current Python assembly, for both `variants` and
+`variant-windows`, incl. the flank-tokenize ride-along (`flank_tokens`), the empty-group fill
+(`fill_empty_groups` / `DummyVariant`), and the unknown-token path. Note `test_e2e_variants` is a
+**pre-existing xfail** (`_FlatVariants.to_fixed` missing) — don't conflate it with a regression; check it
+xfails identically at the base before you start.
+
+**Perf gate:** re-measure `variant-windows` and `variants` via `test_e2e`; expect the GC/eval self-time to
+drop. Record in the roadmap.
+
+**Start your session here:**
+1. Branch `opt/target-7-windows-rust-assembly` off `zero-copy-scale-safe-readpath`.
+2. `perf record` the `variant-windows` mode and read the assembly in `_flat_variants.py` / `_flat_flanks.py`
+   top-to-bottom; map every per-batch allocation.
+3. TDD: pin the current flat-buffer output (data+offsets) for `variants` and `variant-windows` as the
+   oracle, then build the Rust call under it.
+4. Gate: `cargo-test` + `pytest tests/parity tests/unit -q` (both backends) + `variant-windows` re-measure.
+
+---
+
+## Rayon — batch parallelism (BLOCKED: start only after 5/6/7 are merged)
+
+**Goal:** parallelize the fused kernels' per-query loops with rayon, now that single-thread rust is ahead.
+
+**Why blocked:** the roadmap is explicit — "Only after (5)+(6) put rust ahead single-threaded do we add
+rayon batch parallelism — parallelizing first would just scale the numpy RC pass and the ndarray slicing."
+Do not start until target 5, 6, and 7 are on the base branch.
+
+**Approach:** the batch drivers are currently serial by deliberate design — per-`(query, hap)` output
+slices are **disjoint**, which is exactly why they're embarrassingly parallel and why the serial result
+already equals numba's `prange`. Convert the per-query loops in the fused kernels
+(`reconstruct_haplotypes_fused`, `intervals_and_realign_track_fused`, the annotated/spliced variants) to
+`rayon::par_iter` (or `par_chunks` over disjoint output slices — use `split_at_mut` / `ndarray`
+`axis_chunks_iter_mut` to hand each thread a non-overlapping `&mut` slice). Expose a thread-count control
+(env var or arg) so benchmarks can pin it; default to rayon's global pool.
+
+**Parity:** **trivial** — disjoint slices, deterministic per-slice work, so output is identical regardless
+of thread count. Run the existing parity suite at >1 thread.
+
+**Perf gate:** throughput scaling vs thread count on `test_e2e`. **Re-baseline the whole read path here**
+(the roadmap's Phase 5 checkpoint). Note the `NUMBA_NUM_THREADS=1` caveat — for an honest comparison, set
+numba threads to match, or report both single- and multi-thread numbers explicitly.
+
+**Start your session here (once unblocked):**
+1. Branch off the merged base (with 5/6/7 in).
+2. Confirm each fused kernel's per-query output slices are provably disjoint before parallelizing.
+3. Gate: `cargo-test` + full parity suite at N>1 threads + a thread-scaling sweep recorded in the roadmap.
+
+---
+
+## Pointer table
+
+| Need | Where |
+|---|---|
+| Roadmap + targets 5/6/7 detail | `docs/roadmaps/rust-migration.md` (round-2 optimization block) |
+| Fused FFI kernels | `src/ffi/mod.rs` (`:66`, `:393`, `:521`, `:604`, `:728`, `:848`) |
+| tracks slice kernel | `src/intervals.rs` |
+| RC post-pass to delete | `python/genvarloader/_dataset/_query.py` (`reverse_complement_ragged`, getitem paths) |
+| windows assembly | `python/genvarloader/_dataset/_flat_variants.py`, `_flat_flanks.py` |
+| Phase-2 variant cores (reuse) | `src/variants/` |
+| Dispatch registry | `python/genvarloader/_dispatch.py` (`GVL_BACKEND`) |
+| Parity harness | `tests/parity/` |
+| Perf benchmark | `tests/benchmarks/test_e2e.py`, `tests/benchmarks/profiling/profile.py` |
+| Scale guard (don't regress) | `tests/integration/test_scale_guard.py` |

--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -458,7 +458,7 @@ variants/variant-windows) localized the remaining single-thread work:
    20% and close the tracks-only gap; also speeds the combined tracks path (shared kernel). This is the
    single clearest path to **rust > numba single-threaded** on the cheapest read.
 
-   **✅ ADDRESSED (branch `opt/target-5-intervals-slice`, PR: <link pending>).** Raw-slice form
+   **✅ ADDRESSED (branch `opt/target-5-intervals-slice`, PR [#248](https://github.com/mcvickerlab/GenVarLoader/pull/248)).** Raw-slice form
    landed (no `unsafe` needed): `out.as_slice_mut()` hoisted once before the interval loop,
    inner-loop body rewritten to `out_slice[a..b].fill(value)` / `out_slice.fill(0.0)` on
    `&mut [f32]`, dropping per-interval `SliceInfo` construction + bounds-check. Rust min

--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -447,7 +447,7 @@ The de-noised benchmark (above) exposed a real **tracks-only 0.63×** deficit an
 already 1.68×** (rust wins). Profiling each path the user cares about (tracks-only, haplotypes,
 variants/variant-windows) localized the remaining single-thread work:
 
-5. **⬜ tracks-only 0.63× — per-interval `ndarray` slicing in `intervals::intervals_to_tracks`
+5. **✅ tracks-only 0.63× — per-interval `ndarray` slicing in `intervals::intervals_to_tracks`
    (rust-specific, highest value).** `perf` self-time on the tracks-only path:
    `intervals_to_tracks` 31% + `ndarray::slice_mut` **11%** + `ndarray::do_slice` **9.5%** ≈ **20.5%
    spent in ndarray slice machinery**, from `out.slice_mut(s![a..b]).fill(value)` in the inner loop
@@ -457,6 +457,13 @@ variants/variant-windows) localized the remaining single-thread work:
    dropping the per-interval `SliceInfo` construction + bounds-check. Expected to reclaim most of the
    20% and close the tracks-only gap; also speeds the combined tracks path (shared kernel). This is the
    single clearest path to **rust > numba single-threaded** on the cheapest read.
+
+   **✅ ADDRESSED (branch `opt/target-5-intervals-slice`, PR: <link pending>).** Raw-slice form
+   landed (no `unsafe` needed): `out.as_slice_mut()` hoisted once before the interval loop,
+   inner-loop body rewritten to `out_slice[a..b].fill(value)` / `out_slice.fill(0.0)` on
+   `&mut [f32]`, dropping per-interval `SliceInfo` construction + bounds-check. Rust min
+   1.7112 ms → 1.1953 ms (~30% rust-side drop), tracks-only ratio 0.63× → 1.004×
+   (numba_min/rust_min).
 
 6. **⬜ Strand reverse-complement post-pass (`reverse_complement_ragged` / `_flat.reverse_masked`) —
    backend-agnostic, biggest throughput sink on the seq paths.** Self-time (py-spy, no `--native`):

--- a/docs/superpowers/plans/2026-06-25-target7-variant-windows-rust-assembly.md
+++ b/docs/superpowers/plans/2026-06-25-target7-variant-windows-rust-assembly.md
@@ -1,0 +1,1669 @@
+# Target 7 — variant-windows/variants assembly in one Rust call — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the per-batch object/numpy-temporary churn on the `variants` + `variant-windows` flat-output read path into one flag-driven Rust call that owns the reference fetch + LUT tokenize + flank/window assembly and returns flat `(data, offsets)` buffers, so Python builds the wrapper objects once.
+
+**Architecture:** A new Rust module `src/variants/windows.rs` holds small pure cores (`tokenize`, `slice_flanks`, `assemble_alt_window`, `fetch_windows`) and two mode orchestrators (`assemble_variants_mode`, `assemble_windows_mode`) generic over the token type. Two FFI pyfunctions (`assemble_variant_buffers_u8`, `assemble_variant_buffers_i32`) monomorphize the token type and return a `dict[str, (data, seq_offsets)]`. Python keeps the cheap, dtype-polymorphic front-end (v_idxs gather / AF filter / scalar-field gather) and the `fill_empty_groups` post-pass; only the ragged byte/token assembly tail moves to Rust, behind the dispatch registry with the existing Python/numba helpers retained as the parity oracle.
+
+**Tech Stack:** Rust (`ndarray`, `numpy`/PyO3), Python (numpy, numba oracle), `pixi` for env/build/test, `maturin` for the Rust↔Python build, hypothesis + pytest parity harness.
+
+## Global Constraints
+
+- Branch `opt/target-7-windows-rust-assembly` off `zero-copy-scale-safe-readpath` (do NOT branch off `master`/`rust-migration`).
+- Byte-identical parity is the landing gate: the Rust output must equal the existing Python/numba assembly (dtype, shape, values) for both `variants` and `variant-windows`, across the full `ref`/`alt` ∈ {window, allele} mode matrix, empty groups, and the `flank_tokens` ride-along.
+- Front edge is **assembly tail only**: the v_idxs gather / AF filter / compaction / scalar-field gather stay in Python; the issue-#231 custom-FORMAT dtype-polymorphic numba fallback must remain intact (never route a custom-dtype field through the new typed Rust call).
+- `fill_empty_groups` stays a separate Python post-pass over the existing `fill_empty_seq/scalar/fixed` Rust cores — do NOT fold it into the new call.
+- Do NOT delete the numba/numpy assembly helpers (`compute_windows`, `compute_ref_window`, `compute_alt_window`, `tokenize_alleles`, `compute_flank_tokens`); they become the registered parity oracle.
+- Do NOT reintroduce per-batch `np.ascontiguousarray` on sample-scale memmaps (keep `tests/integration/test_scale_guard.py` green). The mega-call's globals come from `Haps.ffi_static` (sub-linear, already cached) + the variant `ref`-allele bytes.
+- Build after every Rust change: `pixi run -e dev maturin develop --release`. Rust unit tests: `pixi run -e dev cargo-test`. Python tests need `--basetemp=$(pwd)/.pytest_tmp` (HPC cross-device `os.link` Errno 18 guard).
+- `test_e2e_variants` is a **pre-existing xfail** (`_FlatVariants.to_fixed` missing) — confirm it xfails identically at base; not a regression introduced here.
+- Conventional commits; commit at the end of every task. End commit messages with the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer.
+
+---
+
+## File Structure
+
+- **Create** `src/variants/windows.rs` — pure cores (`tokenize`, `slice_flanks`, `assemble_alt_window`, `fetch_windows`) + mode orchestrators (`assemble_variants_mode`, `assemble_windows_mode`) + the `VariantBufs<Tok>` return struct + Rust unit tests.
+- **Modify** `src/variants/mod.rs` — add `pub mod windows;` and re-export nothing else (cores stay in the submodule).
+- **Modify** `src/ffi/mod.rs` — two pyfunctions `assemble_variant_buffers_u8` / `assemble_variant_buffers_i32` returning a `PyDict`.
+- **Modify** `src/lib.rs` — `add_function` for both pyfunctions.
+- **Modify** `python/genvarloader/_dataset/_flat_flanks.py` — add `_assemble_variant_buffers_numba` (the oracle that composes existing helpers into the dict contract) — keeps all current helpers.
+- **Modify** `python/genvarloader/_dataset/_flat_variants.py` — register `assemble_variant_buffers`, add the Rust shim that selects the u8/i32 monomorphization, and rewrite the `get_variants_flat` assembly tail to call `get("assemble_variant_buffers")` and wrap the returned dict once.
+- **Modify** `tests/parity/_harness.py` — add `assert_kernel_parity_dict`.
+- **Create** `tests/parity/test_assemble_variant_buffers_parity.py` — mode-matrix + empty + flank parity.
+- **Modify** `tests/parity/test_dataset_parity.py` — spy that the kernel runs on the live windows/variants `__getitem__` path.
+- **Modify** `docs/roadmaps/rust-migration.md` — tick target 7, record re-measured ratios, set PR link.
+
+---
+
+### Task 1: Rust pure cores — `tokenize`, `slice_flanks`, `assemble_alt_window`
+
+**Files:**
+- Create: `src/variants/windows.rs`
+- Modify: `src/variants/mod.rs:1` (add `pub mod windows;`)
+- Test: cargo unit tests inside `src/variants/windows.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub fn tokenize<Tok: Copy>(bytes: ArrayView1<u8>, lut: ArrayView1<Tok>) -> Array1<Tok>`
+  - `pub fn slice_flanks(data: ArrayView1<u8>, rw_off: ArrayView1<i64>, flank_len: usize) -> (Array1<u8>, Array1<u8>)` — each `(n*flank_len,)`, variant-major: `f5[i*L+k] = data[rw_off[i]+k]`, `f3[i*L+k] = data[rw_off[i+1]-L+k]`
+  - `pub fn assemble_alt_window(f5: ArrayView1<u8>, f3: ArrayView1<u8>, alt_data: ArrayView1<u8>, alt_seq_off: ArrayView1<i64>, flank_len: usize) -> (Array1<u8>, Array1<i64>)`
+
+- [ ] **Step 1: Create the module file with the three cores**
+
+Create `src/variants/windows.rs`:
+
+```rust
+//! Variant-windows / variants flat-buffer assembly cores (pure ndarray).
+//! PyO3 lives in `crate::ffi`. Mirrors the Python helpers in
+//! `_dataset/_flat_flanks.py` (`tokenize_alleles`, `_slice_flanks`,
+//! `_assemble_alt_windows`, `compute_*`) — byte-identical by construction.
+use ndarray::{Array1, ArrayView1};
+
+/// Apply a 256-entry byte->token lookup table. `out[i] = lut[bytes[i]]`.
+/// Mirrors numpy `lut[bytes]`. `Tok` is the token dtype (u8 or i32).
+pub fn tokenize<Tok: Copy>(bytes: ArrayView1<u8>, lut: ArrayView1<Tok>) -> Array1<Tok> {
+    let n = bytes.len();
+    let mut out: Vec<Tok> = Vec::with_capacity(n);
+    for i in 0..n {
+        out.push(lut[bytes[i] as usize]);
+    }
+    Array1::from_vec(out)
+}
+
+/// Derive per-variant (f5, f3) fixed-`flank_len` flanks from a contiguous
+/// per-variant window read `[start-L, end+L)`. `f5` = first `L` bytes of each
+/// row, `f3` = last `L`. Both returned flat `(n*L,)`, variant-major. Mirrors
+/// `_slice_flanks` (`f5 = data[rw_off[:-1,None]+cols]`,
+/// `f3 = data[rw_off[1:,None]-L+cols]`).
+pub fn slice_flanks(
+    data: ArrayView1<u8>,
+    rw_off: ArrayView1<i64>,
+    flank_len: usize,
+) -> (Array1<u8>, Array1<u8>) {
+    let n = rw_off.len() - 1;
+    let mut f5: Vec<u8> = Vec::with_capacity(n * flank_len);
+    let mut f3: Vec<u8> = Vec::with_capacity(n * flank_len);
+    for i in 0..n {
+        let s = rw_off[i] as usize;
+        let e = rw_off[i + 1] as usize;
+        for k in 0..flank_len {
+            f5.push(data[s + k]);
+        }
+        for k in 0..flank_len {
+            f3.push(data[e - flank_len + k]);
+        }
+    }
+    (Array1::from_vec(f5), Array1::from_vec(f3))
+}
+
+/// Concatenate `flank5 . alt . flank3` per variant into a flat byte buffer.
+/// `f5`/`f3` are `(n*flank_len,)` variant-major. Mirrors numba
+/// `_assemble_alt_windows`. Returns `(out_bytes, out_offsets)`.
+pub fn assemble_alt_window(
+    f5: ArrayView1<u8>,
+    f3: ArrayView1<u8>,
+    alt_data: ArrayView1<u8>,
+    alt_seq_off: ArrayView1<i64>,
+    flank_len: usize,
+) -> (Array1<u8>, Array1<i64>) {
+    let n = alt_seq_off.len() - 1;
+    let mut out_off = Array1::<i64>::zeros(n + 1);
+    for i in 0..n {
+        let alt_len = alt_seq_off[i + 1] - alt_seq_off[i];
+        out_off[i + 1] = out_off[i] + 2 * flank_len as i64 + alt_len;
+    }
+    let total = out_off[n] as usize;
+    let mut out: Vec<u8> = Vec::with_capacity(total);
+    for i in 0..n {
+        for k in 0..flank_len {
+            out.push(f5[i * flank_len + k]);
+        }
+        for k in alt_seq_off[i] as usize..alt_seq_off[i + 1] as usize {
+            out.push(alt_data[k]);
+        }
+        for k in 0..flank_len {
+            out.push(f3[i * flank_len + k]);
+        }
+    }
+    (Array1::from_vec(out), out_off)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::arr1;
+
+    #[test]
+    fn test_tokenize_u8() {
+        // lut maps byte 65('A')->0, 67('C')->1, everything else->9 (unknown).
+        let mut lut = vec![9u8; 256];
+        lut[65] = 0;
+        lut[67] = 1;
+        let lut = Array1::from_vec(lut);
+        let bytes = arr1(&[65u8, 67, 78]); // A, C, N(unknown)
+        let out = tokenize(bytes.view(), lut.view());
+        assert_eq!(out.to_vec(), vec![0u8, 1, 9]);
+    }
+
+    #[test]
+    fn test_tokenize_i32() {
+        // i32 tokens (alphabet larger than 255 forces i32 in Python).
+        let mut lut = vec![999i32; 256];
+        lut[71] = 300; // 'G' -> 300
+        let lut = Array1::from_vec(lut);
+        let bytes = arr1(&[71u8, 84]); // G, T(unknown)
+        let out = tokenize(bytes.view(), lut.view());
+        assert_eq!(out.to_vec(), vec![300i32, 999]);
+    }
+
+    #[test]
+    fn test_slice_flanks() {
+        // 2 variants, L=2. var0 window=[1,2,3,4,5] (len 5), var1=[6,7,8,9] (len 4).
+        // rw_off = [0, 5, 9].
+        let data = arr1(&[1u8, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let rw_off = arr1(&[0i64, 5, 9]);
+        let (f5, f3) = slice_flanks(data.view(), rw_off.view(), 2);
+        // f5: first 2 of each = [1,2 | 6,7]; f3: last 2 of each = [4,5 | 8,9]
+        assert_eq!(f5.to_vec(), vec![1u8, 2, 6, 7]);
+        assert_eq!(f3.to_vec(), vec![4u8, 5, 8, 9]);
+    }
+
+    #[test]
+    fn test_assemble_alt_window() {
+        // L=1. f5=[10|20], f3=[11|21]. alt: var0="A"(65), var1="CG"(67,71).
+        let f5 = arr1(&[10u8, 20]);
+        let f3 = arr1(&[11u8, 21]);
+        let alt_data = arr1(&[65u8, 67, 71]);
+        let alt_seq_off = arr1(&[0i64, 1, 3]);
+        let (out, off) = assemble_alt_window(
+            f5.view(),
+            f3.view(),
+            alt_data.view(),
+            alt_seq_off.view(),
+            1,
+        );
+        // var0: 10, 65, 11  (2*1 + 1 = 3 bytes)
+        // var1: 20, 67,71, 21  (2*1 + 2 = 4 bytes)
+        assert_eq!(out.to_vec(), vec![10u8, 65, 11, 20, 67, 71, 21]);
+        assert_eq!(off.to_vec(), vec![0i64, 3, 7]);
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module in**
+
+Add to `src/variants/mod.rs` as the first line after the module doc comment (line 1):
+
+```rust
+pub mod windows;
+```
+
+- [ ] **Step 3: Run the cores' unit tests to verify they pass**
+
+Run: `pixi run -e dev cargo-test 2>&1 | rtk err`
+Expected: the four new `windows::tests::*` tests PASS; existing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add src/variants/windows.rs src/variants/mod.rs
+rtk git commit -m "feat(variants): add tokenize/slice_flanks/assemble_alt_window cores
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Rust `fetch_windows` helper (reference window reads)
+
+**Files:**
+- Modify: `src/variants/windows.rs`
+- Test: cargo unit test inside `src/variants/windows.rs`
+
+**Interfaces:**
+- Consumes: `crate::reference::get_reference(regions: ArrayView2<i32>, out_offsets: ArrayView1<i64>, reference: ArrayView1<u8>, ref_offsets: ArrayView1<i64>, pad_char: u8, parallel: bool) -> Array1<u8>`
+- Produces: `pub fn fetch_windows(v_contigs: ArrayView1<i32>, starts_v: ArrayView1<i32>, ilens_v: ArrayView1<i32>, flank_len: i64, reference: ArrayView1<u8>, ref_offsets: ArrayView1<i64>, pad_char: u8) -> (Array1<u8>, Array1<i64>)` — the per-variant `[start-L, end+L)` read flat buffer + its per-variant offsets (`rw_off`, len `n+1`). `ends = starts - min(ilen,0) + 1`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `src/variants/windows.rs`:
+
+```rust
+    #[test]
+    fn test_fetch_windows() {
+        use ndarray::Array1 as A1;
+        // Single contig reference: bytes 0..20.
+        let reference: A1<u8> = A1::from_vec((0u8..20).collect());
+        let ref_offsets = arr1(&[0i64, 20]);
+        // 1 variant, contig 0, start=5, ilen=0 (SNP) → end = 5 - 0 + 1 = 6.
+        // L=2 → read [start-L, end+L) = [3, 8) → bytes [3,4,5,6,7].
+        let v_contigs = arr1(&[0i32]);
+        let starts = arr1(&[5i32]);
+        let ilens = arr1(&[0i32]);
+        let (data, rw_off) = fetch_windows(
+            v_contigs.view(),
+            starts.view(),
+            ilens.view(),
+            2,
+            reference.view(),
+            ref_offsets.view(),
+            b'N',
+        );
+        assert_eq!(data.to_vec(), vec![3u8, 4, 5, 6, 7]);
+        assert_eq!(rw_off.to_vec(), vec![0i64, 5]);
+    }
+
+    #[test]
+    fn test_fetch_windows_deletion_widens() {
+        use ndarray::Array1 as A1;
+        let reference: A1<u8> = A1::from_vec((0u8..20).collect());
+        let ref_offsets = arr1(&[0i64, 20]);
+        // ilen=-2 (2bp deletion) → end = start - (-2) + 1 = start + 3.
+        // start=5, L=1 → read [4, 9) → bytes [4,5,6,7,8] (len 5).
+        let v_contigs = arr1(&[0i32]);
+        let starts = arr1(&[5i32]);
+        let ilens = arr1(&[-2i32]);
+        let (data, rw_off) = fetch_windows(
+            v_contigs.view(),
+            starts.view(),
+            ilens.view(),
+            1,
+            reference.view(),
+            ref_offsets.view(),
+            b'N',
+        );
+        assert_eq!(data.to_vec(), vec![4u8, 5, 6, 7, 8]);
+        assert_eq!(rw_off.to_vec(), vec![0i64, 5]);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pixi run -e dev cargo-test 2>&1 | rtk err`
+Expected: FAIL — `cannot find function fetch_windows in this scope`.
+
+- [ ] **Step 3: Implement `fetch_windows`**
+
+Add to `src/variants/windows.rs` (above the `#[cfg(test)]` module). Note the `use` additions at the top of the file — change the import line to:
+
+```rust
+use ndarray::{Array1, Array2, ArrayView1, ArrayView2};
+```
+
+Then add:
+
+```rust
+/// Fetch the per-variant reference window `[start-L, end+L)` into one flat
+/// buffer, with `ends = starts - min(ilen, 0) + 1`. Returns `(data, rw_off)`
+/// where `rw_off` are per-variant byte boundaries (len `n+1`). Reuses
+/// `reference::get_reference`'s padded core (absolute-coordinate OOB padding).
+/// Mirrors `reference.fetch(v_contigs, starts-L, ends+L)`.
+pub fn fetch_windows(
+    v_contigs: ArrayView1<i32>,
+    starts_v: ArrayView1<i32>,
+    ilens_v: ArrayView1<i32>,
+    flank_len: i64,
+    reference: ArrayView1<u8>,
+    ref_offsets: ArrayView1<i64>,
+    pad_char: u8,
+) -> (Array1<u8>, Array1<i64>) {
+    let n = starts_v.len();
+    let mut regions = Array2::<i32>::zeros((n, 3));
+    let mut rw_off = Array1::<i64>::zeros(n + 1);
+    for i in 0..n {
+        let start = starts_v[i] as i64;
+        let ilen = ilens_v[i] as i64;
+        let end = start - ilen.min(0) + 1;
+        let rstart = start - flank_len;
+        let rend = end + flank_len;
+        regions[[i, 0]] = v_contigs[i];
+        regions[[i, 1]] = rstart as i32;
+        regions[[i, 2]] = rend as i32;
+        rw_off[i + 1] = rw_off[i] + (rend - rstart);
+    }
+    let data = crate::reference::get_reference(
+        regions.view(),
+        rw_off.view(),
+        reference,
+        ref_offsets,
+        pad_char,
+        false, // serial: disjoint output already; this is per-variant fanout
+    );
+    (data, rw_off)
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pixi run -e dev cargo-test 2>&1 | rtk err`
+Expected: `windows::tests::test_fetch_windows` and `..._deletion_widens` PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/variants/windows.rs
+rtk git commit -m "feat(variants): add fetch_windows reference-read helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Rust `assemble_variants_mode` orchestrator (byte alleles + flank_tokens)
+
+**Files:**
+- Modify: `src/variants/windows.rs`
+- Test: cargo unit test inside `src/variants/windows.rs`
+
+**Interfaces:**
+- Consumes: `crate::variants::gather_alleles(v_idxs, allele_bytes, allele_offsets) -> (Array1<u8>, Array1<i64>)`; Task 1/2 cores.
+- Produces:
+  - `pub struct VariantBufs<Tok> { pub byte_bufs: Vec<(&'static str, Array1<u8>, Array1<i64>)>, pub tok_bufs: Vec<(&'static str, Array1<Tok>, Array1<i64>)> }`
+  - `pub fn assemble_variants_mode<Tok: Copy>(...) -> VariantBufs<Tok>` (signature in Step 3)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `src/variants/windows.rs`:
+
+```rust
+    #[test]
+    fn test_assemble_variants_mode_alt_and_flank() {
+        use ndarray::Array1 as A1;
+        // Global alleles: v0="A"(65), v1="CG"(67,71). offsets [0,1,3].
+        let alt_global = arr1(&[65u8, 67, 71]);
+        let alt_off = arr1(&[0i64, 1, 3]);
+        // Select v_idxs [1, 0] in one row.
+        let v_idxs = arr1(&[1i32, 0]);
+        let row_offsets = arr1(&[0i64, 2]);
+        // Reference 0..20, single contig. v_starts/ilens are GLOBAL (indexed by v_idx).
+        let reference: A1<u8> = A1::from_vec((0u8..20).collect());
+        let ref_offsets = arr1(&[0i64, 20]);
+        let v_starts = arr1(&[5i32, 8]); // global per-variant
+        let ilens = arr1(&[0i32, 0]);
+        let v_contigs = arr1(&[0i32, 0]); // per-selected-variant contig
+        // L=1, token LUT: identity-ish u8 (byte value -> itself for the test).
+        let lut: A1<u8> = A1::from_vec((0u8..=255).collect());
+
+        let bufs = assemble_variants_mode::<u8>(
+            v_idxs.view(),
+            row_offsets.view(),
+            alt_global.view(),
+            alt_off.view(),
+            None, // no ref alleles
+            None,
+            true, // want_flank
+            1,    // flank_len
+            Some(lut.view()),
+            v_contigs.view(),
+            v_starts.view(),
+            ilens.view(),
+            reference.view(),
+            ref_offsets.view(),
+            b'N',
+        );
+        // byte_bufs: only "alt". v_idxs [1,0] → "CG" then "A" → [67,71,65], off [0,2,3].
+        assert_eq!(bufs.byte_bufs.len(), 1);
+        let (name, data, off) = &bufs.byte_bufs[0];
+        assert_eq!(*name, "alt");
+        assert_eq!(data.to_vec(), vec![67u8, 71, 65]);
+        assert_eq!(off.to_vec(), vec![0i64, 2, 3]);
+        // tok_bufs: only "flank_tokens". Each variant: [f5(1) | f3(1)] = 2 tokens.
+        // var0 = v_idx 1: start=8, ilen=0 → end=9, read [7,10) = [7,8,9]; f5=[7], f3=[9].
+        // var1 = v_idx 0: start=5, ilen=0 → end=6, read [4,7) = [4,5,6]; f5=[4], f3=[6].
+        // tokens (identity lut) = [7,9, 4,6]; offsets = row_offsets [0,2].
+        assert_eq!(bufs.tok_bufs.len(), 1);
+        let (tname, tdata, toff) = &bufs.tok_bufs[0];
+        assert_eq!(*tname, "flank_tokens");
+        assert_eq!(tdata.to_vec(), vec![7u8, 9, 4, 6]);
+        assert_eq!(toff.to_vec(), vec![0i64, 2]);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pixi run -e dev cargo-test 2>&1 | rtk err`
+Expected: FAIL — `cannot find function assemble_variants_mode` / `cannot find struct VariantBufs`.
+
+- [ ] **Step 3: Implement the struct + orchestrator**
+
+Add to `src/variants/windows.rs` (above the `#[cfg(test)]` module):
+
+```rust
+/// Assembled flat buffers returned by the mode orchestrators. `byte_bufs` carry
+/// raw allele bytes (u8); `tok_bufs` carry LUT-applied tokens (`Tok`). Each
+/// tuple is `(field_name, data, seq_offsets)`.
+pub struct VariantBufs<Tok> {
+    pub byte_bufs: Vec<(&'static str, Array1<u8>, Array1<i64>)>,
+    pub tok_bufs: Vec<(&'static str, Array1<Tok>, Array1<i64>)>,
+}
+
+/// Gather per-selected-variant `start`/`ilen` from the GLOBAL arrays via `v_idxs`.
+fn gather_starts_ilens(
+    v_idxs: ArrayView1<i32>,
+    v_starts: ArrayView1<i32>,
+    ilens: ArrayView1<i32>,
+) -> (Array1<i32>, Array1<i32>) {
+    let n = v_idxs.len();
+    let mut s = Array1::<i32>::zeros(n);
+    let mut il = Array1::<i32>::zeros(n);
+    for i in 0..n {
+        let v = v_idxs[i] as usize;
+        s[i] = v_starts[v];
+        il[i] = ilens[v];
+    }
+    (s, il)
+}
+
+/// Plain-`variants` assembly tail: raw alt bytes (always), raw ref bytes
+/// (optional), `flank_tokens` ride-along (optional). Mirrors the variants tail
+/// of `get_variants_flat` (gather_alleles + compute_flank_tokens).
+#[allow(clippy::too_many_arguments)]
+pub fn assemble_variants_mode<Tok: Copy>(
+    v_idxs: ArrayView1<i32>,
+    row_offsets: ArrayView1<i64>,
+    alt_global: ArrayView1<u8>,
+    alt_off_global: ArrayView1<i64>,
+    ref_global: Option<ArrayView1<u8>>,
+    ref_off_global: Option<ArrayView1<i64>>,
+    want_flank: bool,
+    flank_len: i64,
+    lut: Option<ArrayView1<Tok>>,
+    v_contigs: ArrayView1<i32>,
+    v_starts: ArrayView1<i32>,
+    ilens: ArrayView1<i32>,
+    reference: ArrayView1<u8>,
+    ref_offsets: ArrayView1<i64>,
+    pad_char: u8,
+) -> VariantBufs<Tok> {
+    let mut byte_bufs = Vec::new();
+    let mut tok_bufs = Vec::new();
+
+    let (alt_data, alt_seq_off) =
+        crate::variants::gather_alleles(v_idxs, alt_global, alt_off_global);
+    byte_bufs.push(("alt", alt_data, alt_seq_off));
+
+    if let (Some(rg), Some(ro)) = (ref_global, ref_off_global) {
+        let (ref_data, ref_seq_off) = crate::variants::gather_alleles(v_idxs, rg, ro);
+        byte_bufs.push(("ref", ref_data, ref_seq_off));
+    }
+
+    if want_flank {
+        let lut = lut.expect("flank tokens requested but no token LUT supplied");
+        let (starts_v, ilens_v) = gather_starts_ilens(v_idxs, v_starts, ilens);
+        let (rw_data, rw_off) = fetch_windows(
+            v_contigs, starts_v.view(), ilens_v.view(), flank_len, reference, ref_offsets,
+            pad_char,
+        );
+        let l = flank_len as usize;
+        let (f5, f3) = slice_flanks(rw_data.view(), rw_off.view(), l);
+        // Concatenate [f5 | f3] per variant (2L tokens, variant-major), tokenize.
+        let n = f5.len() / l;
+        let mut flank_bytes: Vec<u8> = Vec::with_capacity(n * 2 * l);
+        for i in 0..n {
+            for k in 0..l {
+                flank_bytes.push(f5[i * l + k]);
+            }
+            for k in 0..l {
+                flank_bytes.push(f3[i * l + k]);
+            }
+        }
+        let fb = Array1::from_vec(flank_bytes);
+        let tok = tokenize(fb.view(), lut);
+        // flank_tokens offsets are the variant-level row_offsets (fixed 2L inner
+        // axis carried separately Python-side as a trailing regular dim).
+        tok_bufs.push(("flank_tokens", tok, row_offsets.to_owned()));
+    }
+
+    VariantBufs { byte_bufs, tok_bufs }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pixi run -e dev cargo-test 2>&1 | rtk err`
+Expected: `test_assemble_variants_mode_alt_and_flank` PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/variants/windows.rs
+rtk git commit -m "feat(variants): assemble_variants_mode (alt/ref bytes + flank tokens)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Rust `assemble_windows_mode` orchestrator (token windows)
+
+**Files:**
+- Modify: `src/variants/windows.rs`
+- Test: cargo unit test inside `src/variants/windows.rs`
+
+**Interfaces:**
+- Consumes: Task 1/2/3 cores + `gather_alleles`.
+- Produces: `pub fn assemble_windows_mode<Tok: Copy>(...) -> VariantBufs<Tok>` (signature in Step 3). `ref_mode`/`alt_mode`: `1` = window (flanked, tokenized), `2` = allele (bare tokenized). Field names: `ref_window`/`alt_window` for mode 1, `ref`/`alt` for mode 2.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `src/variants/windows.rs`:
+
+```rust
+    #[test]
+    fn test_assemble_windows_mode_both_windows() {
+        use ndarray::Array1 as A1;
+        // Global alt alleles: v0="A"(65). offsets [0,1].
+        let alt_global = arr1(&[65u8]);
+        let alt_off = arr1(&[0i64, 1]);
+        let v_idxs = arr1(&[0i32]);
+        let row_offsets = arr1(&[0i64, 1]);
+        let reference: A1<u8> = A1::from_vec((0u8..20).collect());
+        let ref_offsets = arr1(&[0i64, 20]);
+        let v_starts = arr1(&[5i32]);
+        let ilens = arr1(&[0i32]);
+        let v_contigs = arr1(&[0i32]);
+        let lut: A1<u8> = A1::from_vec((0u8..=255).collect()); // identity
+
+        let bufs = assemble_windows_mode::<u8>(
+            v_idxs.view(),
+            row_offsets.view(),
+            1, // ref_mode = window
+            1, // alt_mode = window
+            alt_global.view(),
+            alt_off.view(),
+            None,
+            None,
+            1, // flank_len
+            lut.view(),
+            v_contigs.view(),
+            v_starts.view(),
+            ilens.view(),
+            reference.view(),
+            ref_offsets.view(),
+            b'N',
+        );
+        // SNP start=5 ilen=0 → end=6; read [4,7) = [4,5,6]. L=1.
+        // ref_window tokens (identity) = [4,5,6], off [0,3].
+        // alt_window = f5[4] . alt[65] . f3[6] = [4,65,6], off [0,3].
+        assert_eq!(bufs.byte_bufs.len(), 0);
+        let names: Vec<&str> = bufs.tok_bufs.iter().map(|t| t.0).collect();
+        assert_eq!(names, vec!["ref_window", "alt_window"]);
+        assert_eq!(bufs.tok_bufs[0].1.to_vec(), vec![4u8, 5, 6]);
+        assert_eq!(bufs.tok_bufs[0].2.to_vec(), vec![0i64, 3]);
+        assert_eq!(bufs.tok_bufs[1].1.to_vec(), vec![4u8, 65, 6]);
+        assert_eq!(bufs.tok_bufs[1].2.to_vec(), vec![0i64, 3]);
+    }
+
+    #[test]
+    fn test_assemble_windows_mode_bare_alleles() {
+        use ndarray::Array1 as A1;
+        // alt v0="AC"(65,67); ref v0="G"(71).
+        let alt_global = arr1(&[65u8, 67]);
+        let alt_off = arr1(&[0i64, 2]);
+        let ref_global = arr1(&[71u8]);
+        let ref_off = arr1(&[0i64, 1]);
+        let v_idxs = arr1(&[0i32]);
+        let row_offsets = arr1(&[0i64, 1]);
+        let reference: A1<u8> = A1::from_vec((0u8..20).collect());
+        let ref_offsets = arr1(&[0i64, 20]);
+        let v_starts = arr1(&[5i32]);
+        let ilens = arr1(&[0i32]);
+        let v_contigs = arr1(&[0i32]);
+        let lut: A1<u8> = A1::from_vec((0u8..=255).collect());
+
+        let bufs = assemble_windows_mode::<u8>(
+            v_idxs.view(),
+            row_offsets.view(),
+            2, // ref_mode = allele (bare)
+            2, // alt_mode = allele (bare)
+            alt_global.view(),
+            alt_off.view(),
+            Some(ref_global.view()),
+            Some(ref_off.view()),
+            1,
+            lut.view(),
+            v_contigs.view(),
+            v_starts.view(),
+            ilens.view(),
+            reference.view(),
+            ref_offsets.view(),
+            b'N',
+        );
+        let names: Vec<&str> = bufs.tok_bufs.iter().map(|t| t.0).collect();
+        assert_eq!(names, vec!["ref", "alt"]);
+        // bare ref tokens = [71], off [0,1]; bare alt tokens = [65,67], off [0,2].
+        assert_eq!(bufs.tok_bufs[0].1.to_vec(), vec![71u8]);
+        assert_eq!(bufs.tok_bufs[0].2.to_vec(), vec![0i64, 1]);
+        assert_eq!(bufs.tok_bufs[1].1.to_vec(), vec![65u8, 67]);
+        assert_eq!(bufs.tok_bufs[1].2.to_vec(), vec![0i64, 2]);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pixi run -e dev cargo-test 2>&1 | rtk err`
+Expected: FAIL — `cannot find function assemble_windows_mode`.
+
+- [ ] **Step 3: Implement `assemble_windows_mode`**
+
+Add to `src/variants/windows.rs` (above the `#[cfg(test)]` module):
+
+```rust
+/// `variant-windows` assembly tail. `ref_mode`/`alt_mode`: 1 = flanked window
+/// (`[start-L,end+L)` for ref; `flank5.alt.flank3` for alt), 2 = bare tokenized
+/// allele. Produces only token buffers (scalar fields are handled Python-side).
+/// Mirrors the windows branch of `get_variants_flat` (incl. the single fused
+/// fetch shared by ref_window + alt_window).
+#[allow(clippy::too_many_arguments)]
+pub fn assemble_windows_mode<Tok: Copy>(
+    v_idxs: ArrayView1<i32>,
+    _row_offsets: ArrayView1<i64>,
+    ref_mode: i64,
+    alt_mode: i64,
+    alt_global: ArrayView1<u8>,
+    alt_off_global: ArrayView1<i64>,
+    ref_global: Option<ArrayView1<u8>>,
+    ref_off_global: Option<ArrayView1<i64>>,
+    flank_len: i64,
+    lut: ArrayView1<Tok>,
+    v_contigs: ArrayView1<i32>,
+    v_starts: ArrayView1<i32>,
+    ilens: ArrayView1<i32>,
+    reference: ArrayView1<u8>,
+    ref_offsets: ArrayView1<i64>,
+    pad_char: u8,
+) -> VariantBufs<Tok> {
+    let mut tok_bufs = Vec::new();
+    let l = flank_len as usize;
+
+    // alt alleles are always gathered (needed for alt window or bare alt).
+    let (alt_data, alt_seq_off) =
+        crate::variants::gather_alleles(v_idxs, alt_global, alt_off_global);
+
+    // One fused fetch if either side needs a window read.
+    let need_fetch = ref_mode == 1 || alt_mode == 1;
+    let fetched = if need_fetch {
+        let (starts_v, ilens_v) = gather_starts_ilens(v_idxs, v_starts, ilens);
+        Some(fetch_windows(
+            v_contigs, starts_v.view(), ilens_v.view(), flank_len, reference, ref_offsets,
+            pad_char,
+        ))
+    } else {
+        None
+    };
+
+    // ref side (ordered first to match Python field insertion order).
+    if ref_mode == 1 {
+        let (rw_data, rw_off) = fetched.as_ref().expect("ref window needs a fetch");
+        let tok = tokenize(rw_data.view(), lut);
+        tok_bufs.push(("ref_window", tok, rw_off.clone()));
+    } else if ref_mode == 2 {
+        let rg = ref_global.expect("bare ref allele needs ref byte buffer");
+        let ro = ref_off_global.expect("bare ref allele needs ref offsets");
+        let (ref_data, ref_seq_off) = crate::variants::gather_alleles(v_idxs, rg, ro);
+        let tok = tokenize(ref_data.view(), lut);
+        tok_bufs.push(("ref", tok, ref_seq_off));
+    }
+
+    // alt side.
+    if alt_mode == 1 {
+        let (rw_data, rw_off) = fetched.as_ref().expect("alt window needs a fetch");
+        let (f5, f3) = slice_flanks(rw_data.view(), rw_off.view(), l);
+        let (alt_bytes, alt_off) = assemble_alt_window(
+            f5.view(),
+            f3.view(),
+            alt_data.view(),
+            alt_seq_off.view(),
+            l,
+        );
+        let tok = tokenize(alt_bytes.view(), lut);
+        tok_bufs.push(("alt_window", tok, alt_off));
+    } else if alt_mode == 2 {
+        let tok = tokenize(alt_data.view(), lut);
+        tok_bufs.push(("alt", tok, alt_seq_off));
+    }
+
+    VariantBufs { byte_bufs: Vec::new(), tok_bufs }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pixi run -e dev cargo-test 2>&1 | rtk err`
+Expected: both `test_assemble_windows_mode_*` PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/variants/windows.rs
+rtk git commit -m "feat(variants): assemble_windows_mode (token windows + bare alleles)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: FFI pyfunctions + registration
+
+**Files:**
+- Modify: `src/ffi/mod.rs`
+- Modify: `src/lib.rs:36` (after the last `add_function` for variants)
+- Test: Python smoke import (Step 5)
+
+**Interfaces:**
+- Produces two Python-callable functions, importable as
+  `from genvarloader.genvarloader import assemble_variant_buffers_u8, assemble_variant_buffers_i32`.
+- Signature (identical for both; the suffix names the token dtype `Tok`):
+  ```
+  assemble_variant_buffers_<tok>(
+      mode: int,                # 0 = variants, 1 = windows
+      v_idxs: i32[n],
+      row_offsets: i64[b*p+1],
+      alt_global: u8[],
+      alt_off_global: i64[],
+      ref_global: Optional[u8[]],
+      ref_off_global: Optional[i64[]],
+      want_ref_bytes: bool,     # variants mode: emit raw "ref" bytes
+      want_flank: bool,         # variants mode: emit "flank_tokens"
+      ref_mode: int,            # windows mode: 1 window / 2 allele
+      alt_mode: int,            # windows mode: 1 window / 2 allele
+      flank_len: int,
+      lut: Optional[<tok>[256]],
+      v_contigs: i32[n],
+      v_starts: i32[],          # global per-variant
+      ilens: i32[],             # global per-variant
+      reference: u8[],
+      ref_offsets: i64[],       # contig offsets
+      pad_char: int,
+  ) -> dict[str, tuple[np.ndarray, np.ndarray]]   # name -> (data, seq_offsets)
+  ```
+
+- [ ] **Step 1: Add the shared dict-builder + two pyfunctions**
+
+Add to the top imports of `src/ffi/mod.rs` (extend the existing `use` lines):
+
+```rust
+use numpy::PyArrayMethods;
+use pyo3::types::PyDict;
+use crate::variants::windows::{assemble_variants_mode, assemble_windows_mode, VariantBufs};
+```
+
+Add these functions to `src/ffi/mod.rs` (near the other variants pyfunctions):
+
+```rust
+/// Build the `{name: (data, seq_offsets)}` dict from assembled buffers.
+fn bufs_to_pydict<'py, Tok: numpy::Element + Copy>(
+    py: Python<'py>,
+    bufs: VariantBufs<Tok>,
+) -> Bound<'py, PyDict> {
+    let d = PyDict::new(py);
+    for (name, data, off) in bufs.byte_bufs {
+        d.set_item(name, (data.into_pyarray(py), off.into_pyarray(py)))
+            .unwrap();
+    }
+    for (name, data, off) in bufs.tok_bufs {
+        d.set_item(name, (data.into_pyarray(py), off.into_pyarray(py)))
+            .unwrap();
+    }
+    d
+}
+
+/// Monomorphized assembly entry. `Tok` is the token dtype; `mode` selects
+/// variants (0) vs windows (1). See module docs in `variants::windows`.
+#[allow(clippy::too_many_arguments)]
+fn assemble_variant_buffers_impl<'py, Tok: numpy::Element + Copy>(
+    py: Python<'py>,
+    mode: i64,
+    v_idxs: PyReadonlyArray1<i32>,
+    row_offsets: PyReadonlyArray1<i64>,
+    alt_global: PyReadonlyArray1<u8>,
+    alt_off_global: PyReadonlyArray1<i64>,
+    ref_global: Option<PyReadonlyArray1<u8>>,
+    ref_off_global: Option<PyReadonlyArray1<i64>>,
+    want_ref_bytes: bool,
+    want_flank: bool,
+    ref_mode: i64,
+    alt_mode: i64,
+    flank_len: i64,
+    lut: Option<PyReadonlyArray1<Tok>>,
+    v_contigs: PyReadonlyArray1<i32>,
+    v_starts: PyReadonlyArray1<i32>,
+    ilens: PyReadonlyArray1<i32>,
+    reference: PyReadonlyArray1<u8>,
+    ref_offsets: PyReadonlyArray1<i64>,
+    pad_char: u8,
+) -> Bound<'py, PyDict> {
+    let rg = ref_global.as_ref().map(|a| a.as_array());
+    let ro = ref_off_global.as_ref().map(|a| a.as_array());
+    let lut_v = lut.as_ref().map(|a| a.as_array());
+    let bufs = if mode == 0 {
+        assemble_variants_mode::<Tok>(
+            v_idxs.as_array(),
+            row_offsets.as_array(),
+            alt_global.as_array(),
+            alt_off_global.as_array(),
+            if want_ref_bytes { rg } else { None },
+            if want_ref_bytes { ro } else { None },
+            want_flank,
+            flank_len,
+            lut_v,
+            v_contigs.as_array(),
+            v_starts.as_array(),
+            ilens.as_array(),
+            reference.as_array(),
+            ref_offsets.as_array(),
+            pad_char,
+        )
+    } else {
+        assemble_windows_mode::<Tok>(
+            v_idxs.as_array(),
+            row_offsets.as_array(),
+            ref_mode,
+            alt_mode,
+            alt_global.as_array(),
+            alt_off_global.as_array(),
+            rg,
+            ro,
+            flank_len,
+            lut_v.expect("windows mode requires a token LUT"),
+            v_contigs.as_array(),
+            v_starts.as_array(),
+            ilens.as_array(),
+            reference.as_array(),
+            ref_offsets.as_array(),
+            pad_char,
+        )
+    };
+    bufs_to_pydict(py, bufs)
+}
+
+/// u8-token assembly (token_dtype == uint8). See `assemble_variant_buffers_impl`.
+#[pyfunction]
+#[allow(clippy::too_many_arguments)]
+pub fn assemble_variant_buffers_u8<'py>(
+    py: Python<'py>,
+    mode: i64,
+    v_idxs: PyReadonlyArray1<i32>,
+    row_offsets: PyReadonlyArray1<i64>,
+    alt_global: PyReadonlyArray1<u8>,
+    alt_off_global: PyReadonlyArray1<i64>,
+    ref_global: Option<PyReadonlyArray1<u8>>,
+    ref_off_global: Option<PyReadonlyArray1<i64>>,
+    want_ref_bytes: bool,
+    want_flank: bool,
+    ref_mode: i64,
+    alt_mode: i64,
+    flank_len: i64,
+    lut: Option<PyReadonlyArray1<u8>>,
+    v_contigs: PyReadonlyArray1<i32>,
+    v_starts: PyReadonlyArray1<i32>,
+    ilens: PyReadonlyArray1<i32>,
+    reference: PyReadonlyArray1<u8>,
+    ref_offsets: PyReadonlyArray1<i64>,
+    pad_char: u8,
+) -> Bound<'py, PyDict> {
+    assemble_variant_buffers_impl::<u8>(
+        py, mode, v_idxs, row_offsets, alt_global, alt_off_global, ref_global,
+        ref_off_global, want_ref_bytes, want_flank, ref_mode, alt_mode, flank_len,
+        lut, v_contigs, v_starts, ilens, reference, ref_offsets, pad_char,
+    )
+}
+
+/// i32-token assembly (token_dtype == int32). See `assemble_variant_buffers_impl`.
+#[pyfunction]
+#[allow(clippy::too_many_arguments)]
+pub fn assemble_variant_buffers_i32<'py>(
+    py: Python<'py>,
+    mode: i64,
+    v_idxs: PyReadonlyArray1<i32>,
+    row_offsets: PyReadonlyArray1<i64>,
+    alt_global: PyReadonlyArray1<u8>,
+    alt_off_global: PyReadonlyArray1<i64>,
+    ref_global: Option<PyReadonlyArray1<u8>>,
+    ref_off_global: Option<PyReadonlyArray1<i64>>,
+    want_ref_bytes: bool,
+    want_flank: bool,
+    ref_mode: i64,
+    alt_mode: i64,
+    flank_len: i64,
+    lut: Option<PyReadonlyArray1<i32>>,
+    v_contigs: PyReadonlyArray1<i32>,
+    v_starts: PyReadonlyArray1<i32>,
+    ilens: PyReadonlyArray1<i32>,
+    reference: PyReadonlyArray1<u8>,
+    ref_offsets: PyReadonlyArray1<i64>,
+    pad_char: u8,
+) -> Bound<'py, PyDict> {
+    assemble_variant_buffers_impl::<i32>(
+        py, mode, v_idxs, row_offsets, alt_global, alt_off_global, ref_global,
+        ref_off_global, want_ref_bytes, want_flank, ref_mode, alt_mode, flank_len,
+        lut, v_contigs, v_starts, ilens, reference, ref_offsets, pad_char,
+    )
+}
+```
+
+- [ ] **Step 2: Register both in `src/lib.rs`**
+
+After the line `m.add_function(wrap_pyfunction!(ffi::fill_empty_seq_i32, m)?)?;` (currently `src/lib.rs:35`), add:
+
+```rust
+    m.add_function(wrap_pyfunction!(ffi::assemble_variant_buffers_u8, m)?)?;
+    m.add_function(wrap_pyfunction!(ffi::assemble_variant_buffers_i32, m)?)?;
+```
+
+- [ ] **Step 3: Build the extension**
+
+Run: `pixi run -e dev maturin develop --release 2>&1 | rtk err`
+Expected: builds clean (no errors). Warnings about `too_many_arguments` are suppressed by the `allow` attributes.
+
+- [ ] **Step 4: Run the Rust unit tests again (regression)**
+
+Run: `pixi run -e dev cargo-test 2>&1 | rtk err`
+Expected: all `windows::tests::*` plus existing tests PASS.
+
+- [ ] **Step 5: Smoke-test the import**
+
+Run:
+```bash
+pixi run -e dev python -c "from genvarloader.genvarloader import assemble_variant_buffers_u8, assemble_variant_buffers_i32; print('ok')"
+```
+Expected: prints `ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add src/ffi/mod.rs src/lib.rs
+rtk git commit -m "feat(ffi): assemble_variant_buffers_{u8,i32} pyfunctions
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Python numba oracle + dispatch registration + dict parity harness
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_flat_flanks.py`
+- Modify: `python/genvarloader/_dataset/_flat_variants.py` (imports + register block)
+- Modify: `tests/parity/_harness.py`
+- Test: `tests/parity/test_assemble_variant_buffers_parity.py` (created in Task 8; harness verified here via a tiny inline check)
+
+**Interfaces:**
+- Produces:
+  - `_flat_flanks._assemble_variant_buffers_numba(mode, v_idxs, row_offsets, alt_global, alt_off_global, ref_global, ref_off_global, want_ref_bytes, want_flank, ref_mode, alt_mode, flank_len, lut, v_contigs, v_starts, ilens, reference, ref_offsets, pad_char) -> dict[str, tuple[np.ndarray, np.ndarray]]` — same contract as the Rust pyfunctions, composed from the existing helpers.
+  - `_flat_variants._assemble_variant_buffers_rust(...same args...)` — the dtype-selecting shim.
+  - dispatch key `"assemble_variant_buffers"` (default `"rust"`).
+  - `tests.parity._harness.assert_kernel_parity_dict(name, *inputs)`.
+
+- [ ] **Step 1: Write the numba oracle composing existing helpers**
+
+Add to `python/genvarloader/_dataset/_flat_flanks.py` (after the existing imports and `from ._flat_variants import _FlatWindow`):
+
+```python
+from ._flat_variants import _gather_alleles  # noqa: E402  (numba/rust dispatch gather)
+
+
+def _assemble_variant_buffers_numba(
+    mode,
+    v_idxs,
+    row_offsets,
+    alt_global,
+    alt_off_global,
+    ref_global,
+    ref_off_global,
+    want_ref_bytes,
+    want_flank,
+    ref_mode,
+    alt_mode,
+    flank_len,
+    lut,
+    v_contigs,
+    v_starts,
+    ilens,
+    reference,
+    ref_offsets,
+    pad_char,
+):
+    """Parity oracle: compose the existing numpy/numba assembly helpers into the
+    same ``{name: (data, seq_offsets)}`` dict the Rust mega-call returns.
+
+    ``reference``/``ref_offsets``/``pad_char`` are the raw reference-genome
+    arrays; this oracle wraps them in a lightweight fetch shim so it can reuse
+    ``compute_*`` unchanged."""
+    from numpy.typing import NDArray  # noqa: F401
+
+    out: dict = {}
+    v_idxs = np.ascontiguousarray(v_idxs, np.int32)
+    row_offsets = np.ascontiguousarray(row_offsets, np.int64)
+
+    # per-selected-variant start/ilen (global arrays indexed by v_idxs)
+    starts_v = np.asarray(v_starts, np.int32)[v_idxs]
+    ilens_v = np.asarray(ilens, np.int32)[v_idxs]
+    v_contigs = np.ascontiguousarray(v_contigs, np.int32)
+
+    class _RefShim:
+        """Minimal reference.fetch() over raw arrays, matching Reference.fetch."""
+
+        def fetch(self, contigs, starts, ends):
+            from .._ragged import Ragged
+            from ..genvarloader import get_reference
+
+            lengths = np.asarray(ends) - np.asarray(starts)
+            from .._utils import lengths_to_offsets
+
+            offs = lengths_to_offsets(lengths)
+            regions = np.stack(
+                [
+                    np.asarray(contigs, np.int32),
+                    np.asarray(starts, np.int32),
+                    np.asarray(ends, np.int32),
+                ],
+                axis=1,
+            )
+            seqs = get_reference(
+                regions,
+                offs,
+                np.asarray(reference, np.uint8),
+                np.asarray(ref_offsets, np.int64),
+                int(pad_char),
+                False,
+            )
+            return Ragged.from_offsets(seqs.view("S1"), (len(contigs), None), offs)
+
+    ref_shim = _RefShim()
+    lut_arr = None if lut is None else np.asarray(lut)
+
+    if mode == 0:
+        alt_data, alt_seq_off = _gather_alleles(v_idxs, alt_global, alt_off_global)
+        out["alt"] = (np.ascontiguousarray(alt_data, np.uint8), alt_seq_off)
+        if want_ref_bytes:
+            ref_data, ref_seq_off = _gather_alleles(v_idxs, ref_global, ref_off_global)
+            out["ref"] = (np.ascontiguousarray(ref_data, np.uint8), ref_seq_off)
+        if want_flank:
+            tok, off = compute_flank_tokens(
+                ref_shim, v_contigs, starts_v, ilens_v, flank_len, lut_arr, row_offsets
+            )
+            out["flank_tokens"] = (tok, np.asarray(off, np.int64))
+    else:
+        alt_data, alt_seq_off = _gather_alleles(v_idxs, alt_global, alt_off_global)
+        if ref_mode == 1:
+            rw = compute_ref_window(
+                ref_shim, v_contigs, starts_v, ilens_v, flank_len, lut_arr, row_offsets
+            )
+            out["ref_window"] = (rw.data, rw.seq_offsets)
+        elif ref_mode == 2:
+            ref_data, ref_seq_off = _gather_alleles(v_idxs, ref_global, ref_off_global)
+            rw = tokenize_alleles(ref_data, ref_seq_off, lut_arr, row_offsets)
+            out["ref"] = (rw.data, rw.seq_offsets)
+        if alt_mode == 1:
+            aw = compute_alt_window(
+                ref_shim, v_contigs, starts_v, ilens_v, alt_data, alt_seq_off,
+                flank_len, lut_arr, row_offsets,
+            )
+            out["alt_window"] = (aw.data, aw.seq_offsets)
+        elif alt_mode == 2:
+            aw = tokenize_alleles(alt_data, alt_seq_off, lut_arr, row_offsets)
+            out["alt"] = (aw.data, aw.seq_offsets)
+    return out
+```
+
+> Note: confirm the import paths `from .._ragged import Ragged`, `from .._utils import lengths_to_offsets`, and `from ..genvarloader import get_reference` resolve in this package (grep them: `rtk grep "def lengths_to_offsets" python/genvarloader/_utils.py` and `rtk grep "get_reference" python/genvarloader/__init__.py` / the compiled module). If `get_reference` is not yet exported from the Python package, import it from `..genvarloader` (the compiled extension) — it is already used by `_reference.py:143`, so mirror that exact import.
+
+- [ ] **Step 2: Add the Rust dtype-selecting shim + register the kernel**
+
+In `python/genvarloader/_dataset/_flat_variants.py`, add to the rust imports block (near the other `from ..genvarloader import ... as ..._rust`):
+
+```python
+from ..genvarloader import assemble_variant_buffers_i32 as _assemble_i32_rust
+from ..genvarloader import assemble_variant_buffers_u8 as _assemble_u8_rust
+```
+
+Then add the shim + registration (place it after the existing `register(...)` blocks, e.g. after the `fill_empty_seq` registrations):
+
+```python
+def _assemble_variant_buffers_rust(
+    mode,
+    v_idxs,
+    row_offsets,
+    alt_global,
+    alt_off_global,
+    ref_global,
+    ref_off_global,
+    want_ref_bytes,
+    want_flank,
+    ref_mode,
+    alt_mode,
+    flank_len,
+    lut,
+    v_contigs,
+    v_starts,
+    ilens,
+    reference,
+    ref_offsets,
+    pad_char,
+):
+    """Select the u8/i32 monomorphization by token dtype. ``lut`` is None only
+    when no tokenized output is requested (plain variants, no flank); then the
+    u8 entry is used and ``lut`` stays None."""
+    fn = _assemble_u8_rust
+    if lut is not None and np.asarray(lut).dtype == np.int32:
+        fn = _assemble_i32_rust
+    return fn(
+        int(mode),
+        np.ascontiguousarray(v_idxs, np.int32),
+        np.ascontiguousarray(row_offsets, np.int64),
+        np.ascontiguousarray(alt_global, np.uint8),
+        np.ascontiguousarray(alt_off_global, np.int64),
+        None if ref_global is None else np.ascontiguousarray(ref_global, np.uint8),
+        None if ref_off_global is None else np.ascontiguousarray(ref_off_global, np.int64),
+        bool(want_ref_bytes),
+        bool(want_flank),
+        int(ref_mode),
+        int(alt_mode),
+        int(flank_len),
+        None if lut is None else np.ascontiguousarray(lut),
+        np.ascontiguousarray(v_contigs, np.int32),
+        np.ascontiguousarray(v_starts, np.int32),
+        np.ascontiguousarray(ilens, np.int32),
+        np.ascontiguousarray(reference, np.uint8),
+        np.ascontiguousarray(ref_offsets, np.int64),
+        int(pad_char),
+    )
+
+
+def _assemble_variant_buffers_numba_entry(*args):
+    from ._flat_flanks import _assemble_variant_buffers_numba
+
+    return _assemble_variant_buffers_numba(*args)
+
+
+register(
+    "assemble_variant_buffers",
+    numba=_assemble_variant_buffers_numba_entry,
+    rust=_assemble_variant_buffers_rust,
+    default="rust",
+)
+```
+
+> The numba entry is a thin lazy wrapper to avoid a circular import (`_flat_flanks` imports from `_flat_variants`).
+
+- [ ] **Step 3: Add the dict parity assertion to the harness**
+
+Add to `tests/parity/_harness.py`:
+
+```python
+def assert_kernel_parity_dict(name: str, *inputs) -> None:
+    """Parity for kernels that RETURN a dict[str, tuple[ndarray, ...]].
+
+    Asserts identical key sets and byte-identical values per key (dtype, shape,
+    values) between the numba and rust backends.
+    """
+    numba_fn, rust_fn = _dispatch.backends(name)
+    got_numba = numba_fn(*inputs)
+    got_rust = rust_fn(*inputs)
+    assert set(got_numba) == set(got_rust), (
+        f"{name}: keys {sorted(got_numba)} != {sorted(got_rust)}"
+    )
+    for key in got_numba:
+        nt = got_numba[key]
+        rt = got_rust[key]
+        assert len(nt) == len(rt), f"{name}[{key}]: tuple len {len(nt)} != {len(rt)}"
+        for i, (a, b) in enumerate(zip(nt, rt)):
+            a = np.asarray(a)
+            b = np.asarray(b)
+            assert a.dtype == b.dtype, f"{name}[{key}][{i}]: dtype {a.dtype} != {b.dtype}"
+            assert a.shape == b.shape, f"{name}[{key}][{i}]: shape {a.shape} != {b.shape}"
+            np.testing.assert_array_equal(a, b)
+```
+
+- [ ] **Step 4: Build + verify the registration imports cleanly**
+
+Run:
+```bash
+pixi run -e dev maturin develop --release 2>&1 | rtk err
+pixi run -e dev python -c "import genvarloader._dataset._flat_variants as m; from genvarloader._dispatch import backends; print(backends('assemble_variant_buffers'))"
+```
+Expected: prints the `(numba_entry, rust_shim)` callables tuple — confirms the key registered.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_flat_flanks.py python/genvarloader/_dataset/_flat_variants.py tests/parity/_harness.py
+rtk git commit -m "feat(variants): register assemble_variant_buffers (rust default, numba oracle)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Rewrite `get_variants_flat` assembly tail to call the dispatched kernel
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_flat_variants.py:974-1083` (the windows branch + flank ride-along + the alt/ref allele gather in the scalar-field block)
+- Test: covered by Task 8 parity + the existing `tests/parity/test_variants_dataset_parity.py`
+
+**Interfaces:**
+- Consumes: `get("assemble_variant_buffers")(...)` from Task 6 returning `dict[str, (data, seq_off)]`.
+- Produces: unchanged public return types `_FlatVariants` / `_FlatVariantWindows` (callers see no change).
+
+- [ ] **Step 1: Replace the alt/ref allele gather + windows branch + flank ride-along**
+
+In `get_variants_flat`, the current flow gathers `alt` (and optional `ref`) alleles inline (lines ~927-942), then later builds windows (lines ~974-1055) and the flank ride-along (lines ~1057-1077). Replace those three regions so the **ragged** buffers come from one dispatched call, while **scalar** fields stay inline.
+
+Concretely, after the scalar/dosage/custom fields are built into `fields` (keep all of that), compute the shared inputs and call the kernel:
+
+```python
+    from .._haps import _HapsFfiStatic  # noqa: F401  (type only)
+
+    stat = haps.ffi_static
+    # v_contigs: per-selected-variant contig id (only needed when fetching).
+    needs_fetch = (
+        regions is not None
+        and haps.token_lut is not None
+        and (
+            (issubclass(haps.kind, _FlatVariantWindows) and opt is not None)
+            or bool(haps.flank_length)
+        )
+    )
+    if needs_fetch:
+        regions_arr = np.asarray(regions)
+        group_contigs = np.repeat(regions_arr[:, 0], eff_ploidy)
+        v_contigs = np.repeat(group_contigs, np.diff(row_offsets)).astype(np.int32)
+    else:
+        v_contigs = np.zeros(len(v_idxs), np.int32)
+
+    ref_present = "ref" in haps.var_fields and haps.variants.ref is not None
+    ref_global = ref_off_global = None
+    if ref_present or (
+        issubclass(haps.kind, _FlatVariantWindows)
+        and opt is not None
+        and (opt.ref == "allele")
+    ):
+        ref_global = np.asarray(haps.variants.ref.data).view(np.uint8)
+        ref_off_global = np.asarray(haps.variants.ref.offsets, np.int64)
+```
+
+- [ ] **Step 2: Build the windows-mode result from the dict**
+
+Replace the windows branch (`if regions is not None and issubclass(haps.kind, _FlatVariantWindows) and opt is not None:` ... `return win`) with:
+
+```python
+    opt = haps.window_opt
+    if (
+        regions is not None
+        and issubclass(haps.kind, _FlatVariantWindows)
+        and opt is not None
+    ):
+        L = opt.flank_length
+        ref_mode = 1 if opt.ref == "window" else 2
+        alt_mode = 1 if opt.alt == "window" else 2
+        bufs = get("assemble_variant_buffers")(
+            1,  # windows mode
+            v_idxs,
+            row_offsets,
+            stat.alt_alleles,
+            stat.alt_offsets,
+            ref_global,
+            ref_off_global,
+            False,  # want_ref_bytes (windows mode emits tokens, not raw bytes)
+            False,  # want_flank
+            ref_mode,
+            alt_mode,
+            L,
+            haps.token_lut,
+            v_contigs,
+            stat.v_starts,
+            stat.ilens,
+            stat.ref,        # reference genome buffer
+            stat.ref_offsets,  # contig offsets
+            haps.reference.pad_char,
+        )
+        wshape = (b, eff_ploidy, None, None)
+        wfields = {k: v for k, v in fields.items() if k not in ("alt", "ref")}
+        win = _FlatVariantWindows(wfields)
+        for name, (data, seq_off) in bufs.items():
+            fw = _FlatWindow(data, np.asarray(seq_off, np.int64), row_offsets, wshape)
+            setattr(win, name, fw)
+        if haps.dummy_variant is not None:
+            win = win.fill_empty_groups(
+                haps.dummy_variant, unk=haps.unknown_token, flank_length=L
+            )
+        return win
+```
+
+- [ ] **Step 3: Build the plain-variants alt/ref + flank result from the dict**
+
+Replace the inline alt/ref allele gather and the flank ride-along so the plain-variants path also goes through the kernel. Where the code currently does `fields["alt"] = _FlatAlleles(...)` and `fields["ref"] = _FlatAlleles(...)`, and the later `if haps.flank_length and ...: compute_flank_tokens(...)` block, replace with a single call after the scalar fields are assembled:
+
+```python
+    want_flank = bool(
+        haps.flank_length and haps.token_lut is not None and regions is not None
+    )
+    L = haps.flank_length or 0
+    bufs = get("assemble_variant_buffers")(
+        0,  # variants mode
+        v_idxs,
+        row_offsets,
+        stat.alt_alleles,
+        stat.alt_offsets,
+        ref_global,
+        ref_off_global,
+        ref_present,  # want_ref_bytes
+        want_flank,
+        0,  # ref_mode (unused in variants mode)
+        0,  # alt_mode (unused)
+        L,
+        haps.token_lut,
+        v_contigs,
+        stat.v_starts,
+        stat.ilens,
+        stat.ref if stat.ref is not None else np.zeros(0, np.uint8),
+        stat.ref_offsets if stat.ref_offsets is not None else np.zeros(1, np.int64),
+        haps.reference.pad_char if haps.reference is not None else 0,
+    )
+    alt_data, alt_seq_off = bufs["alt"]
+    fields["alt"] = _FlatAlleles(
+        np.asarray(alt_data, np.uint8), np.asarray(alt_seq_off, np.int64), row_offsets, shape
+    )
+    if "ref" in bufs:
+        ref_data, ref_seq_off = bufs["ref"]
+        fields["ref"] = _FlatAlleles(
+            np.asarray(ref_data, np.uint8), np.asarray(ref_seq_off, np.int64), row_offsets, shape
+        )
+    flat = _FlatVariants(fields)
+    if "flank_tokens" in bufs:
+        from .._flat import _Flat
+
+        tok, off = bufs["flank_tokens"]
+        flat.flank_tokens = _Flat.from_offsets(
+            tok, (b, eff_ploidy, None, 2 * L), np.asarray(off, np.int64)
+        )
+
+    if haps.dummy_variant is not None:
+        flat = flat.fill_empty_groups(haps.dummy_variant, unk=haps.unknown_token)
+
+    return flat
+```
+
+> IMPORTANT ordering: the `fields` dict insertion order determines downstream wrapping; today `alt` is inserted before `start`/`ref`/etc. Preserve the existing field order — build `fields["alt"]` placeholder position by keeping the scalar block as-is and only swapping the alt/ref *values* to come from `bufs`. If the original code inserted `alt` first, keep `alt` first (move the `bufs["alt"]` assignment up to where `fields["alt"]` was originally set, not appended at the end). Verify with `RaggedVariants` field order in a parity run (Task 8).
+
+- [ ] **Step 4: Remove the now-dead inline assembly**
+
+Delete the now-unreachable inline `compute_windows`/`compute_ref_window`/`compute_alt_window`/`tokenize_alleles`/`compute_flank_tokens` call sites in `get_variants_flat` (the helper *functions* stay in `_flat_flanks.py` as the oracle). Confirm no other caller depends on them on the hot path: `rtk grep "compute_windows\|compute_ref_window\|compute_alt_window\|compute_flank_tokens\|tokenize_alleles" python/genvarloader/_dataset/_flat_variants.py` should now only show imports used by the oracle, not the hot path.
+
+- [ ] **Step 5: Build + smoke-run one windows query**
+
+Run:
+```bash
+pixi run -e dev maturin develop --release 2>&1 | rtk err
+pixi run -e dev pytest tests/parity/test_variants_dataset_parity.py -q --basetemp=$(pwd)/.pytest_tmp 2>&1 | rtk err
+```
+Expected: existing variants dataset parity PASSES on the default (rust) backend.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_flat_variants.py
+rtk git commit -m "perf(variants): route windows/variants assembly through one rust call
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Parity fixtures + dataset backstop spy + both-backend gate
+
+**Files:**
+- Create: `tests/parity/test_assemble_variant_buffers_parity.py`
+- Modify: `tests/parity/test_dataset_parity.py` (add a kernel-spy that proves the call runs on the live windows/variants `__getitem__` path)
+
+**Interfaces:**
+- Consumes: `assert_kernel_parity_dict` (Task 6), the registered `assemble_variant_buffers` kernel.
+
+- [ ] **Step 1: Write the kernel-level mode-matrix parity test**
+
+Create `tests/parity/test_assemble_variant_buffers_parity.py`:
+
+```python
+"""Parity: the new assemble_variant_buffers mega-call (rust) must be
+byte-identical to the composed numba oracle for variants + variant-windows,
+across the ref/alt mode matrix, the flank ride-along, and empty selections."""
+
+import numpy as np
+import pytest
+
+import genvarloader._dataset._flat_variants  # noqa: F401  (triggers register())
+from tests.parity._harness import assert_kernel_parity_dict
+
+pytestmark = pytest.mark.parity
+
+
+def _reference():
+    # single contig of 40 bytes, ASCII A/C/G/T cycling.
+    bases = np.frombuffer(b"ACGT", np.uint8)
+    ref = np.tile(bases, 10).astype(np.uint8)
+    ref_offsets = np.array([0, ref.size], np.int64)
+    return ref, ref_offsets
+
+
+def _lut(dtype):
+    # A->0 C->1 G->2 T->3, everything else (incl. N) -> 4 (unknown).
+    lut = np.full(256, 4, dtype)
+    for i, b in enumerate(b"ACGT"):
+        lut[b] = i
+    return lut
+
+
+def _globals():
+    # 3 global variants: alt "A","CG","T"; ref "C","G","AA".
+    alt = np.frombuffer(b"ACGT", np.uint8)  # placeholder; rebuild explicitly below
+    alt_bytes = np.frombuffer(b"ACGT", np.uint8)
+    # alt alleles: v0="A", v1="CG", v2="T"
+    alt_data = np.frombuffer(b"ACGT", np.uint8)
+    alt_data = np.frombuffer(b"A" b"CG" b"T", np.uint8)
+    alt_off = np.array([0, 1, 3, 4], np.int64)
+    ref_data = np.frombuffer(b"C" b"G" b"AA", np.uint8)
+    ref_off = np.array([0, 1, 2, 4], np.int64)
+    v_starts = np.array([5, 12, 20], np.int32)
+    ilens = np.array([0, -1, 1], np.int32)  # SNP, 1bp del, 1bp ins
+    return alt_data, alt_off, ref_data, ref_off, v_starts, ilens
+
+
+@pytest.mark.parametrize("tok_dtype", [np.uint8, np.int32])
+@pytest.mark.parametrize("ref_mode,alt_mode", [(1, 1), (1, 2), (2, 1), (2, 2)])
+def test_windows_mode_matrix(tok_dtype, ref_mode, alt_mode):
+    ref, ref_offsets = _reference()
+    alt_data, alt_off, ref_data, ref_off, v_starts, ilens = _globals()
+    lut = _lut(tok_dtype)
+    # one row selecting all 3 variants
+    v_idxs = np.array([0, 1, 2], np.int32)
+    row_offsets = np.array([0, 3], np.int64)
+    v_contigs = np.zeros(3, np.int32)
+    assert_kernel_parity_dict(
+        "assemble_variant_buffers",
+        1,  # windows
+        v_idxs, row_offsets, alt_data, alt_off, ref_data, ref_off,
+        False, False, ref_mode, alt_mode, 2, lut, v_contigs, v_starts, ilens,
+        ref, ref_offsets, ord("N"),
+    )
+
+
+@pytest.mark.parametrize("tok_dtype", [np.uint8, np.int32])
+@pytest.mark.parametrize("want_ref,want_flank", [(False, False), (True, False), (False, True), (True, True)])
+def test_variants_mode_matrix(tok_dtype, want_ref, want_flank):
+    ref, ref_offsets = _reference()
+    alt_data, alt_off, ref_data, ref_off, v_starts, ilens = _globals()
+    lut = _lut(tok_dtype) if want_flank else None
+    v_idxs = np.array([2, 0, 1], np.int32)
+    row_offsets = np.array([0, 1, 3], np.int64)  # 2 rows
+    v_contigs = np.zeros(3, np.int32)
+    assert_kernel_parity_dict(
+        "assemble_variant_buffers",
+        0,  # variants
+        v_idxs, row_offsets, alt_data, alt_off, ref_data, ref_off,
+        want_ref, want_flank, 0, 0, 2, lut, v_contigs, v_starts, ilens,
+        ref, ref_offsets, ord("N"),
+    )
+
+
+@pytest.mark.parametrize("mode,ref_mode,alt_mode", [(0, 0, 0), (1, 1, 1)])
+def test_empty_selection(mode, ref_mode, alt_mode):
+    """A row that selects zero variants must round-trip identically."""
+    ref, ref_offsets = _reference()
+    alt_data, alt_off, ref_data, ref_off, v_starts, ilens = _globals()
+    lut = _lut(np.uint8)
+    v_idxs = np.array([], np.int32)
+    row_offsets = np.array([0, 0], np.int64)  # 1 empty row
+    v_contigs = np.array([], np.int32)
+    assert_kernel_parity_dict(
+        "assemble_variant_buffers",
+        mode,
+        v_idxs, row_offsets, alt_data, alt_off, ref_data, ref_off,
+        False, (mode == 0), ref_mode, alt_mode, 2, lut, v_contigs, v_starts, ilens,
+        ref, ref_offsets, ord("N"),
+    )
+```
+
+> Clean up the placeholder lines in `_globals` (the first two `alt`/`alt_bytes`/`alt_data` reassignments are scratch — keep only the final explicit `alt_data = np.frombuffer(b"A" b"CG" b"T", np.uint8)`). Verify the test file has no unused locals via `ruff check`.
+
+- [ ] **Step 2: Run the kernel parity on both backends**
+
+Run:
+```bash
+pixi run -e dev pytest tests/parity/test_assemble_variant_buffers_parity.py -q --basetemp=$(pwd)/.pytest_tmp 2>&1 | rtk err
+GVL_BACKEND=numba pixi run -e dev pytest tests/parity/test_assemble_variant_buffers_parity.py -q --basetemp=$(pwd)/.pytest_tmp 2>&1 | rtk err
+```
+Expected: all PASS on both backends. (The dict harness compares numba vs rust internally regardless of `GVL_BACKEND`, but running both confirms registration import paths are env-independent.)
+
+- [ ] **Step 3: Add a live-path kernel spy to the dataset backstop**
+
+In `tests/parity/test_dataset_parity.py`, add a test that monkeypatches the registry's rust entry for `assemble_variant_buffers` with a counting wrapper, opens a small variant-windows dataset, indexes one batch, and asserts the wrapper was called (proves the kernel runs on the live `__getitem__`, guarding against a vacuous parity pass). Mirror the existing spy pattern in that file. Skeleton:
+
+```python
+def test_assemble_variant_buffers_runs_on_live_windows_path(tmp_path):
+    """The rust mega-call must actually fire on the windows __getitem__ path."""
+    from genvarloader import _dispatch
+
+    entry = _dispatch._REGISTRY["assemble_variant_buffers"]
+    calls = {"n": 0}
+    real = entry["rust"]
+
+    def spy(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    entry["rust"] = spy
+    try:
+        ds = _open_variant_windows_dataset(tmp_path)  # reuse this file's helper
+        _ = ds[0, 0]
+    finally:
+        entry["rust"] = real
+    assert calls["n"] > 0, "assemble_variant_buffers never ran on the live path"
+```
+
+> Use the existing dataset-construction helper in `test_dataset_parity.py` (grep for how the file builds a windows/variants dataset: `rtk grep "variant.windows\|VarWindowOpt\|with_seqs" tests/parity/test_dataset_parity.py`). If no windows helper exists, build a minimal one with `gvl.write` + `Dataset.open(...).with_seqs("variant-windows", VarWindowOpt(...))`, matching the corpus the other dataset-parity tests use.
+
+- [ ] **Step 4: Run the dataset backstop + the variants/windows dataset parity, both backends**
+
+Run:
+```bash
+pixi run -e dev pytest tests/parity/test_dataset_parity.py tests/parity/test_variants_dataset_parity.py -q --basetemp=$(pwd)/.pytest_tmp 2>&1 | rtk err
+GVL_BACKEND=numba pixi run -e dev pytest tests/parity/test_dataset_parity.py tests/parity/test_variants_dataset_parity.py -q --basetemp=$(pwd)/.pytest_tmp 2>&1 | rtk err
+```
+Expected: all PASS on both backends.
+
+- [ ] **Step 5: Full tree, both backends, + lint/format/typecheck**
+
+Run:
+```bash
+pixi run -e dev pytest tests -q --basetemp=$(pwd)/.pytest_tmp 2>&1 | rtk err
+GVL_BACKEND=numba pixi run -e dev pytest tests -q --basetemp=$(pwd)/.pytest_tmp 2>&1 | rtk err
+pixi run -e dev cargo-test 2>&1 | rtk err
+pixi run -e dev ruff check python/ tests/ && pixi run -e dev ruff format python/ tests/ && pixi run -e dev typecheck
+```
+Expected: full tree PASSES on both backends (except the pre-existing `test_e2e_variants` xfail, which must xfail identically — confirm it is xfail, not fail). Rust tests pass; lint/format/typecheck clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add tests/parity/test_assemble_variant_buffers_parity.py tests/parity/test_dataset_parity.py
+rtk git commit -m "test(parity): assemble_variant_buffers mode matrix + live-path spy
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Perf re-measure + roadmap update
+
+**Files:**
+- Modify: `docs/roadmaps/rust-migration.md` (round-2 target 7 entry + re-measurement block + Phase-5 marker/PR link)
+
+**Interfaces:** none (documentation + measurement).
+
+- [ ] **Step 1: Confirm the pre-existing xfail is unchanged at this branch**
+
+Run: `pixi run -e dev pytest tests/benchmarks/test_e2e.py::test_e2e_variants -q --basetemp=$(pwd)/.pytest_tmp 2>&1 | rtk err`
+Expected: `xfailed` (NOT failed, NOT passed). Record that it matches base behavior.
+
+- [ ] **Step 2: Re-measure variant-windows and variants (rust vs numba, min of pedantic)**
+
+Run (build release first if not already):
+```bash
+pixi run -e dev maturin develop --release 2>&1 | rtk err
+pixi run -e dev pytest tests/benchmarks/test_e2e.py -k "variant" --benchmark-only -q --basetemp=$(pwd)/.pytest_tmp
+```
+Also capture the `perf` flat self-time to confirm the GC/eval share dropped:
+```bash
+NUMBA_NUM_THREADS=1 perf record -F 999 -o p.data -- .pixi/envs/dev/bin/python \
+    tests/benchmarks/profiling/profile.py --mode variant-windows --n-batches 12000
+perf report --stdio --no-children -i p.data | head -40
+```
+Expected: GC (`gc_collect_main`/`deduce_unreachable`/`visit_reachable`/`dict_traverse`) self-time share is materially lower than the ~14% baseline; record the new variant-windows and variants min-ms ratios.
+
+- [ ] **Step 3: Update the roadmap**
+
+In `docs/roadmaps/rust-migration.md`, change target 7's marker from ⬜ to ✅ (or 🚧 with the PR link if not yet merged), append the re-measured variant-windows/variants ratios to the round-2 re-measurement block, and set the PR link. Keep the wording consistent with how targets 1–4 record their results (status marker + branch/PR + before→after numbers).
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add docs/roadmaps/rust-migration.md
+rtk git commit -m "docs(roadmap): target 7 done — variant-windows rust assembly, re-measured
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Final push gate (per CLAUDE.md)**
+
+Confirm the full tree is green on both backends (Task 8 Step 5) and the branch is ready for PR. Open the PR against `zero-copy-scale-safe-readpath` (the base branch), not `master`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Scope = all variants + windows → Tasks 3 (variants mode) + 4 (windows mode), routed in Task 7. ✓
+- Rust owns the fetch → Task 2 `fetch_windows` reusing `reference::get_reference`. ✓
+- One mega-call → single FFI entry per token dtype (Task 5), one dispatch key (Task 6). ✓
+- Front edge = assembly tail only → front-end + scalar gather untouched in Task 7; #231 dtype-polymorphic fields never routed through the typed call. ✓
+- fill_empty stays separate → Task 7 keeps `fill_empty_groups` post-pass. ✓
+- Parity via registry with numba oracle → Task 6 oracle + Task 8 mode-matrix + live-path spy. ✓
+- Perf gate + roadmap → Task 9. ✓
+- Pre-existing xfail handling → Task 9 Step 1 + Task 8 Step 5 note. ✓
+- Scale-guard not regressed → globals sourced from `ffi_static` (sub-linear), no new `ascontiguousarray` on sample-scale memmaps. ✓
+
+**Placeholder scan:** Two intentional verification-and-adjust notes remain (Task 6 Step 1 import-path confirmation; Task 7 Step 3 field-order preservation; Task 8 Step 3 dataset-helper reuse). These are explicit "grep-then-confirm" instructions with the exact command and fallback, not vague TODOs — acceptable because the exact existing symbol/helper must be confirmed against the live tree rather than guessed.
+
+**Type consistency:** `VariantBufs<Tok>` (Task 3) is consumed unchanged in Tasks 4–5. Field names (`alt`, `ref`, `ref_window`, `alt_window`, `flank_tokens`) are identical across the Rust orchestrators (Tasks 3–4), the numba oracle (Task 6), the Python wrapping (Task 7), and the parity test (Task 8). The mega-call argument order is identical across the Rust pyfunctions (Task 5), the rust shim + numba oracle (Task 6), and both call sites (Task 7) and the parity tests (Task 8).
+
+---
+
+## Risks & watch-points (for the implementer)
+
+- **Field insertion order** (`_FlatVariants.fields`) feeds `RaggedVariants` construction order downstream. Task 7 Step 3 must preserve today's order (`alt` first where it was first); the dataset parity in Task 8 Step 4 is the gate that catches a reordering.
+- **`reference is None`** path: variants mode with no reference + no flank must still emit `alt` (and `ref`) bytes. Task 7 passes zero-length reference placeholders in that case; the empty-selection parity (Task 8 `test_empty_selection`) and the no-reference dataset parity cover it.
+- **Token dtype selection**: `_assemble_variant_buffers_rust` picks i32 only when `lut.dtype == int32`; otherwise u8. When `lut is None` (plain variants, no flank), u8 entry with `lut=None` — the orchestrator never touches the LUT on that path.
+- **`unphased_union`**: `row_offsets` is already folded to `eff_ploidy=1` before the kernel call (front-end, unchanged). `v_contigs` is built with `eff_ploidy`, so it stays consistent. Add an `unphased_union=True` windows fixture to the dataset parity if the existing corpus lacks one.

--- a/docs/superpowers/specs/2026-06-25-target-5-tracks-intervals-slice-design.md
+++ b/docs/superpowers/specs/2026-06-25-target-5-tracks-intervals-slice-design.md
@@ -1,0 +1,126 @@
+# Target 5 — tracks-only ndarray slicing optimization
+
+**Date:** 2026-06-25
+**Workstream:** Phase 5, optimization round 2, Target 5 (rust-only, byte-identical).
+**Branch:** `opt/target-5-intervals-slice` off `rust-migration`.
+**Roadmap:** `docs/roadmaps/rust-migration.md` — Phase 5 ⬜, "Optimization targets — round 2".
+**Handoff:** `docs/handoffs/2026-06-25-phase5-getitem-optimization.md` (Target 5 section).
+
+## Problem
+
+`intervals_to_tracks` (`src/intervals.rs`) is the kernel behind the cheapest read
+path (tracks-only, ~1.1–1.7 ms/batch). On that path Rust runs at **0.63× numba**
+— the single read path where Rust is clearly slower. `perf` flat self-time
+attributes ~20.5% of the kernel to ndarray slice machinery:
+`ndarray::slice_mut` (11%) + `ndarray::do_slice` (9.5%), all from constructing a
+`SliceInfo` per painted interval in:
+
+```rust
+out.slice_mut(ndarray::s![a..b]).fill(value);
+```
+
+numba compiles the equivalent `out[a:b] = value` to a direct memset and pays none
+of this. Because tracks-only does no sequence work, this fixed per-interval cost
+dominates with nothing to amortize it against.
+
+## Goal
+
+Close the deficit so Rust is **≥ 1.0× numba** on tracks-only, while keeping the
+output **byte-identical** to the numba oracle. The kernel is shared by the
+combined **tracks** (seqs + read-depth) path, which improves with it.
+
+## Scope
+
+- **In:** `src/intervals.rs` — the `intervals_to_tracks` body, and (only if the
+  perf fallback lands) one added cargo test.
+- **Out:** No Python changes. No FFI-signature changes. No oracle change. No
+  changes to `out.fill(0.0)` semantics. No overlap with Targets 6/7 (they touch
+  `intervals.rs` too, but Target 5 merges first and they rebase onto it).
+
+## Design
+
+The `out` buffer is freshly allocated and contiguous, so we can address it as a
+raw `&mut [f32]` and drop the per-interval `SliceInfo`.
+
+1. **Hoist the slice once**, at the top of the function, after the zero prelude:
+   ```rust
+   let out_slice = out.as_slice_mut().unwrap();
+   ```
+   `.unwrap()` is intentional: a non-contiguous `out` is an invariant violation,
+   not a recoverable case, and should fail loud.
+
+2. **Zero prelude on the raw slice:**
+   ```rust
+   out_slice.fill(0.0);
+   ```
+   **Keep the zero prelude.** tracks-only depends on it — gaps between intervals
+   must read 0. This is unlike the fully-overwritten sequence buffers whose
+   zero-init was skipped in commit `1b3e355`; that optimization does not apply
+   here.
+
+3. **Per-interval write on the raw slice** (default, safe form):
+   ```rust
+   let a = out_s + s as usize;
+   let b = out_s + e as usize;
+   out_slice[a..b].fill(value);
+   ```
+   This keeps a single range bounds-check but removes `SliceInfo` construction —
+   the proven cost.
+
+All surrounding arithmetic and control flow is **unchanged**:
+- `start = itv_starts[i] - query_start`, `end = itv_ends[i] - query_start` in i64.
+- `break` when `start >= length` (intervals sorted by start).
+- `s = start.max(0)`, `e = end.min(length)`; write only when `e > s`.
+- Per-query `itv_s == itv_e` → skip (out slice stays 0).
+
+## Parity
+
+Byte-identical by construction — same arithmetic, same write order, same values,
+only a different way to address the contiguous buffer.
+
+Gates (all must stay green):
+- `pixi run -e dev cargo-test` — the 8 existing unit tests in `src/intervals.rs`
+  pin the full contract (basic paint, empty intervals, end-clamp, break-on-
+  start≥length, the three #242 jitter cases, multi-query disjoint). Refactor
+  **under** them, untouched.
+- `pixi run -e dev pytest tests/parity -q` (rust default) **and**
+  `GVL_BACKEND=numba pixi run -e dev pytest tests/parity -q` (oracle) — including
+  the `intervals_to_tracks` hypothesis parity gate and the tracks dataset
+  backstop that proves the kernel runs on the live `__getitem__` path.
+
+No new test is required for the safe form (no new behavior). A SAFETY-proof test
+is added **only if** the unsafe fallback (below) is needed.
+
+## Perf gate and fallback
+
+Build release first: `pixi run -e dev maturin develop --release`. Re-measure
+tracks-only via `tests/benchmarks/test_e2e.py` — `_bench_indexing` uses
+`benchmark.pedantic(iterations=10, rounds=50)`; compare the **min** rust ÷ min
+numba (cleanest CPU-bound estimate), with `NUMBA_NUM_THREADS=1`.
+
+- **≥ 1.0×** → done. Record the ratio in the roadmap round-2 re-measurement block.
+- **< 1.0×** → escalate the inner write to elide the bounds-check:
+  ```rust
+  // SAFETY: a = out_s + s, b = out_s + e with 0 <= s <= e <= length and
+  // out_s + length == out_e <= out_slice.len() (out_offsets is a valid CSR
+  // layout over out_slice), so a..b is in bounds.
+  unsafe { out_slice.get_unchecked_mut(a..b).fill(value); }
+  ```
+  Add one cargo test asserting the bounds invariant the SAFETY comment relies on,
+  re-measure, then record.
+
+The expected outcome is that the safe form clears the gate (the `SliceInfo`
+construction, not the bounds-check, was the dominant cost); the unsafe form is a
+contingency, not the plan.
+
+## Definition of done
+
+1. Refactored `intervals_to_tracks`, all existing cargo tests green untouched.
+2. `cargo-test` + `pytest tests/parity` on **both** backends green.
+3. Full tree on both backends (`pixi run -e dev pytest tests -q`, then
+   `GVL_BACKEND=numba …`) — scoped runs skip `tests/unit/`.
+4. `ruff check python/ tests/` + `ruff format python/ tests/` + `typecheck`
+   clean (no Python changes expected, but run them).
+5. tracks-only re-measured ≥ 1.0×; ratio recorded in
+   `docs/roadmaps/rust-migration.md` with Target 5 ticked and the PR link set.
+6. Parity-gated PR opened from `opt/target-5-intervals-slice`.

--- a/docs/superpowers/specs/2026-06-25-target6-kernel-rc-design.md
+++ b/docs/superpowers/specs/2026-06-25-target6-kernel-rc-design.md
@@ -1,0 +1,201 @@
+# Design — Target 6: fold strand reverse-complement into the Rust read-path kernels
+
+**Date:** 2026-06-25
+**Workstream:** Phase 5, Target 6 (rust-migration roadmap, round-2 optimization block)
+**Branch:** `opt/target-6-kernel-rc` off `zero-copy-scale-safe-readpath`
+**Handoff:** `docs/handoffs/2026-06-25-phase5-getitem-optimization.md` (Target 6 section)
+
+## Goal
+
+Delete the per-batch reverse-complement (RC) post-pass on the read path by emitting
+negative-strand regions already reverse-complemented from the Rust kernels. This is the
+largest single-thread throughput lever left before rayon, and it is **backend-agnostic**
+(numba pays the same cost), so it must land before rayon batch parallelism.
+
+## Corrected cost model (why this design, not the handoff's literal framing)
+
+The handoff calls the RC cost a "numpy post-pass." The code shows otherwise: RC today runs
+through seqpro's **compiled** flat kernels (`_reverse_rows_masked` /
+`reverse_complement_masked` via `_query.py::reverse_complement_ragged` and
+`_flat.py::_Flat.reverse_masked`), not a Python loop. Both backends call the *same* RC code
+*after* reconstruction, which is exactly why numba shows the same ~19% self-time on
+haplotypes.
+
+Therefore the cost is **the second full-batch traversal of the output buffer** (re-read +
+complement + numpy re-wrap), **not** an FFI crossing unique to rust. This rules out a
+"rewrite the post-pass in Rust but keep it batch-wide" approach — it would re-read the same
+cold buffer and barely move the number.
+
+The chosen approach removes the **cold, batch-wide** traversal: RC each negative-strand
+query's slice **in-place, immediately after that query is written, inside the existing
+per-query kernel loop**, while the slice is still hot in L1/L2. A second hot pass over a
+~16 KB slice is near-noise next to reconstruction; today's cost is high precisely because
+the pass is cold, whole-batch, and materialized through numpy.
+
+### Approach considered and rejected
+
+- **A — fold the reversed write into the reconstruct core** (emit bytes already RC'd, no
+  second pass at all). Rejected: maximum single-thread perf, but RC logic entangles with
+  indel + insertion-fill + trailing-fill in the hottest kernels, is bespoke per output kind,
+  and the annotated/splice cases make a subtle parity break likely. Its only gain over the
+  chosen approach is eliminating one *hot* pass — not worth the risk. Revisit only if the
+  chosen approach's measured ratio still lags numba.
+- **C — Rust post-pass called from Python** (replace `reverse_complement_ragged` with one
+  Rust pyfunction over the returned flat buffers). Rejected: keeps the exact cold,
+  batch-wide traversal; captures neither the cache-locality win nor a meaningful dispatch
+  win, since RC is not an extra rust FFI crossing today.
+
+## Scope
+
+In scope — five flat-buffer output kinds, all sharing the in-place primitives:
+
+| Kind | Buffers | RC behavior |
+|---|---|---|
+| haplotypes (S1) | `out_data: u8` | reverse + complement |
+| reference (S1) | `out_data: u8` | reverse + complement |
+| tracks (f32) | `out_data: f32` | reverse only (no complement) |
+| annotated | `haps: u8`, `var_idxs: i32`, `ref_coords: i32/i64` | haps reverse+complement; both index arrays reverse-only; all three in lockstep per query |
+| splice (haps / ref / tracks) | permuted element buffer | same primitive per spliced **element**, using permuted offsets + permuted per-element mask |
+
+Out of scope:
+
+- **`RaggedVariants` (`variants` mode) RC — deferred to Target 7.** Its RC is structurally
+  different (reverse allele order within each row **and** complement allele bytes over the
+  nested ragged allele structure, `RaggedVariants.rc_`) and lives in the `src/variants/`
+  gather path that Target 7 is concurrently rewriting. Target 6 leaves a slimmed
+  `reverse_complement_ragged` husk handling only this case; Target 7 absorbs it and deletes
+  the husk.
+- **`variant-windows` and `intervals`** — reference-oriented, RC is a no-op today and stays a
+  no-op.
+
+## Components — Rust primitives
+
+A new small module (`src/reverse.rs`) with two generic in-place primitives, each over a flat
+`(data, offsets)` buffer + a per-row `to_rc` mask:
+
+1. `reverse_flat_rows_inplace<T: Copy>(data: &mut [T], offsets, to_rc)` — reverses element
+   order within each masked row. Order only, no complement. Generic over element width
+   (`u8`, `f32`, `i32`, `i64`).
+2. `rc_flat_rows_inplace(data: &mut [u8], offsets, to_rc)` — reverses **and** complements
+   bytes via a 256-entry `_COMP` LUT.
+
+**`_COMP` LUT contract:** reproduce `bytes.maketrans(b"ACGT", b"TGCA")`
+(`python/genvarloader/_ragged.py:330`) exactly — a `[u8; 256]` that is **identity for
+everything** except `A↔T` and `C↔G` (uppercase only). `N`, IUPAC codes, and lowercase
+`a/c/g/t` are pass-through (identity), matching today's behavior byte-for-byte.
+
+Output-kind → primitive mapping:
+
+- haplotypes, reference → `rc_flat_rows_inplace`
+- tracks → `reverse_flat_rows_inplace::<f32>`
+- annotated → `rc_flat_rows_inplace` on `haps`; `reverse_flat_rows_inplace` on `var_idxs`
+  and `ref_coords`; applied in lockstep per query.
+- splice → the relevant primitive per spliced element.
+
+## Mask threading & per-kernel integration
+
+The `to_rc` mask is **computed in Python and passed into each kernel** as a new
+`Option<PyReadonlyArray1<bool>>` argument. Rationale: the strand→mask logic and (critically)
+the splice permutation logic already exist and are tested; reproducing the permutation in
+Rust would be gratuitous risk.
+
+- **Unspliced kernels** (`reconstruct_haplotypes_fused` `src/ffi/mod.rs:393`,
+  `reconstruct_annotated_haplotypes_fused` `:604`, `intervals_and_realign_track_fused`
+  `:848`, `get_reference` `:728`): Python passes `to_rc = full_regions[r_idx, 3] == -1`
+  (one bool per query). The kernel applies the primitive to query `k`'s just-written slice
+  when `to_rc[k]`.
+- **Spliced kernels** (`reconstruct_haplotypes_spliced_fused` `:521`, the spliced-reference
+  fetch `_fetch_spliced_ref` / reference core): Python passes the **already-permuted
+  per-element** mask — the existing `to_rc_per_elem` (`_query.py:259-280`) / `to_rc_perm`
+  (`_reference.py:438-444`) computation moves from post-pass input to kernel input,
+  unchanged. The spliced kernel's loop is already per-element over permuted `out_offsets`,
+  so the primitive applies per element with no new boundary math. **Assert** the element
+  boundaries being RC'd match `plan.group_offsets` (handoff warning).
+
+**`Option` keeps the fast path trivially byte-identical:** when `rc_neg` is off or no
+negative-strand region is selected (`to_rc.any() == false`), Python passes `None` and the
+kernel does zero extra work. All-positive datasets are provably unchanged; existing fixtures
+and the scale guard cannot regress.
+
+**Insertion-fill / trailing-fill ordering preserved for free:** RC runs *after* a query's
+full forward write (fills already placed), so it sees the exact final post-fill bytes the
+current post-pass sees. No interleaving with fill logic.
+
+**Rust files touched:** `src/ffi/mod.rs` (6 kernel signatures + call sites), the
+reconstruct/track/reference cores under `src/{reconstruct,tracks,intervals,reference}/`, and
+the new `src/reverse.rs` (with cargo unit tests).
+
+## Python-side changes & deletion plan
+
+- **`_query.py::_getitem_unspliced`** (`:188-190`): delete the
+  `reverse_complement_ragged` post-pass; compute `to_rc` and thread it through
+  `view.recon(...)` into the kernels. Only the deferred `RaggedVariants` case still routes
+  through the husk.
+- **`_query.py::_getitem_spliced`** (`:259-280`): keep the permuted `to_rc_per_elem`
+  computation, but hand its result to the kernel via the splice plan / recon call instead of
+  to `reverse_complement_ragged`.
+- **`_query.py::reverse_complement_ragged`** (`:374-410`): shrink to the **husk** — only the
+  `RaggedVariants` branch survives (`return rag.rc_(to_rc)`); delete the `_Flat`,
+  `_FlatAnnotatedHaps`, and no-op branches. Add `# TODO(target-7)` noting Target 7 absorbs
+  and deletes it.
+- **`_reference.py`** (`:438-444`): delete the spliced-reference
+  `per_elem.reverse_masked(to_rc_perm, comp=_COMP)` post-pass; thread `to_rc_perm` into
+  `_fetch_spliced_ref` / the reference kernel. (Third RC site, missed by the handoff, now
+  in-scope.)
+- **Reconstructors** (`Haps`, `Ref`, `Tracks`, `HapsTracks`, `SeqsTracks`, annotated) gain a
+  `to_rc` parameter on their recon entry that they forward to the FFI kernel. Exact signature
+  confirmed when reading `_reconstruct.py`; principle: mask flows region-compute → recon →
+  kernel, and the only Python RC left anywhere is the variants husk.
+- **No stray callers:** `grep -rn reverse_complement_ragged python/` and
+  `grep -rn reverse_masked python/` confirm nothing else depends on the deleted paths.
+
+## Parity, tests & perf gate
+
+**Primary risk: vacuous parity pass.** Default fixtures use `max_jitter=0` and may be
+all-positive-strand, so RC code could never fire and parity would pass trivially. Guards:
+
+- **New strand=−1 fixtures** in `tests/parity/test_dataset_parity.py`: datasets mixing `+`
+  and `−` regions, covering every in-scope kind (haplotypes, reference, tracks, annotated)
+  and the spliced variant of each. Reuse the kernel-spy backstop to prove RC executes on the
+  live `__getitem__` path.
+- **Non-vacuity assertion:** for a `−`-strand region, assert output bytes ≠ the `+`-strand
+  orientation (RC genuinely fired), and assert exact RC'd bytes for a known fixture.
+- **Rust unit tests** (`src/reverse.rs`): empty rows, single byte, odd/even lengths,
+  `to_rc` all-false (no-op) / all-true / mixed; LUT identity on `N`/lowercase/IUPAC; `f32`
+  reverse-only; lockstep reversal of the three annotated buffers.
+
+**Parity gate (byte-identical vs current post-pass), both backends:**
+
+```bash
+pixi run -e dev cargo-test
+pixi run -e dev pytest tests/parity -q                       # rust default
+GVL_BACKEND=numba pixi run -e dev pytest tests/parity -q      # oracle
+```
+
+**TDD order:** reference (simplest, no fill) → haplotypes → tracks (reverse-only) →
+annotated → **splice last**. Land each kind behind parity before deleting its Python
+post-pass branch. Variants deferred.
+
+**Before push:** full tree both backends (`pixi run -e dev pytest tests -q`, then
+`GVL_BACKEND=numba …`) to catch `tests/unit/` references to deleted code; lint/format/
+typecheck on `python/ tests/`.
+
+**Perf gate:** re-measure `haplotypes`, `tracks-only`, `tracks-seqs`, `annotated` via the
+de-noised `tests/benchmarks/test_e2e.py` harness (min over `pedantic(iterations=10,
+rounds=50)`, release build). Expect the RC self-time gone from `perf` flat profiles and the
+rust÷numba ratios up (haplotypes was 0.94× with RC its biggest sink at ~19% self). Record
+re-measured ratios in `docs/roadmaps/rust-migration.md` under the Phase 5 round-2 block,
+tick Target 6, set the PR link, and set the marker that Target 6 must merge before rayon.
+
+**HPC gotcha:** run pytest with `--basetemp=$(pwd)/.pytest_tmp` so the write path's `os.link`
+hardlink does not fail cross-device (Errno 18). Work in a dedicated git worktree.
+
+## Coordination with parallel workstreams
+
+- **Target 7** (variants/windows assembly): owns the deferred `RaggedVariants.rc_` port and
+  the `reverse_complement_ragged` husk deletion. Overlaps Target 6 in `src/ffi/mod.rs`
+  (additive — new pyfunction args vs new pyfunctions, low conflict).
+- **Target 5** (intervals slicing): overlaps `src/intervals.rs`; merge order is 5 first, then
+  6/7. Rebase Target 6 onto 5 if 5 lands first.
+- **Rayon** is blocked until 5 + 6 + 7 are on the base branch. The in-loop, per-query RC of
+  this design parallelizes cleanly (disjoint per-query slices).

--- a/docs/superpowers/specs/2026-06-25-target7-variant-windows-rust-assembly-design.md
+++ b/docs/superpowers/specs/2026-06-25-target7-variant-windows-rust-assembly-design.md
@@ -1,0 +1,162 @@
+# Design: Target 7 — variant-windows/variants assembly in one Rust call
+
+**Date:** 2026-06-25
+**Branch:** `opt/target-7-windows-rust-assembly` off `zero-copy-scale-safe-readpath`
+**Roadmap:** `docs/roadmaps/rust-migration.md` — Phase 5 round-2 target 7 (⬜)
+**Handoff:** `docs/handoffs/2026-06-25-phase5-getitem-optimization.md`
+
+## Problem
+
+The `variant-windows` (and `variants`) flat-output read path is **Python-overhead / GC-bound,
+not kernel-bound**. `perf` flat self-time on `profile.py --mode variant-windows` shows no dominant
+Rust kernel; the cost is the interpreter + allocator: `_PyEval_EvalFrameDefault` ~8.5%, GC
+(`gc_collect_main` + `deduce_unreachable` + `visit_reachable` + `dict_traverse`) **~14% combined**,
+dict/attr lookups, and ctypes/cffi dynamic-symbol lookup ~2.3%.
+
+The source is the per-batch object graph the assembly tail allocates: a `Ragged` from
+`reference.fetch`, numpy LUT-gather temporaries (`lut[bytes]`), `np.concatenate`/`reshape`
+temporaries, and wrapper dataclasses (`_FlatWindow` / `_FlatAlleles` / `_FlatVariants` /
+`_FlatVariantWindows` / scalar `_Flat`). The fix is to collapse the **ragged byte/token assembly**
+into **one Rust call** that returns the final flat `(data, offsets)` buffers, so Python builds the
+wrapper objects once and the numpy temporaries disappear.
+
+This is the windows half of the deferred Phase-5 single-big-kernel rewrite.
+
+## Decisions (locked during brainstorming)
+
+1. **Scope:** cover **all** of `variants` + `variant-windows` (alleles, windows, bare alleles, the
+   `flank_tokens` ride-along) — the full collapse, not windows-only.
+2. **Fetch boundary:** the Rust call **owns the reference fetch** internally (the reference is a
+   contiguous `u8` buffer + `i64` contig offsets — the same inputs `get_reference` already takes),
+   removing the per-batch `Ragged` allocation and a Python round-trip.
+3. **Granularity:** **one mega-call** (flag-driven) returning a bundle of all requested flat
+   buffers in a single FFI crossing — fewest objects/crossings.
+4. **Front edge:** **assembly tail only.** The mega-call takes already-gathered `v_idxs` /
+   `row_offsets` + dataset-static per-variant arrays and returns all ragged byte/token buffers. The
+   `v_idxs` gather + AF filter + compaction front-end and the cheap, dtype-polymorphic scalar-field
+   gathers stay in Python — this keeps the issue-#231 custom-FORMAT-field numba fallback intact.
+5. **Empty-group fill:** **not** folded into the mega-call. `fill_empty_groups` runs afterward on
+   the wrapped buffers via the existing `fill_empty_seq/scalar/fixed` Rust cores, keeping the
+   offset-consistency logic in one place.
+
+## Architecture
+
+Three layers; only the middle changes.
+
+| Layer | Status | What |
+|---|---|---|
+| **Front-end** | unchanged (Python) | `geno_offset_idx` → `gather_rows` → `v_idxs`/`row_offsets`, AF filter, `compact_keep`, dosage gather, unphased-union fold → compacted `v_idxs`, `row_offsets`, `eff_ploidy` |
+| **Scalar fields** | unchanged (Python) | `arr[v_idxs]` + `_Flat` wrap for start/ilen/dosage/info/custom-FORMAT — cheap fancy-indexing, dtype-polymorphic, #231 fallback preserved |
+| **Ragged byte/token assembly** | **NEW (Rust mega-call)** | one FFI call owning `gather_alleles`, reference fetch, LUT tokenize, flank slice, alt-window assemble, flank-tokens — returns all requested flat `(data, seq_offsets)` buffers in one crossing |
+| **Empty-group fill** | unchanged (Python + existing Rust cores) | `fill_empty_groups` on wrapped buffers, only when `dummy_variant` is set |
+
+Python wraps the returned buffers into `_FlatAlleles` / `_FlatWindow` / `_Flat` **once** and
+assembles `_FlatVariants` / `_FlatVariantWindows`. **No consumer change:** `reshape` / `squeeze` /
+`to_ragged` / `fill_empty_groups` still operate on the same wrapper types; flat output mode returns
+`_FlatVariantWindows` directly as before.
+
+## The mega-call
+
+`assemble_variant_buffers(...)` — Rust pyfunction in `src/variants/windows.rs`, registered in the
+dispatch registry (`python/genvarloader/_dispatch.py`) with `rust` default and `numba` = today's
+Python/numba assembly composed into the same bundle shape (the parity oracle).
+
+### Inputs
+
+- `v_idxs (i32)` — compacted variant indices, length `n_var`.
+- `row_offsets (i64)` — per-`(b*p_eff)`-row variant boundaries, length `b*p_eff + 1`.
+- Dataset-static globals (reuse `Haps.ffi_static` where already cached):
+  - `v_starts (i32)`, `ilens (i32)` — global per-variant arrays (gathered by `v_idxs` inside Rust).
+  - `alt_bytes (u8)` + `alt_off (i64)` — global allele byte buffer + offsets.
+  - `ref_bytes (u8)` + `ref_off (i64)` — global, when ref is requested.
+- `reference (u8)` + `contig_offsets (i64)` + `pad_char` — reference genome (owns the fetch).
+- `v_contigs (i32)` — per-variant contig id (computed in Python via
+  `np.repeat(regions[:,0], eff_ploidy)` then repeat by row counts; precomputed, cheap).
+- `flank_length (i32)`.
+- `token_lut ((256,) u8 | i32)` — `unknown_token` already baked in.
+- **Flag set** describing which outputs to emit and the `ref` / `alt` ∈ {`window`, `allele`, `byte`}
+  modes.
+
+### Internals (small, individually unit-tested Rust cores)
+
+Mirror today's Python/numba helpers:
+- `gather_alleles` — variable-length allele bytestrings for `v_idxs`.
+- `fetch_window` — reuse `get_reference`'s core; `[start-L, end+L)` read with absolute-coordinate
+  OOB padding.
+- `slice_flanks` — `f5` = first `L` bytes, `f3` = last `L` bytes of each window read.
+- `assemble_alt_window` — `flank5 · alt · flank3` per variant.
+- `tokenize` — apply the 256-entry LUT (output dtype = `lut.dtype`).
+
+Preserve the **single fused fetch** for the `ref=window & alt=window` hot path (derive alt-window
+flanks by slicing the one ref read), exactly as `compute_windows` does today. Fetch only when a
+window output is actually requested.
+
+### Returns
+
+A dict keyed by field name → flat buffers:
+- `alt` / `ref` (plain variants): `(byte_data u8, seq_offsets i64)`.
+- `ref_window` / `alt_window` / bare `ref` / bare `alt` (windows): `(token_data lut.dtype, seq_offsets i64)`.
+- `flank_tokens`: `(token_data,)` with fixed inner `2L`, offsets = `row_offsets`.
+
+`var_offsets` equals `row_offsets` unchanged (no fill applied yet), so Python reuses it rather than
+returning a copy. Token dtype follows `lut.dtype` (two monomorphizations: `u8` / `i32`).
+
+## Parity strategy
+
+Byte-identical gate, both backends. The assembly is **not** currently dispatched, so:
+
+1. Register `assemble_variant_buffers` in the dispatch registry with:
+   - `numba` = today's exact Python/numba helpers (`compute_windows`, `compute_ref_window`,
+     `compute_alt_window`, `tokenize_alleles`, `compute_flank_tokens`, `gather_alleles`) composed to
+     return the same bundle shape.
+   - `rust` = the new mega-call.
+2. TDD: pin the current flat `(data, offsets)` bundle as the oracle, build Rust under it.
+3. The dataset backstop (`tests/parity/test_dataset_parity.py`) spies on the kernel to prove it runs
+   on the live `__getitem__` path (no vacuous pass).
+
+Reproduce exactly:
+- `ends = starts - min(ilens, 0) + 1`.
+- absolute-coordinate OOB padding with `pad_char`.
+- `flank5 · alt · flank3` byte order.
+- `[flank5 | flank3]` variant-major `2L` layout for `flank_tokens`.
+- LUT mapping incl. `unknown_token` and `N` / out-of-alphabet bytes.
+
+**Pre-existing xfail:** `test_e2e_variants` xfails today (`_FlatVariants.to_fixed` missing). Confirm
+it xfails identically at base before starting; it is **not** a regression introduced here.
+
+## Testing & perf gate
+
+- Rust unit tests on each core (`gather_alleles`, `slice_flanks`, `assemble_alt_window`, `tokenize`,
+  fused windows) + the orchestrator.
+- `pixi run -e dev pytest tests/parity tests/unit -q` on both backends
+  (`GVL_BACKEND=numba` too). Add fixtures covering the full `ref`/`alt` ∈ {window, allele} mode
+  matrix, empty groups (dummy-variant fill), and the `flank_tokens` ride-along.
+- `pixi run -e dev cargo-test`.
+- Full tree before push (`pixi run -e dev pytest tests -q`, then `GVL_BACKEND=numba …`) per
+  CLAUDE.md (scoped runs skip `tests/unit/`).
+- Lint/format/typecheck: `ruff check python/ tests/ && ruff format … && typecheck`.
+- Perf: re-measure `variant-windows` and `variants` via `tests/benchmarks/test_e2e.py` (min of
+  `benchmark.pedantic`); expect GC/eval self-time to drop. Record the re-measured ratios in the
+  roadmap, set the Phase-5 target-7 marker + PR link.
+- HPC gotcha: `--basetemp=$(pwd)/.pytest_tmp` so the write path's `os.link` hardlink doesn't fail
+  cross-device (Errno 18).
+
+## Files
+
+- **New:** `src/variants/windows.rs` — the cores + `assemble_variant_buffers` pyfunction. Wire into
+  `src/ffi/mod.rs` (re-export) and `src/lib.rs` (`add_function`).
+- **Rewrite:** `python/genvarloader/_dataset/_flat_variants.py` (`get_variants_flat` assembly tail
+  calls the dispatched mega-call and wraps once) and `python/genvarloader/_dataset/_flat_flanks.py`
+  (helpers retained as the numba oracle behind the registry).
+- **Tests:** `tests/parity/` fixtures (mode matrix + empty + flank), Rust unit tests in
+  `src/variants/windows.rs`.
+- **Roadmap:** tick target 7, record ratios, set PR link.
+
+## Out of scope
+
+- Folding `fill_empty_groups` into the mega-call (kept as a separate post-pass).
+- Folding the `v_idxs` gather / AF filter / compaction / scalar-field gather into Rust (front edge =
+  assembly tail only; preserves #231 dtype-polymorphic fallback).
+- Strand reverse-complement (target 6) and rayon batch parallelism (blocked until 5/6/7 land).
+- Deleting the numba assembly helpers — they remain as registered parity oracles (wholesale numba
+  deletion is a later Phase-5 step, not this workstream).

--- a/src/intervals.rs
+++ b/src/intervals.rs
@@ -24,7 +24,10 @@ pub fn intervals_to_tracks(
     out_offsets: ArrayView1<i64>,
 ) {
     // Step 1: zero the whole output buffer, exactly like `out[:] = 0.0`.
-    out.fill(0.0);
+    // The out buffer is freshly allocated and contiguous; address it as a raw
+    // &mut [f32] so per-interval writes avoid ndarray SliceInfo construction.
+    let out_slice = out.as_slice_mut().unwrap();
+    out_slice.fill(0.0);
 
     let n_queries = starts.len();
 
@@ -63,7 +66,7 @@ pub fn intervals_to_tracks(
             if e > s {
                 let a = out_s + s as usize;
                 let b = out_s + e as usize;
-                out.slice_mut(ndarray::s![a..b]).fill(value);
+                out_slice[a..b].fill(value);
             }
         }
     }


### PR DESCRIPTION
Closes Target 5 of the Phase 5 read-path optimization (handoff
`docs/handoffs/2026-06-25-phase5-getitem-optimization.md`).

Byte-identical refactor of `intervals_to_tracks` to drop per-interval
`ndarray` `SliceInfo` construction: hoist `out.as_slice_mut()` once and
write `out_slice[a..b].fill(value)` / `out_slice.fill(0.0)` on the raw
`&mut [f32]`. Same arithmetic, same write order, same values; safe form
(no `unsafe` needed).

**tracks-only min numba ÷ min rust: 0.63× → 1.004×** (rust now ≥ numba
single-threaded; rust min 1.7112 ms → 1.1953 ms, ~30% drop).

Parity: byte-identical on both backends (rust default + `GVL_BACKEND=numba`),
incl. the `intervals_to_tracks` hypothesis gate and the two tracks dataset
backstops. Full tree green both backends (955/0); cargo 88/88; ruff +
pyrefly clean.

Note: this branch also carries a few unrelated parallel-work docs/spec/plan
commits (Target-6 RC spec, Target-7 variant-windows spec & plan) that ride
along — they touch only `docs/` and are independent of the kernel change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)