### PR TITLE
fix: pad full tail on reference overshoot in haplotype/track reconstruction (Phase 5 W1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,9 @@ pixi run -e dev typecheck
 pixi run -e docs doc
 ```
 
-The build system uses Maturin (Rust + Python). Rust code is compiled automatically when running tests via pixi.
+The build system uses Maturin (Rust + Python).
+
+**IMPORTANT — rebuild Rust before testing Rust changes:** `pixi run -e dev pytest` (and `pixi run -e dev test`) do **not** rebuild the Rust extension. After editing anything in `src/`, run `pixi run -e dev maturin develop --release` first, or pytest silently imports the *stale* compiled extension — parity/integration tests then pass or fail against the old binary, not your change. (`cargo test`/`cargo-test` compile from source and are unaffected; this only bites the Python tests that import the extension.)
 
 **Before pushing a change that renames/removes a public symbol or touches shared code, run the full tree** (`pixi run -e dev pytest tests -q`, or the full `pixi run -e dev test`). Scoped runs like `pytest tests/dataset` skip `tests/unit/` (e.g. `tests/unit/dataset/test_build_reconstructor.py`), so a stale reference there fails only in CI.
 

--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -743,6 +743,37 @@ narrowed to genoray (variant IO) only.
 
 ## Notes & decisions log
 
+- 2026-06-26 (Phase 5 W1 — trailing-fill overshoot fix + parity gate; branch `phase-5-w1`):
+  Fixed the trailing-fill overshoot divergence in **all four kernels** that advance `ref_idx`
+  past the contig end (deletion whose `v_ref_end > contig_len`):
+  (1) **Rust haplotype kernel** (`src/reconstruct/mod.rs`): when `writable_ref <= 0` the old
+  code set `out_end_idx = (out_idx + writable_ref).max(0)` which could be `< out_idx`, causing
+  the right-pad `out[out_end_idx..length]` to silently overwrite already-written positions.
+  Fixed by clamping to `out_end_idx = out_idx` — the whole unfilled tail `out[out_idx..length]`
+  is now padded, never less.
+  (2) **Numba haplotype kernel** (`python/genvarloader/_dataset/_genotypes.py`): replaced
+  `writable_ref = min(unfilled_length, len(ref) - ref_idx)` (could be negative) with
+  `writable_ref = max(0, min(unfilled_length, len(ref) - ref_idx))` so `out_end_idx` is
+  never below `out_idx`.
+  (3) **Rust track kernel** (`src/tracks/mod.rs`): same overshoot family — when
+  `writable_ref <= 0` the else-branch now clamps to `out_idx` (mirrors the haplotype fix).
+  (4) **Numba track kernel** (`python/genvarloader/_dataset/_tracks.py`): same `max(0, ...)`
+  guard on `writable_ref`.
+  Both kernels now write byte-identically across the full input domain including the
+  overshoot sub-domain. **Parity gates updated:** Guards 1–3 removed from
+  `tests/parity/test_reconstruct_haplotypes_parity.py` (overshoot pre-check,
+  `try/except SystemError`, double-init sentinel), and the `SystemError` guard removed from
+  `tests/parity/test_shift_and_realign_tracks_parity.py`. These sub-domains are now
+  first-class parity-covered inputs.
+  **Note:** the `pixi run -e dev pytest` command does NOT auto-rebuild the Rust extension;
+  `maturin develop --release` must be run explicitly before testing Rust changes (else the old
+  binary runs and tests fail on the pre-fix behavior — caught and fixed during this W1 run).
+  Full tree gate (rust backend): 993 passed, 12 skipped, 5 xfailed, 0 failed.
+  Subset gate on `tests/dataset tests/unit tests/parity` — rust: 709/6/2, numba: 709/6/2
+  (identical profiles, parity confirmed). Cargo: 114 passed. Lint/format/typecheck clean
+  (one branch-introduced test file reformatted by ruff). Phase 5 🚧 (W1 done; W2–W9 remain).
+  Issue tracking the overshoot: (issue: TODO — file before PR).
+
 - 2026-06-26 (Phase 4 close-out; branch `phase-4-close-out`, PR [#253](https://github.com/mcvickerlab/GenVarLoader/pull/253)): Investigation found the
   default write/update path already fully Rust-backed (bigWig streaming writer + COITrees table;
   variant IO via genoray). The roadmap's "variant normalization" bullet was a mischaracterization —

--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -772,7 +772,7 @@ narrowed to genoray (variant IO) only.
   Subset gate on `tests/dataset tests/unit tests/parity` — rust: 709/6/2, numba: 709/6/2
   (identical profiles, parity confirmed). Cargo: 114 passed. Lint/format/typecheck clean
   (one branch-introduced test file reformatted by ruff). Phase 5 🚧 (W1 done; W2–W9 remain).
-  Issue tracking the overshoot: (issue: TODO — file before PR).
+  Issue tracking the overshoot: #255.
 
 - 2026-06-26 (Phase 4 close-out; branch `phase-4-close-out`, PR [#253](https://github.com/mcvickerlab/GenVarLoader/pull/253)): Investigation found the
   default write/update path already fully Rust-backed (bigWig streaming writer + COITrees table;

--- a/docs/superpowers/plans/2026-06-26-rust-migration-phase-5.md
+++ b/docs/superpowers/plans/2026-06-26-rust-migration-phase-5.md
@@ -1,0 +1,325 @@
+# Rust Migration Phase 5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the Rust migration's Phase 5 — fix the remaining numba/rust correctness divergences, fuse the last deferred read path, freeze the numba oracle as golden fixtures, delete numba, add rayon, and merge `rust-migration → main` once a final `__getitem__` benchmark shows rust at parity-or-better.
+
+**Architecture:** Phase 5 is a strict sequential pipeline of distinct PRs into the `rust-migration` integration branch. Correctness fixes (W1, W2) and the fusion (W3) must land **while numba still exists** as the differential oracle; the final numba-vs-rust verdict (W4) must be captured **before** deletion; only then is it safe to golden-snapshot (W5) and delete numba (W6), add rayon (W7), measure RSS (W8), and merge (W9). **This document fully specifies PR1 (W1).** PR2–PR6 (W2–W9) are scoped at the end and each gets its own detailed plan written at its turn — W2 in particular requires a coordinate-math investigation whose root cause is not yet known and therefore cannot be bite-sized in advance.
+
+**Tech Stack:** Rust (ndarray, PyO3, rayon), Python (numpy, numba — being deleted), pixi (`-e dev`), maturin, pytest + hypothesis, cargo test, memray, pytest-benchmark.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-26-rust-migration-phase-5-design.md`. Roadmap (source of truth, must be updated): `docs/roadmaps/rust-migration.md` (Phase 5).
+- Byte-identical parity is the landing gate for every kernel change; numba is the oracle until W6 deletes it (W5 freezes it to golden fixtures first).
+- Benchmark parity verdict is **single-thread**: `NUMBA_NUM_THREADS=1`, rayon threads=1, `maturin develop --release`, corpus `chr22_geuv.gvl` (format 2.0), Carter HPC (AMD EPYC 7543, linux-64). Node is shared/noisy — use within-session ratios + pedantic min; the durable signal is parity + the recorded instruction-count reductions.
+- Dataset/parity tests on the HPC need `--basetemp=$(pwd)/.pytest_tmp` (numba write path's `os.link` fails cross-device, Errno 18).
+- Numba-oracle-bug policy: a numba-vs-rust divergence where numba is buggy gets an issue + an isolated fix PR + un-exclusion from parity. W1 and W2 follow this.
+- Per-kernel rust core lives in `src/`; PyO3 only in `src/ffi/`. No `unsafe` unless justified by a profile.
+- Commits: conventional-commit style; no squash on the final merge (preserve history). Co-author trailer on commits:
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+## PR1 (W1): Fix the haplotype/track trailing-fill divergence in BOTH kernels
+
+**Why this is "fix both," not "fix numba to match rust":** reading the actual code, *neither* kernel is correct in the overshoot sub-domain (a deletion drives `ref_idx` past the contig end with output still unfilled). The roadmap's "rust is correct" was an assertion about an untested, parity-excluded sub-domain. Concretely, with `ref=[1,2,3,4]`, a deletion at pos 2 with `ilen=-5` (so `v_ref_end = 2+5+1 = 8`), `out_len=8`, `pad_char=0`:
+
+- Correct output: ref consumed `[1,2]`, allele `[50]`, then **ref is exhausted** → pad the entire tail → `[1,2,50,0,0,0,0,0]`.
+- Current **numba** (`_genotypes.py:508`): `writable_ref = min(5, 4-8) = -4`, `out_end_idx = 3 + (-4) = -1`; `out[3:-1] = ref[8:4]` is a numpy shape mismatch inside njit → SystemError / unwritten tail (the bug).
+- Current **rust** (`src/reconstruct/mod.rs:245`): `out_end_idx = (3 + (-4)).max(0) = 0`; then `out[0..8] = pad` → `[0,0,0,0,0,0,0,0]` — **overwrites the valid prefix** `[1,2,50]`.
+
+**The fix (both kernels):** when `ref` is exhausted (`writable_ref <= 0`), clamp `out_end_idx` to `out_idx` (not 0) so the right-pad fills exactly the unfilled tail `out[out_idx:length]`. In numba this is `writable_ref = max(0, min(unfilled_length, len(ref) - ref_idx))`. The same latent pattern exists in the track-realign kernels (`_tracks.py:396` numba) — apply the identical clamp.
+
+**Files:**
+- Modify: `src/reconstruct/mod.rs:208-260` (rust haplotype trailing-fill; the `else` branch at 240-246) + its in-module test block.
+- Modify: `python/genvarloader/_dataset/_genotypes.py:508` (numba haplotype singular kernel).
+- Modify: `python/genvarloader/_dataset/_tracks.py:396` (numba track singular kernel).
+- Verify/Modify: rust track-realign trailing-fill in `src/tracks*` (check for the same `.max(0)` pattern).
+- Test (new): `tests/unit/dataset/test_reconstruct_trailing_fill.py` (numba + rust correctness, deterministic).
+- Test (new): `src/reconstruct/mod.rs` cargo unit test `overshoot_ref_past_contig`.
+- Modify: `tests/parity/test_reconstruct_haplotypes_parity.py` (remove the 3 exclusion guards once the divergence is gone).
+- Check: `tests/parity/test_shift_and_realign_tracks_parity.py`, `tests/parity/test_dataset_parity.py`, `tests/parity/strategies.py`, `tests/parity/_fixtures.py` for analogous overshoot/`max_jitter` exclusions tied to this divergence.
+
+**Interfaces:**
+- Consumes: `reconstruct_haplotype_from_sparse(v_idxs, v_starts, ilens, shift, alt_alleles, alt_offsets, ref, ref_start, out, pad_char, keep=None, annot_v_idxs=None, annot_ref_pos=None)` — numba singular kernel, `@nb.njit(nogil=True, cache=True)`, directly importable from `genvarloader._dataset._genotypes`.
+- Produces: no signature changes. Behavior change only: overshoot inputs now produce full-tail-pad output, byte-identical across numba and rust.
+
+### Task 1: Characterize the rust overshoot bug (cargo, failing test)
+
+**Files:**
+- Test: `src/reconstruct/mod.rs` (add to the `#[cfg(test)] mod tests` block, alongside `deletion`/`del_spanning_ref_start`).
+
+- [ ] **Step 1: Write the failing cargo test**
+
+Add next to the existing `run(...)`-helper tests (the helper signature is
+`run(v_idxs, v_starts, ilens, shift, alt_alleles, alt_offsets, ref, ref_start, out_len, pad_char, keep, annotate)`):
+
+```rust
+// -------------------------------------------------------------------------
+// Case: deletion drives ref_idx past the contig end (overshoot).
+// ref = [1,2,3,4] (len 4), ref_start=0, out_len=8.
+// variant at pos=2, ilen=-5, allele=[50] (anchor).
+//   v_ref_end = 2 - min(0,-5) + 1 = 8  → ref_idx advances to 8 (> len 4).
+// Processing: ref[0..2]=[1,2], allele=[50] → out_idx=3.
+// Final clause: unfilled=5, ref exhausted (writable_ref = min(5, 4-8) = -4 <= 0).
+// CORRECT: no ref left → pad the whole tail → [1,2,50,0,0,0,0,0].
+// (Pre-fix rust over-pads from index 0 → all zeros.)
+// -------------------------------------------------------------------------
+#[test]
+fn overshoot_ref_past_contig() {
+    let (out, _av, _ap) = run(
+        &[0],
+        &[2],          // v_pos=2
+        &[-5],         // ilen=-5 (deletion past contig end)
+        0,             // shift
+        &[50u8],       // anchor allele
+        &[0i64, 1],
+        &[1, 2, 3, 4], // ref, len 4
+        0,             // ref_start
+        8,             // out_len
+        0,             // pad_char
+        None,
+        false,
+    );
+    assert_eq!(out, vec![1, 2, 50, 0, 0, 0, 0, 0]);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS**
+
+Run: `pixi run -e dev cargo test --lib reconstruct::tests::overshoot_ref_past_contig`
+Expected: FAIL — actual `[0, 0, 0, 0, 0, 0, 0, 0]` (rust over-pads from index 0).
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+rtk git add src/reconstruct/mod.rs
+rtk git commit -m "test(reconstruct): pin correct full-tail-pad on ref overshoot (failing)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 2: Fix the rust trailing-fill clamp
+
+**Files:**
+- Modify: `src/reconstruct/mod.rs:240-246` (the `else` branch) + the stale comments at 211-218.
+
+- [ ] **Step 1: Apply the clamp-to-`out_idx` fix**
+
+Replace the `else` branch (currently `(out_idx + writable_ref).max(0)`) so an exhausted ref pads exactly the unfilled tail:
+
+```rust
+        } else {
+            // writable_ref <= 0: ref exhausted (ref_idx at/after contig end).
+            // No reference bytes remain to copy, so the entire unfilled tail
+            // out[out_idx..length] must be padded. Clamp out_end_idx to out_idx
+            // (NOT 0) so the right-pad below fills exactly out[out_idx..length]
+            // and never overwrites already-written positions.
+            out_idx
+        };
+```
+
+Also fix the now-inaccurate comment block at lines 211-218 (it describes mirroring numpy's negative-index behavior, which was the bug). Replace with a one-line note that the tail is padded when ref is exhausted.
+
+- [ ] **Step 2: Run the cargo test to verify it PASSES**
+
+Run: `pixi run -e dev cargo test --lib reconstruct::tests::overshoot_ref_past_contig`
+Expected: PASS — `[1, 2, 50, 0, 0, 0, 0, 0]`.
+
+- [ ] **Step 3: Run the full rust suite (no regressions)**
+
+Run: `pixi run -e dev cargo-test`
+Expected: all pass (the existing `deletion`, `del_spanning_ref_start`, etc. are unaffected — they never overshoot).
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add src/reconstruct/mod.rs
+rtk git commit -m "fix(reconstruct): pad full tail when ref exhausted, not from index 0
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 3: Characterize + fix the numba haplotype/track kernels
+
+**Files:**
+- Test: `tests/unit/dataset/test_reconstruct_trailing_fill.py` (new).
+- Modify: `python/genvarloader/_dataset/_genotypes.py:508`.
+- Modify: `python/genvarloader/_dataset/_tracks.py:396`.
+
+- [ ] **Step 1: Write the failing numba correctness test**
+
+```python
+"""Correctness of the trailing-fill clause when a deletion exhausts the contig.
+
+The overshoot sub-domain (ref_idx past contig end with output unfilled) was
+historically excluded from parity because numba and rust diverged AND both were
+wrong. Correct behavior: pad the entire unfilled tail (no reference left).
+"""
+
+import numpy as np
+
+from genvarloader._dataset._genotypes import reconstruct_haplotype_from_sparse
+
+
+def test_overshoot_pads_full_tail():
+    # ref=[1,2,3,4], deletion at pos 2 (ilen=-5) -> ref_idx advances to 8 (>4).
+    # out_len=8: [1,2] ref + [50] allele, then ref exhausted -> pad rest with 0.
+    out = np.full(8, 255, dtype=np.uint8)  # 0xFF sentinel: catches unwritten positions
+    reconstruct_haplotype_from_sparse(
+        np.array([0], dtype=np.int32),        # v_idxs
+        np.array([2], dtype=np.int32),        # v_starts
+        np.array([-5], dtype=np.int32),       # ilens
+        0,                                    # shift
+        np.array([50], dtype=np.uint8),       # alt_alleles
+        np.array([0, 1], dtype=np.int64),     # alt_offsets
+        np.array([1, 2, 3, 4], dtype=np.uint8),  # ref
+        0,                                    # ref_start
+        out,                                  # out
+        0,                                    # pad_char
+    )
+    np.testing.assert_array_equal(out, np.array([1, 2, 50, 0, 0, 0, 0, 0], dtype=np.uint8))
+```
+
+- [ ] **Step 2: Run to verify it FAILS**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_reconstruct_trailing_fill.py -v --basetemp=$(pwd)/.pytest_tmp`
+Expected: FAIL — numba leaves the tail unwritten (0xFF sentinel leaks through) or raises a numpy shape error inside the njit kernel.
+
+- [ ] **Step 3: Apply the numba clamp (haplotype kernel)**
+
+In `python/genvarloader/_dataset/_genotypes.py:508`, clamp the available ref to be non-negative so an exhausted ref yields `out_end_idx == out_idx` and the right-pad fills the whole tail:
+
+```python
+        writable_ref = max(0, min(unfilled_length, len(ref) - ref_idx))
+```
+
+- [ ] **Step 4: Apply the same clamp to the numba track kernel**
+
+In `python/genvarloader/_dataset/_tracks.py:396`:
+
+```python
+        writable_ref = max(0, min(unfilled_length, len(track) - track_idx))
+```
+
+- [ ] **Step 5: Run the numba test to verify it PASSES**
+
+Run: `pixi run -e dev pytest tests/unit/dataset/test_reconstruct_trailing_fill.py -v --basetemp=$(pwd)/.pytest_tmp`
+Expected: PASS — `[1, 2, 50, 0, 0, 0, 0, 0]`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add python/genvarloader/_dataset/_genotypes.py python/genvarloader/_dataset/_tracks.py tests/unit/dataset/test_reconstruct_trailing_fill.py
+rtk git commit -m "fix(reconstruct,tracks): pad full tail in numba trailing-fill on ref overshoot
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 4: Verify the rust track-realign kernel + un-exclude parity
+
+**Files:**
+- Verify/Modify: rust track trailing-fill (search `src/` for the analog).
+- Modify: `tests/parity/test_reconstruct_haplotypes_parity.py`.
+- Check: `tests/parity/test_shift_and_realign_tracks_parity.py`, `tests/parity/test_dataset_parity.py`, `tests/parity/strategies.py`, `tests/parity/_fixtures.py`.
+
+- [ ] **Step 1: Verify the rust track kernel has no `.max(0)` over-pad**
+
+Run: `pixi run -e dev grep -n "max(0)\|writable_ref\|out_end" src/tracks.rs src/intervals.rs`
+If the track-realign trailing-fill uses the same `(out_idx + writable_ref).max(0)` pattern, apply the identical `out_idx` clamp + add a cargo test mirroring Task 1. If it already clamps to `out_idx` (or has no negative-`writable_ref` path), record that in the commit message and skip.
+
+- [ ] **Step 2: Remove the now-obsolete exclusion guards from the haplotype parity test**
+
+In `tests/parity/test_reconstruct_haplotypes_parity.py`, delete:
+- the `_ref_idx_overshoots_contig(...)` helper and both `assume(not _ref_idx_overshoots_contig(inputs))` calls (Guard 1),
+- the `_numba_fully_defined(...)` double-init helper and `assume(defined)` calls (Guard 3),
+- the `try/except SystemError: assume(False)` wrapper (Guard 2).
+
+The body simplifies to: run numba into `out_n`, run rust into `out_r`, `np.testing.assert_array_equal`. (Both kernels now fully write every position byte-identically across the full generated domain, including overshoot.)
+
+- [ ] **Step 3: Run the haplotype parity suite (both backends, full domain)**
+
+Run: `pixi run -e dev pytest tests/parity/test_reconstruct_haplotypes_parity.py -v --basetemp=$(pwd)/.pytest_tmp`
+Expected: PASS — hypothesis explores overshoot inputs (no longer assumed away) and finds byte-identity. (The parity helper calls both `numba_fn` and `rust_fn` directly, so one run covers both backends.)
+
+- [ ] **Step 4: Lift analogous exclusions in the track + dataset parity suites**
+
+Inspect `test_shift_and_realign_tracks_parity.py`, `test_dataset_parity.py`, `strategies.py`, `_fixtures.py` for overshoot/`max_jitter`-pinned guards tied to THIS divergence (not the separate #242 `intervals_to_tracks` clip bug — leave those for W2). Remove only the trailing-fill-overshoot exclusions; re-run each touched suite:
+
+Run: `pixi run -e dev pytest tests/parity/test_shift_and_realign_tracks_parity.py tests/parity/test_dataset_parity.py -v --basetemp=$(pwd)/.pytest_tmp`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/ tests/parity/
+rtk git commit -m "test(parity): un-exclude ref-overshoot sub-domain now both kernels pad correctly
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 5: Full-tree verification, roadmap update, and PR
+
+**Files:**
+- Modify: `docs/roadmaps/rust-migration.md` (Phase 5 notes/log).
+
+- [ ] **Step 1: Run the full Python tree on the rust backend**
+
+Run: `pixi run -e dev pytest tests -q --basetemp=$(pwd)/.pytest_tmp`
+Expected: green (the pre-existing xfails remain xfailed; no new failures).
+
+- [ ] **Step 2: Run the full tree on the numba backend**
+
+Run: `GVL_BACKEND=numba pixi run -e dev pytest tests/dataset tests/unit tests/parity -q --basetemp=$(pwd)/.pytest_tmp`
+Expected: green — same pass/xfail profile, confirming byte-identical parity.
+
+- [ ] **Step 3: Lint, format, typecheck, cargo**
+
+Run:
+```bash
+pixi run -e dev ruff check python/ tests/ && \
+pixi run -e dev ruff format --check python/ tests/ && \
+pixi run -e dev typecheck && \
+pixi run -e dev cargo-test
+```
+Expected: all clean/green.
+
+- [ ] **Step 4: Record the fix in the roadmap**
+
+Add a dated entry to the Notes & decisions log in `docs/roadmaps/rust-migration.md` noting: the overshoot trailing-fill divergence was fixed in BOTH kernels (clamp `out_end_idx` to `out_idx`; numba `writable_ref = max(0, ...)`), the previously-excluded sub-domain is now parity-covered (Guards 1–3 removed), and reference the filed issue. Do NOT yet mark Phase 5 ✅ (W2–W9 remain).
+
+- [ ] **Step 5: Commit and open the PR**
+
+```bash
+rtk git add docs/roadmaps/rust-migration.md
+rtk git commit -m "docs(roadmap): record trailing-fill overshoot fix (Phase 5 W1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+rtk git push -u origin rust-migration   # (or a w1 topic branch, per your PR convention)
+```
+Then open the PR into `rust-migration` (file the GVL issue first and reference it). Title: `fix: pad full tail on reference overshoot in haplotype/track reconstruction (Phase 5 W1)`.
+
+---
+
+## Subsequent PRs (planned separately, in order)
+
+Each gets its own detailed bite-sized plan written when its predecessor lands. They are **not** bite-sized here because they depend on results that don't exist yet.
+
+- **PR2 (W2) — Fix the #242 `intervals_to_tracks` store-vs-query divergence.** Requires a systematic-debugging investigation: gvl stores intervals at `chromStart - max_jitter` but queries at `chromStart + jitter`, so a stored interval can start before the query window (`max_jitter>0`). The correct reconciliation (kernel clip vs store/query coordinate math) is unknown until investigated and may touch the write path. Fix both backends to agree-and-be-correct; un-exclude the #242 sub-domain across the parity + dataset suites; close issue #242. *Plan written after the investigation; W1 should land first so the oracle is otherwise trustworthy.*
+
+- **PR3 (W3) — Fuse the deferred annotated+spliced intersection path.** Add a fused rust kernel collapsing its remaining FFI crossings (pattern: `reconstruct_annotated_haplotypes_fused` / `reconstruct_haplotypes_spliced_fused`). Parity-gate against the composed numba oracle **while numba still exists**. Extend the parity suite to cover it.
+
+- **PR4 (W4) — Final single-thread numba-vs-rust `__getitem__` A/B.** Benchmark only (no code): `tests/benchmarks/test_e2e.py` pedantic min + `profile.py` wall-clock across all modes, both backends present, one back-to-back session. **Gate:** rust at parity-or-better single-thread → proceed to consolidation.
+
+- **PR5 (W5–W7) — The consolidation PR.** (a) Golden-snapshot the ~17 numba-oracle parity suites to frozen fixtures (storage scheme decided in that plan — compressed `.npz` keyed by generated input, or a bounded seeded sample); (b) delete all numba: ~21 `register()` refs, njit bodies, `_dispatch` registry + `GVL_BACKEND`, every `import numba`; replace `get(name)(...)` with direct rust calls; assert `import genvarloader` pulls neither numba nor llvmlite; (c) add rayon batch parallelism over per-(query,hap) work items, gated byte-identical to the serial golden result.
+
+- **PR6 (W8–W9) — Measure & merge.** Rust-only peak RSS (memray) vs the 3.53 GB numba baseline (expect the ~3.2 GB JIT drop); rayon multi-thread speedup (rayon N vs 1). If RSS and wall-clock are parity-or-better, open `rust-migration → main` (no squash); mark Phase 5 ✅ in the roadmap with the final tables + PR link; update `skills/genvarloader/SKILL.md` for any public-API change (e.g. `GVL_BACKEND` removal).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** W1 (haps trailing-fill) is fully planned as PR1 — and corrected to "fix both kernels," a deviation from the spec's "verify rust already correct" found during planning (documented in the PR1 preamble). W2–W9 map to PR2–PR6. Decisions D1–D7 are all reflected (D4 = PR1; D5 = PR2; D3 = PR3; D6 = PR4; D2 = PR5; D1 = PR5; D7 = separate PRs throughout).
+- **Placeholder scan:** PR1 steps contain concrete code, exact commands, and expected output. PR2–PR6 are intentionally high-level (planned separately) and labeled as such — not placeholders within an executable task.
+- **Type consistency:** `reconstruct_haplotype_from_sparse` signature and the `run(...)` cargo helper argument order match the source read during planning; `writable_ref`/`out_end_idx`/`out_idx` names match both kernels.

--- a/docs/superpowers/specs/2026-06-26-rust-migration-phase-5-design.md
+++ b/docs/superpowers/specs/2026-06-26-rust-migration-phase-5-design.md
@@ -1,0 +1,263 @@
+# Design: Rust Migration Phase 5 — Consolidation, numba deletion, rayon, final benchmark → main
+
+**Date:** 2026-06-26
+**Branch:** `rust-migration` (the persistent integration branch; pre-consolidation bug fixes land as their own PRs into it first)
+**Roadmap:** `docs/roadmaps/rust-migration.md` — Phase 5 (⬜ → target ✅)
+**Status:** design approved; spec for writing-plans
+
+---
+
+## 1. Context & goal
+
+Phases 0–4 of the Rust migration are ✅: the read path (`Dataset.__getitem__`) and
+write/update path are Rust-backed and rust-by-default, with byte-identical parity proven
+against retained numba reference kernels. Those numba kernels were **deliberately kept
+alive** as differential-test oracles, to be "deleted wholesale in Phase 5."
+
+Phase 5 is the consolidation phase. Its roadmap checklist:
+
+- Collapse the PyO3 surface so Python is a true shim.
+- Delete all remaining core numba kernels (target count = 0).
+- Confirm the crate is fully cargo-testable standalone.
+
+**Goal of this work:** finish Phase 5, run a final numba-vs-rust benchmark on
+`__getitem__` (wall-clock + peak RSS), and — if rust reaches parity or better — open the
+`rust-migration → main` PR (the single big merge the branch strategy was built around).
+
+### What is already satisfied
+
+- **cargo-testable standalone:** `seqpro-core = "0.1.0"` is a published crates.io registry
+  dependency (checksum-locked in `Cargo.lock`), not an editable path-dep. `cargo test`
+  already runs without the Python/maturin layer (prior phases cite "cargo 109 passed").
+  This checklist item needs only a final verification, not new work.
+
+### Why this is not a no-op (the RSS gate)
+
+All three hot read-path modules (`_genotypes.py`, `_flat_variants.py`, `_tracks.py`) still
+`import numba as nb` at module load. The roadmap repeatedly records that peak RSS
+(~3.53 GB) is "dominated by the numba/llvmlite JIT baseline (~3.2 GB)." Therefore the
+rust-only peak-RSS win **cannot be measured until numba is deleted** — a benchmark today
+would show near-parity RSS by construction (both backends import numba). The RSS metric
+the user wants is gated on the numba deletion that is Phase 5's core.
+
+---
+
+## 2. Current state (measured 2026-06-26)
+
+- `rust-migration` is **162 commits ahead of `main`, 0 behind, 123 files changed** — a
+  clean fast-forward merge whenever chosen. `main` stays shippable.
+- **~21 `register(...)` dual-backend kernels** across `_genotypes.py`, `_flat_variants.py`,
+  `_intervals.py`, `_tracks.py`, `_reference.py`, all routed through the
+  `python/genvarloader/_dispatch.py` registry (`GVL_BACKEND` override, per-kernel default
+  `rust`).
+- **~17 numba-oracle parity suites** in `tests/parity/` (e.g.
+  `test_reconstruct_haplotypes_parity.py`, `test_fused_haps_parity.py`,
+  `test_dataset_parity.py`) compare rust against the live numba impl.
+- **Two known numba-vs-rust divergences are currently excluded from parity** (rust is
+  correct in both; numba is the buggy oracle):
+  1. **Haplotype trailing-fill** (`_genotypes.py:508`): when a deletion drives `ref_idx`
+     past the contig end, `writable_ref = min(unfilled_length, len(ref) - ref_idx)` goes
+     negative, so `out_end_idx = out_idx + writable_ref < out_idx`, and
+     `out[out_end_idx:] = pad_char` uses Python-style negative indexing — it wraps and
+     leaves trailing positions unwritten. Rust clamps `out_end_idx` to 0 and pads
+     correctly. The same latent pattern exists at `_tracks.py:396`.
+  2. **#242-family** (`intervals_to_tracks`): gvl stores intervals at
+     `chromStart - max_jitter` but queries at `chromStart + jitter`, so for `max_jitter>0`
+     datasets a stored interval can start before the query window. The numba/rust kernels
+     diverge (debug_assert panic / clip behavior). Filed as
+     [mcvickerlab/GenVarLoader#242](https://github.com/mcvickerlab/GenVarLoader/issues/242).
+- **Deferred fusion:** the annotated+spliced *intersection* read path still runs on the
+  unfused dispatched rust core (Phase 3 explicitly deferred its fusion to Phase 5).
+
+---
+
+## 3. Decisions (locked with the user)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | Rayon batch parallelism | **In scope** for Phase 5 (the roadmap's "next lever"). |
+| D2 | Fate of numba-oracle parity suites after deletion | **Golden-snapshot** them to frozen fixtures (preserve independent differential coverage in perpetuity), *after* fixing the numba bugs so the frozen oracle is correct. |
+| D3 | PyO3 shim collapse aggressiveness | **Also fuse the deferred annotated+spliced path**, not just remove dispatch indirection. |
+| D4 | Haplotype trailing-fill numba bug | **Fix it** (clamp), so the golden oracle is correct. |
+| D5 | #242-family exclusion | **Fix it too**, so the golden oracle is fully exclusion-free (touches the write/store path; needs a correct-behavior investigation). |
+| D6 | Final benchmark threading convention | **Single-thread verdict** (rayon=1 vs `NUMBA_NUM_THREADS=1`), comparable to all prior baselines; rayon multi-thread speedup reported separately as an additive bonus. |
+| D7 | Bug fixes (D4, D5) PR strategy | **Separate PR(s), land first**, per the established numba-oracle-bug-policy (file issue + isolated fix + un-exclude from parity). |
+
+---
+
+## 4. Workstreams
+
+### Stage A — Pre-consolidation correctness (separate PRs, land first)
+
+These make numba a trustworthy, exclusion-free oracle **before** it is frozen as golden
+fixtures and then deleted. Each uses systematic-debugging to establish the correct
+behavior, and lands as its own PR into `rust-migration` (per D7).
+
+**W1 — Fix the haplotype trailing-fill numba bug (D4).**
+- File a GVL issue referencing the `_genotypes.py:508` trailing-fill divergence.
+- Fix: `writable_ref = max(0, min(unfilled_length, len(ref) - ref_idx))` at
+  `_genotypes.py:508`; mirror the clamp at `_tracks.py:396`.
+- Verify rust already produces the correct (clamped/padded) output; confirm
+  rust == numba after the fix across the previously-excluded overshoot sub-domain.
+- Un-exclude that sub-domain: drop Guard 1 (the overshoot pre-check) in
+  `tests/parity/test_reconstruct_haplotypes_parity.py`; remove the double-init sentinel
+  guard where it only existed to mask this divergence.
+- **Acceptance:** the overshoot sub-domain is parity-covered (not excluded), full tree
+  green on both backends.
+
+**W2 — Fix the #242-family divergence (D5).**
+- Investigation (systematic-debugging): determine the correct `intervals_to_tracks`
+  behavior when a stored interval starts before the query window (`max_jitter>0`),
+  reconciling the `chromStart - max_jitter` store vs `chromStart + jitter` query offset.
+  This may touch the write/store path and/or the query coordinate math, not only the
+  kernel.
+- Apply the fix to **both** backends so they agree and both are correct; reference/close
+  #242.
+- Un-exclude the #242-family sub-domain: remove the `assume(False)` / xfail guards in the
+  affected parity + dataset suites (`test_reconstruct_haplotypes_parity.py`,
+  `test_dataset_parity.py`, `test_shift_and_realign_tracks_parity.py`,
+  `strategies.py`/`_fixtures.py` generators), lifting fixtures off the forced
+  `max_jitter=0` where they were pinned only to dodge #242.
+- **Acceptance:** `max_jitter>0` parity restored; #242 closed; full tree green on both
+  backends.
+
+### Stage B — Fusion (parity-gated against numba, before deletion)
+
+**W3 — Fuse the deferred annotated+spliced intersection path (D3).**
+- Add a fused rust kernel that collapses the remaining FFI crossings on the
+  annotated+spliced read path (the intersection still on the unfused dispatched core),
+  matching the fusion pattern of `reconstruct_annotated_haplotypes_fused` /
+  `reconstruct_haplotypes_spliced_fused`.
+- Gate on byte-identical parity against the composed numba oracle **while numba still
+  exists**.
+- **Acceptance:** annotated+spliced path is fused and byte-identical; parity suite extended
+  to cover it.
+
+### Stage C — Final numba-vs-rust benchmark (the gate; numba still present)
+
+**W4 — Capture the single-thread parity verdict (D6).**
+- Harness: existing `tests/benchmarks/test_e2e.py` (pytest-benchmark pedantic min) +
+  `tests/benchmarks/profiling/profile.py` wall-clock, `NUMBA_NUM_THREADS=1`, rayon
+  threads=1, release build, corpus `chr22_geuv.gvl` (format 2.0), Carter HPC.
+- Run the numba-vs-rust A/B in **one back-to-back session** across all modes:
+  tracks-only, tracks-seqs, haplotypes, annotated, variants, variant-windows.
+- This is the canonical "final numba vs rust" wall-clock comparison; it must run while both
+  backends exist (after deletion there is no numba to A/B).
+- **Gate:** rust at **parity or better** (single-thread) on `__getitem__`. Per-path
+  node-noise caveat applies (use within-session ratios; the durable signal is the
+  established instruction-count reductions + parity).
+
+### Stage D — Consolidation (the single big Phase 5 PR)
+
+**W5 — Golden-snapshot the parity suites (D2).**
+- Before deleting numba, generate frozen golden fixtures from the now-correct numba oracle
+  for each of the ~17 parity suites (including the W3 fused path and the W1/W2
+  un-excluded sub-domains).
+- Convert the suites from "run-both-assert-byte-identical" to golden-file regression tests
+  that need no live numba. Store fixtures compactly (compressed `.npz`/`.npy` keyed by the
+  hypothesis-generated input, or a deterministic seeded sample set — chosen in the plan to
+  keep the repo size bounded).
+- **Acceptance:** golden suites pass against rust with numba uninstalled/uncalled.
+
+**W6 — Delete numba + collapse to thin shim.**
+- Delete the ~21 `register()` numba refs, all njit bodies, the `python/genvarloader/_dispatch.py`
+  registry + `GVL_BACKEND`, and every `import numba` in the core modules.
+- Replace `get(name)(...)` dispatch call sites (`_intervals.py`, `_reference.py`,
+  `_reconstruct.py`, `_tracks.py`, `_flat_variants.py`, `_rag_variants.py`,
+  `_genotypes.py`) with direct rust calls — Python becomes indexing sugar + torch +
+  validation/error messages only.
+- Remove `numba` from the project's runtime dependency set (verify nothing else in the
+  package imports it).
+- **Acceptance:** core numba kernel count = 0; `python -c "import genvarloader"` does not
+  import numba or llvmlite (asserted by a test); full tree green.
+
+**W7 — Add rayon batch parallelism (D1).**
+- Parallelize the read-path batch drivers with rayon over the per-(query, hap) work items
+  (disjoint output slices — proven safe / serial-equivalent in Phase 3). Rust-only;
+  thread count controlled by an env/config knob, default chosen in the plan.
+- **Acceptance:** byte-identical to the serial result (golden suites still pass);
+  multi-thread speedup measured.
+
+### Stage E — Measure & merge
+
+**W8 — Rust-only RSS + rayon speedup.**
+- After deletion, measure rust-only peak RSS on `__getitem__` (memray) vs the recorded
+  numba baseline (3.53 GB) — expect the ~3.2 GB JIT removal.
+- Measure rayon multi-thread speedup (rayon N vs rayon 1) as the additive bonus (D6).
+
+**W9 — PR `rust-migration → main`.**
+- If the Stage C verdict is parity-or-better and RSS is parity-or-better, open the merge
+  PR (no squash — preserve commit history). Update `docs/roadmaps/rust-migration.md`:
+  mark Phase 5 ✅, record the final single-thread A/B table, the rust-only RSS, the rayon
+  speedup, and the PR link. Update `skills/genvarloader/SKILL.md` if any public symbol
+  changed (e.g. removal of `GVL_BACKEND`).
+
+---
+
+## 5. Sequencing & PR strategy
+
+```
+W1 (haps trailing-fill fix)   ──┐  separate PRs into rust-migration
+W2 (#242 fix)                 ──┘  (land first; un-exclude parity)
+        │
+W3 (annotated+spliced fusion) ───  PR into rust-migration (parity-gated vs numba)
+        │
+W4 (final numba-vs-rust A/B)  ───  benchmark only (both backends present) → GATE
+        │
+W5..W8 (golden snapshot, delete numba, rayon, RSS) ── single Phase 5 consolidation PR
+        │
+W9 (rust-migration → main)    ───  the big merge, if gate passes
+```
+
+Rationale for ordering: the numba bugs must be fixed (W1, W2) and the deferred path fused
+(W3) **while numba still exists** as the oracle; the parity verdict (W4) must be captured
+**before** deletion; only then is it safe to freeze golden fixtures (W5) and delete numba
+(W6). Rayon (W7) is rust-only and lands after deletion. RSS (W8) is only meaningful after
+deletion.
+
+---
+
+## 6. Out of scope
+
+- **Phase 6 (absorb genoray):** variant IO stays on Python genoray.
+- **Multi-thread numba (prange) A/B:** the verdict is single-thread per D6.
+- Any further single-thread kernel micro-optimization (rounds 1–3 are complete; headroom
+  is maximized per the roadmap).
+
+---
+
+## 7. Risks & mitigations
+
+- **#242 is broader than a kernel clamp (W2).** It touches store-vs-query coordinate math;
+  the correct behavior must be established by investigation before coding. Mitigation:
+  systematic-debugging, fix both backends together, land as its own PR with the
+  un-exclusion as the acceptance gate. If it proves larger than expected, it can be split
+  out without blocking W1/W3.
+- **Golden-fixture repo bloat (W5).** Frozen oracle outputs could be large. Mitigation:
+  compress and/or use a bounded deterministic seeded sample rather than the full
+  hypothesis space; decide the exact scheme in the plan.
+- **Node-noise on the benchmark verdict (W4).** Carter is a shared node (absolute ms/batch
+  drifts ≥2× across sessions). Mitigation: single back-to-back session, within-session
+  ratios, pedantic min; lean on the durable instruction-count + parity evidence already in
+  the roadmap.
+- **Rayon non-determinism (W7).** Mitigation: disjoint output slices (already established);
+  gate on byte-identical equality to the serial golden result.
+
+---
+
+## 8. Acceptance criteria (Phase 5 ✅)
+
+1. Haplotype trailing-fill and #242 divergences fixed; both previously-excluded sub-domains
+   parity-covered (W1, W2).
+2. Annotated+spliced path fused, byte-identical (W3).
+3. Final single-thread numba-vs-rust `__getitem__` A/B captured; rust at parity-or-better
+   (W4).
+4. Parity suites converted to golden fixtures; pass with numba absent (W5).
+5. Core numba kernel count = 0; `import genvarloader` pulls neither numba nor llvmlite;
+   `_dispatch`/`GVL_BACKEND` gone; PyO3 surface is a thin shim (W6).
+6. Rayon batch parallelism byte-identical to serial; speedup measured (W7).
+7. Rust-only peak RSS at parity-or-better vs the 3.53 GB numba baseline (W8).
+8. `cargo test` green standalone; full Python tree green; lint/format/typecheck clean;
+   abi3 wheel builds.
+9. `rust-migration → main` PR opened (no squash); roadmap Phase 5 ✅ + final numbers + PR
+   link recorded; skill updated if public API changed (W9).

--- a/python/genvarloader/_dataset/_genotypes.py
+++ b/python/genvarloader/_dataset/_genotypes.py
@@ -505,7 +505,7 @@ def reconstruct_haplotype_from_sparse(
     unfilled_length = length - out_idx
     if unfilled_length > 0:
         # fill with reference sequence
-        writable_ref = min(unfilled_length, len(ref) - ref_idx)
+        writable_ref = max(0, min(unfilled_length, len(ref) - ref_idx))
         out_end_idx = out_idx + writable_ref
         ref_end_idx = ref_idx + writable_ref
         out[out_idx:out_end_idx] = ref[ref_idx:ref_end_idx]

--- a/python/genvarloader/_dataset/_tracks.py
+++ b/python/genvarloader/_dataset/_tracks.py
@@ -393,7 +393,7 @@ def shift_and_realign_track_sparse(
     # fill rest with track and pad with 0
     unfilled_length = length - out_idx
     if unfilled_length > 0:
-        writable_ref = min(unfilled_length, len(track) - track_idx)
+        writable_ref = max(0, min(unfilled_length, len(track) - track_idx))
         out_end_idx = out_idx + writable_ref
         ref_end_idx = track_idx + writable_ref
         out[out_idx:out_end_idx] = track[track_idx:ref_end_idx]

--- a/src/reconstruct/mod.rs
+++ b/src/reconstruct/mod.rs
@@ -629,6 +629,35 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
+    // Case: deletion drives ref_idx past the contig end (overshoot).
+    // ref = [1,2,3,4] (len 4), ref_start=0, out_len=8.
+    // variant at pos=2, ilen=-5, allele=[50] (anchor).
+    //   v_ref_end = 2 - min(0,-5) + 1 = 8  → ref_idx advances to 8 (> len 4).
+    // Processing: ref[0..2]=[1,2], allele=[50] → out_idx=3.
+    // Final clause: unfilled=5, ref exhausted (writable_ref = min(5, 4-8) = -4 <= 0).
+    // CORRECT: no ref left → pad the whole tail → [1,2,50,0,0,0,0,0].
+    // (Pre-fix rust over-pads from index 0 → all zeros.)
+    // -------------------------------------------------------------------------
+    #[test]
+    fn overshoot_ref_past_contig() {
+        let (out, _av, _ap) = run(
+            &[0],
+            &[2],          // v_pos=2
+            &[-5],         // ilen=-5 (deletion past contig end)
+            0,             // shift
+            &[50u8],       // anchor allele
+            &[0i64, 1],
+            &[1, 2, 3, 4], // ref, len 4
+            0,             // ref_start
+            8,             // out_len
+            0,             // pad_char
+            None,
+            false,
+        );
+        assert_eq!(out, vec![1, 2, 50, 0, 0, 0, 0, 0]);
+    }
+
+    // -------------------------------------------------------------------------
     // Case 7: overlapping ALTs — only first applied
     // ref = [1,2,3,4,5], ref_start=0, out_len=5
     // v_idxs=[0,1]: two variants both at pos=2, but second has v_pos < ref_idx after first

--- a/src/reconstruct/mod.rs
+++ b/src/reconstruct/mod.rs
@@ -207,15 +207,8 @@ pub fn reconstruct_haplotype_from_sparse(
     // fill rest with reference sequence and right-pad with Ns
     let unfilled_length = length - out_idx;
     if unfilled_length > 0 {
-        // fill with reference sequence
-        // Mirror numba: `writable_ref = min(unfilled_length, len(ref) - ref_idx)`.
-        // When `ref_idx` has advanced past the contig end (e.g. a DEL whose
-        // ref_end exceeds contig_len), `len(ref) - ref_idx` is negative.
-        // In numpy, `out[out_idx : out_idx + negative] = …` is a no-op (empty
-        // slice), and the subsequent right-pad starts from
-        // `out_end_idx = out_idx + writable_ref` which can be < `out_idx`.
-        // We clamp `out_end_idx` to 0 (never negative address) to reproduce
-        // the same right-pad range.
+        // fill with reference sequence; when ref_idx is past the contig end,
+        // writable_ref <= 0 and the tail out[out_idx..length] is right-padded.
         let writable_ref = unfilled_length.min(ref_flat.len() as i64 - ref_idx);
         // Positive: copy ref bytes from ref_idx. Zero or negative: no-op.
         let out_end_idx = if writable_ref > 0 {
@@ -238,11 +231,12 @@ pub fn reconstruct_haplotype_from_sparse(
             }
             oe
         } else {
-            // writable_ref <= 0: ref exhausted or ref_idx past contig.
-            // out_end_idx = out_idx + writable_ref, clamped to 0 to stay
-            // in-bounds (matches numpy: `out[out_end_idx:]` where
-            // out_end_idx >= 0).
-            (out_idx + writable_ref).max(0)
+            // writable_ref <= 0: ref exhausted (ref_idx at/after contig end).
+            // No reference bytes remain to copy, so the entire unfilled tail
+            // out[out_idx..length] must be padded. Clamp out_end_idx to out_idx
+            // (NOT 0) so the right-pad below fills exactly out[out_idx..length]
+            // and never overwrites already-written positions.
+            out_idx
         };
 
         // right-pad

--- a/src/tracks/mod.rs
+++ b/src/tracks/mod.rs
@@ -377,14 +377,14 @@ pub fn shift_and_realign_track_sparse(
     // Numba: unfilled_length = length - out_idx
     let unfilled_length = length as i64 - out_idx;
     if unfilled_length > 0 {
-        // Mirror Task 5 (reconstruct/mod.rs:212-238): when a deletion's v_rel_end
-        // runs past the track end, track_idx > track.len() and writable_ref goes
-        // negative. Numpy treats out[out_idx : out_idx + negative] as a no-op
-        // empty slice; the subsequent zero-pad starts from
-        // out_end_idx = (out_idx + writable_ref).max(0).
-        // We guard the copy loop and clamp out_end_idx to 0.
+        // When a deletion's v_rel_end runs past the track end, track_idx advances
+        // past track.len() and writable_ref becomes negative. The fixed numba kernel
+        // uses max(0, min(unfilled, len(track)-track_idx)), so writable_ref >= 0 and
+        // out_end_idx = out_idx. Mirror that: clamp out_end_idx to out_idx so the
+        // zero-pad fills exactly out[out_idx..length] without overwriting
+        // already-written positions (mirrors reconstruct/mod.rs:234-239).
         let writable_ref = unfilled_length.min(track.len() as i64 - track_idx);
-        // Positive: copy track bytes. Zero or negative: no-op (mirrors numpy empty-slice).
+        // Positive: copy track bytes. Zero or negative: track exhausted, no copy.
         let out_end_idx = if writable_ref > 0 {
             let oe = out_idx + writable_ref;
             let re = track_idx + writable_ref;
@@ -395,10 +395,11 @@ pub fn shift_and_realign_track_sparse(
             let _ = re; // ref_end_idx used only to bound the copy above
             oe
         } else {
-            // writable_ref <= 0: track exhausted or track_idx past end.
-            // out_end_idx = out_idx + writable_ref, clamped to 0 to stay in-bounds
-            // (matches numpy: `out[out_end_idx:]` where out_end_idx >= 0).
-            (out_idx + writable_ref).max(0)
+            // writable_ref <= 0: track exhausted (track_idx at/after track end).
+            // No track bytes remain to copy; zero-pad the entire unfilled tail
+            // out[out_idx..length]. Clamp to out_idx (NOT (out_idx+writable_ref).max(0))
+            // to avoid overwriting already-written positions.
+            out_idx
         };
         // Numba: if out_end_idx < length: out[out_end_idx:] = 0
         if out_end_idx < length as i64 {
@@ -1357,14 +1358,13 @@ mod tests {
         assert_eq!(result[3], 0.0f32, "trailing pad = 0.0");
     }
 
-    /// Deletion whose `v_rel_end` runs past track end — exercises the `writable_ref` clamp.
+    /// Deletion whose `v_rel_end` runs past track end — trailing pad starts from out_idx.
     ///
-    /// This is the edge case fixed by the Task-9 writable_ref clamp: when a deletion
-    /// is so large that `v_rel_end` exceeds `track_len`, `track_idx` advances past the
-    /// end of `track` after the main loop, so `track.len() - track_idx` is negative.
-    /// Without the clamp, `0..writable_ref as usize` would panic (negative-as-usize wrap).
-    /// With the clamp, out_end_idx = (out_idx + writable_ref).max(0), so the copy is
-    /// skipped and out[out_end_idx..] is zero-padded — matching numba's empty-slice no-op.
+    /// When a deletion is so large that `v_rel_end` exceeds `track_len`, `track_idx`
+    /// advances past the end of `track`, making `writable_ref` negative.  The fixed
+    /// kernel clamps `out_end_idx` to `out_idx` (matching the fixed numba kernel's
+    /// `max(0, min(unfilled, len(track)-track_idx))`), so the zero-pad covers exactly
+    /// `out[out_idx..length]` without overwriting already-written positions.
     ///
     /// Setup:
     ///   track = [1.0, 2.0, 3.0, 4.0, 5.0] (track_len=5), query_start=0, out_len=8
@@ -1372,31 +1372,15 @@ mod tests {
     ///   v_len = max(0,-3)+1 = 1
     ///
     /// Main loop:
-    ///   track_len (ref to copy before variant) = v_rel_pos - track_idx = 3 - 0 = 3
-    ///   out_idx + track_len = 0 + 3 = 3 < 8 → copy track[0..3] → out[0..3] = [1,2,3]
-    ///   out_idx = 3
-    ///   writable_length = min(1, 8-3) = 1
-    ///   deletion (v_diff < 0), REPEAT_5P: out[3] = track[v_rel_pos=3] = 4.0; out_idx=4
+    ///   copy track[0..3] → out[0..3] = [1,2,3]; out_idx=3
+    ///   deletion REPEAT_5P: out[3] = track[3] = 4.0; out_idx=4
     ///   track_idx = v_rel_end = 7  (past track end = 5!)
     ///
-    /// Trailing fill:
-    ///   unfilled_length = 8 - 4 = 4 > 0
-    ///   writable_ref = min(4, 5 - 7) = min(4, -2) = -2  (NEGATIVE)
-    ///   Clamp: out_end_idx = (4 + (-2)).max(0) = 2.max(0) = 2
-    ///   Zero-pad: out[2..8] — but wait, out_end_idx=2 < length=8
-    ///   So out[2..8] = 0.0; but out[0..4] are already written (3+1), and we zero-pad
-    ///   from out_end_idx=2 onward → out[2..8] = 0.0?
-    ///
-    ///   Wait — re-read: out_end_idx is computed relative to out_idx (=4), not absolute.
-    ///   out_end_idx = (out_idx + writable_ref).max(0) = (4 + (-2)).max(0) = 2
-    ///   out[out_end_idx..] = out[2..8] = 0.0 — this overwrites out[2] and out[3] too.
-    ///
-    ///   But numba's numpy semantics: `out[2:8] = 0` is exactly this: it zeros [2..8].
-    ///   So final out = [1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    ///
-    /// This matches numba exactly: out[0..3] from the copy, out[3] from REPEAT_5P = 4.0,
-    /// then trailing clamp zeros from out_end_idx=2 (which is 4 + -2 = 2 absolute) onward.
-    /// But out[2] was already 3.0 — numba would overwrite it with 0 too. ✓
+    /// Trailing fill (correct):
+    ///   writable_ref = min(4, 5-7) = -2  ← negative, no track bytes remain
+    ///   out_end_idx = out_idx = 4  (NOT (4 + -2).max(0) = 2)
+    ///   out[4..8] = 0.0
+    ///   Final: [1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0]
     #[test]
     fn test_singular_deletion_past_track_end() {
         // track_len=5, out_len=8, deletion at v_start=3 with ilen=-3
@@ -1424,18 +1408,67 @@ mod tests {
             0,
         );
 
-        // Verify: no panic (the primary goal of the clamp fix).
-        // out[0..3] = track[0..3] (ref before variant)
+        // out[0..4] from main loop; zero-pad covers out[4..8] from out_idx (not index 2).
         assert_eq!(result[0], 1.0f32, "ref[0]");
         assert_eq!(result[1], 2.0f32, "ref[1]");
-        // out_end_idx = (4 + -2).max(0) = 2 → zero-pad from index 2 onward
-        // (matches numba empty-slice no-op + right-pad from out_end_idx=2)
-        assert_eq!(result[2], 0.0f32, "zero-pad[2] (numba overwrites from out_end_idx=2)");
-        assert_eq!(result[3], 0.0f32, "zero-pad[3]");
+        assert_eq!(result[2], 3.0f32, "ref[2] — must NOT be overwritten by zero-pad");
+        assert_eq!(result[3], 4.0f32, "deletion REPEAT_5P value — must NOT be overwritten");
         assert_eq!(result[4], 0.0f32, "zero-pad[4]");
         assert_eq!(result[5], 0.0f32, "zero-pad[5]");
         assert_eq!(result[6], 0.0f32, "zero-pad[6]");
         assert_eq!(result[7], 0.0f32, "zero-pad[7]");
+    }
+
+    /// Deletion drives track_idx past the track end (overshoot) — trailing pad from out_idx.
+    ///
+    /// Mirrors ``overshoot_ref_past_contig`` from reconstruct/mod.rs.
+    /// When writable_ref <= 0, out_end_idx must be clamped to out_idx so that
+    /// out[out_idx..length] is zero-padded without overwriting already-written positions.
+    ///
+    /// The fixed numba kernel uses ``max(0, min(unfilled, len(track)-track_idx))``,
+    /// giving writable_ref=0 and out_end_idx=out_idx. The Rust kernel must match.
+    ///
+    /// Setup (identical to test_singular_deletion_past_track_end):
+    ///   track=[1,2,3,4,5] (len=5), out_len=8, deletion at v_start=3, ilen=-3
+    ///   v_rel_end=7 (>track_len=5) → track_idx advances past track end
+    ///   After main loop: out[0..4]=[1,2,3,4], out_idx=4, track_idx=7
+    ///
+    /// Trailing fill (correct):
+    ///   writable_ref = min(4, 5-7) = -2  ← negative
+    ///   out_end_idx = out_idx = 4  (NOT (4 + -2).max(0) = 2)
+    ///   out[4..8] = 0.0
+    ///   Expected: [1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0]
+    #[test]
+    fn overshoot_track_past_end() {
+        let track = [1.0f32, 2.0, 3.0, 4.0, 5.0];
+        let v_starts = [3i32];
+        let ilens = [-3i32];
+        let geno_v_idxs = [0i32];
+        let geno_offsets = [0i64, 1];
+
+        let result = run_singular(
+            &geno_v_idxs,
+            &geno_offsets,
+            0,
+            &v_starts,
+            &ilens,
+            0,
+            &track,
+            0,
+            8,
+            &[0.0],
+            None,
+            REPEAT_5P,
+            0,
+            0,
+            0,
+        );
+        // out[0..4] from main loop; out[4..8] zero-padded from out_idx (not index 2)
+        assert_eq!(
+            result,
+            [1.0f32, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0],
+            "overshoot: zero-pad must start from out_idx=4, not (out_idx+writable_ref).max(0)=2"
+        );
     }
 
     /// SNP (ilen=0) is SKIPPED — the output copies reference track straight through.

--- a/tests/parity/test_reconstruct_haplotypes_parity.py
+++ b/tests/parity/test_reconstruct_haplotypes_parity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from hypothesis import assume, given, settings
+from hypothesis import given, settings
 
 from genvarloader._dataset import _genotypes  # noqa: F401 — triggers register()
 from tests.parity.strategies import reconstruct_haplotypes_inputs
@@ -12,182 +12,19 @@ from tests.parity.strategies import reconstruct_haplotypes_inputs
 pytestmark = pytest.mark.parity
 
 
-def _ref_idx_overshoots_contig(inputs: tuple) -> bool:
-    """Return True if any (query, hap) pair drives ref_idx past the contig end.
-
-    WHY this is needed: when a deletion's ref_end exceeds the contig length, the
-    trailing-fill clause in reconstruct_haplotype_from_sparse computes a negative
-    writable_ref, leading to ``out_end_idx = out_idx + writable_ref < out_idx``.
-
-    Numba (njit) handles the subsequent ``out[out_end_idx:]`` fill via Python-style
-    negative-integer slice indexing (treating -k as len(out)-k), which preserves
-    already-written positions but may or may not pad trailing positions correctly.
-
-    Rust clamps ``out_end_idx`` to 0 (``(out_idx + writable_ref).max(0)``) and
-    pads from position 0 to the end, which overwrites already-written data.
-
-    Both behaviors are undefined for this degenerate input sub-domain (production
-    contracts guarantee variants lie within contig bounds). Numba and Rust diverge
-    here in a deterministic but non-trivially-comparable way, so these inputs are
-    excluded from the byte-identity parity domain via assume(False) — consistent
-    with the start>=clen / #242-family precedent.
-    """
-    (
-        _out_offsets,
-        regions,
-        _shifts,
-        geno_offset_idx,
-        geno_offsets,
-        geno_v_idxs,
-        v_starts,
-        ilens,
-        _alt_alleles,
-        _alt_offsets,
-        _reference,
-        ref_offsets,
-        _pad_char,
-        keep,
-        keep_offsets,
-        _annot_v,
-        _annot_rp,
-    ) = inputs
-
-    n_q, ploidy = geno_offset_idx.shape
-
-    for qi in range(n_q):
-        c_idx = int(regions[qi, 0])
-        ref_start = int(regions[qi, 1])
-        c_len = int(ref_offsets[c_idx + 1] - ref_offsets[c_idx])
-
-        for h in range(ploidy):
-            o_idx = int(geno_offset_idx[qi, h])
-            if geno_offsets.ndim == 1:
-                o_s = int(geno_offsets[o_idx])
-                o_e = int(geno_offsets[o_idx + 1])
-            else:
-                o_s = int(geno_offsets[0, o_idx])
-                o_e = int(geno_offsets[1, o_idx])
-
-            if o_s >= o_e:
-                continue
-
-            k_idx = qi * ploidy + h
-
-            # Simulate the ref_idx advancement through each variant.
-            ref_idx = ref_start
-            for vi in range(o_e - o_s):
-                # Apply keep mask if present.
-                if keep is not None and keep_offsets is not None:
-                    k_s = int(keep_offsets[k_idx])
-                    if not keep[k_s + vi]:
-                        continue
-
-                variant = int(geno_v_idxs[o_s + vi])
-                v_pos = int(v_starts[variant])
-                v_diff = int(ilens[variant])
-                v_ref_end = v_pos - min(0, v_diff) + 1
-
-                # Skip DEL spanning before ref_start.
-                if v_diff < 0 and v_pos < ref_start and v_ref_end >= ref_start:
-                    ref_idx = v_ref_end
-                    continue
-
-                if v_pos < ref_idx:
-                    continue
-
-                ref_idx = v_ref_end
-
-            # If ref_idx has advanced past the contig length, the trailing-fill
-            # clause will compute a negative out_end_idx. Numba and Rust handle
-            # that differently (negative-index wrap vs clamp to 0). Exclude.
-            if ref_idx > c_len:
-                return True
-
-    return False
-
-
-def _numba_fully_defined(
-    numba_fn,
-    args_a: list,
-    args_b: list,
-    buffers_a: list[np.ndarray],
-    buffers_b: list[np.ndarray],
-) -> bool:
-    """Return True iff numba fully wrote every output position.
-
-    Run the numba kernel twice: once with output buffer(s) pre-filled with
-    sentinel 0x00 (uint8) / 0 (int32), and once pre-filled with 0xFF (uint8)
-    / -1 (int32).  If any position differs between the two runs, numba left
-    that position unwritten — the sentinel value leaked through — and the
-    kernel is not a valid byte-identity oracle for this input.
-
-    WHY: when a deletion drives ref_idx past the contig end, numba's
-    trailing-fill clause may leave trailing output positions unwritten
-    (returning whatever sentinel was in the buffer).  The Rust kernel pads
-    those positions correctly with pad_char / annotation sentinels.  Numba
-    is not a valid oracle in this sub-domain, so these inputs are excluded
-    via assume(False) — consistent with the start>=clen / #242-family
-    precedent.
-    """
-    numba_fn(*args_a)
-    numba_fn(*args_b)
-    for buf_a, buf_b in zip(buffers_a, buffers_b):
-        if not np.array_equal(buf_a, buf_b):
-            return False
-    return True
-
-
 def _assert_non_annotated_parity(total_out: int, inputs: tuple) -> None:
     """Check that the out buffer is byte-identical between numba and Rust.
 
-    Three exclusion guards are applied so Hypothesis discards invalid inputs
-    rather than reporting test failures:
-
-    1. Overshoot pre-check — if any deletion drives ref_idx past the contig
-       end, numba and Rust handle the resulting negative out_end_idx
-       differently (negative-index wrap vs clamp to 0).  Both behaviors are
-       undefined for inputs outside the production contract; excluded via
-       assume(False).
-
-    2. SystemError guard — numba's parallel=True batch driver raises
-       SystemError on some inputs (negative slice index inside prange).
-
-    3. Double-init guard — numba leaves trailing positions unwritten when a
-       deletion drives ref_idx past the contig end (numba bug; Rust pads
-       correctly).  Detected by running numba twice with sentinel fills
-       0x00 vs 0xFF: any position that differs means numba did not write it.
-       Those inputs are discarded via assume(False).
+    Both kernels now fully write every output position (including the
+    trailing-fill overshoot sub-domain where a deletion drives ref_idx past
+    the contig end), so no exclusion guards are needed.
     """
     from genvarloader import _dispatch
 
     numba_fn, rust_fn = _dispatch.backends("reconstruct_haplotypes_from_sparse")
 
-    # Guard 1: exclude inputs where any deletion overshoots the contig end.
-    # Numba and Rust diverge on these (negative-index wrap vs clamp to 0)
-    # and both behaviors are undefined per the production contract.
-    assume(not _ref_idx_overshoots_contig(inputs))
-
-    # Build two sentinel-prefilled output buffers.
-    out_a = np.full(total_out, 0x00, dtype=np.uint8)
-    out_b = np.full(total_out, 0xFF, dtype=np.uint8)
-    args_a = [out_a] + list(inputs)
-    args_b = [out_b] + list(inputs)
-
-    # Guard 2: numba's parallel=True batch kernel has a pre-existing
-    # SystemError on some inputs (negative slice index inside prange).
-    try:
-        defined = _numba_fully_defined(numba_fn, args_a, args_b, [out_a], [out_b])
-    except SystemError:
-        assume(False)
-        return  # unreachable, but keeps type-checkers happy
-
-    # Guard 3: double-init divergence — numba left ≥1 position unwritten
-    # (deletion drove ref_idx past the contig end; numba returns uninitialized
-    # bytes, Rust pads correctly).  Discard from the parity domain.
-    assume(defined)
-
-    # Numba fully wrote the buffer — run Rust and compare byte-for-byte.
-    out_n = out_a  # already filled by first sentinel run
+    out_n = np.empty(total_out, dtype=np.uint8)
+    numba_fn(*([out_n] + list(inputs)))
 
     out_r = np.empty(total_out, dtype=np.uint8)
     rust_fn(*([out_r] + list(inputs)))
@@ -205,65 +42,18 @@ def test_reconstruct_haplotypes_non_annotated(args):
 def _assert_annotated_parity(total_out: int, inputs: tuple) -> None:
     """Check all three inplace buffers (out, annot_v_idxs, annot_ref_pos) match.
 
-    Three exclusion guards are applied so Hypothesis discards invalid inputs
-    rather than reporting test failures:
-
-    1. Overshoot pre-check — if any deletion drives ref_idx past the contig
-       end, numba and Rust handle the resulting negative out_end_idx
-       differently (negative-index wrap vs clamp to 0).  Both behaviors are
-       undefined for inputs outside the production contract; excluded via
-       assume(False).
-
-    2. SystemError guard — numba's parallel=True batch driver raises
-       SystemError on some annotated inputs (negative slice index in prange).
-
-    3. Double-init guard — numba leaves trailing positions unwritten when a
-       deletion drives ref_idx past the contig end (numba bug; Rust pads
-       correctly).  Detected by running numba twice with distinct sentinel
-       fills for each buffer:
-         out:           0x00 vs 0xFF  (uint8)
-         annot_v_idxs:  0    vs -1   (int32)
-         annot_ref_pos: 0    vs -1   (int32)
-       Any buffer position that differs between runs was not written by numba.
-       Those inputs are discarded via assume(False) — consistent with #242.
+    Both kernels now fully write every output position (including the
+    trailing-fill overshoot sub-domain), so no exclusion guards are needed.
     """
     from genvarloader import _dispatch
 
     numba_fn, rust_fn = _dispatch.backends("reconstruct_haplotypes_from_sparse")
 
-    # Guard 1: exclude inputs where any deletion overshoots the contig end.
-    assume(not _ref_idx_overshoots_contig(inputs))
+    out_n = np.empty(total_out, dtype=np.uint8)
+    av_n = np.empty(total_out, dtype=np.int32)
+    ap_n = np.empty(total_out, dtype=np.int32)
 
-    # Build sentinel-prefilled buffer pairs for the double-init check.
-    out_a = np.full(total_out, 0x00, dtype=np.uint8)
-    out_b = np.full(total_out, 0xFF, dtype=np.uint8)
-    av_a = np.full(total_out, 0, dtype=np.int32)
-    av_b = np.full(total_out, -1, dtype=np.int32)
-    ap_a = np.full(total_out, 0, dtype=np.int32)
-    ap_b = np.full(total_out, -1, dtype=np.int32)
-
-    args_a = [out_a] + list(inputs[:-2]) + [av_a, ap_a]
-    args_b = [out_b] + list(inputs[:-2]) + [av_b, ap_b]
-
-    # Guard 2: numba's parallel=True batch kernel has a pre-existing
-    # SystemError on some annotated inputs (negative slice index in prange).
-    try:
-        defined = _numba_fully_defined(
-            numba_fn,
-            args_a,
-            args_b,
-            [out_a, av_a, ap_a],
-            [out_b, av_b, ap_b],
-        )
-    except SystemError:
-        assume(False)
-        return  # unreachable, but keeps type-checkers happy
-
-    # Guard 3: double-init divergence — numba left ≥1 position unwritten.
-    assume(defined)
-
-    # Numba fully wrote all buffers — run Rust and compare byte-for-byte.
-    out_n, av_n, ap_n = out_a, av_a, ap_a  # already filled by first sentinel run
+    numba_fn(*([out_n] + list(inputs[:-2]) + [av_n, ap_n]))
 
     out_r = np.empty(total_out, dtype=np.uint8)
     av_r = np.empty(total_out, dtype=np.int32)

--- a/tests/parity/test_shift_and_realign_tracks_parity.py
+++ b/tests/parity/test_shift_and_realign_tracks_parity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from hypothesis import assume, given, settings
+from hypothesis import given, settings
 
 from genvarloader._dataset import _tracks  # noqa: F401 — triggers register()
 from tests.parity.strategies import shift_and_realign_tracks_inputs
@@ -15,36 +15,19 @@ pytestmark = pytest.mark.parity
 def _assert_parity(total_out: int, inputs: tuple) -> None:
     """Check that the out buffer is byte-identical between numba and Rust.
 
-    The numba parallel=True batch driver has a known SystemError for certain
-    inputs (negative slice index inside prange, same root cause as the
-    haplotype reconstruct kernel). We skip those inputs via ``assume(False)``
-    so Hypothesis discards them rather than reporting a test failure.
+    Both kernels now fully write every output position (including the
+    trailing-fill overshoot sub-domain where a deletion drives track_idx past
+    the track end), so no exclusion guards are needed.
     """
     from genvarloader import _dispatch
 
     numba_fn, rust_fn = _dispatch.backends("shift_and_realign_tracks_sparse")
 
-    def run_numba():
-        out = np.zeros(total_out, np.float32)
-        args_list = [out] + list(inputs)
-        try:
-            numba_fn(*args_list)
-        except SystemError:
-            return None
-        return out
+    out_n = np.zeros(total_out, np.float32)
+    numba_fn(*([out_n] + list(inputs)))
 
-    def run_rust():
-        out = np.zeros(total_out, np.float32)
-        args_list = [out] + list(inputs)
-        rust_fn(*args_list)
-        return out
-
-    out_n = run_numba()
-    if out_n is None:
-        assume(False)
-        return  # unreachable, keeps type-checkers happy
-
-    out_r = run_rust()
+    out_r = np.zeros(total_out, np.float32)
+    rust_fn(*([out_r] + list(inputs)))
 
     np.testing.assert_array_equal(out_n, out_r, err_msg="out mismatch (tracks)")
 

--- a/tests/unit/dataset/test_reconstruct_trailing_fill.py
+++ b/tests/unit/dataset/test_reconstruct_trailing_fill.py
@@ -1,0 +1,29 @@
+"""Correctness of the trailing-fill clause when a deletion exhausts the contig.
+
+The overshoot sub-domain (ref_idx past contig end with output unfilled) was
+historically excluded from parity because numba and rust diverged AND both were
+wrong. Correct behavior: pad the entire unfilled tail (no reference left).
+"""
+
+import numpy as np
+
+from genvarloader._dataset._genotypes import reconstruct_haplotype_from_sparse
+
+
+def test_overshoot_pads_full_tail():
+    # ref=[1,2,3,4], deletion at pos 2 (ilen=-5) -> ref_idx advances to 8 (>4).
+    # out_len=8: [1,2] ref + [50] allele, then ref exhausted -> pad rest with 0.
+    out = np.full(8, 255, dtype=np.uint8)  # 0xFF sentinel: catches unwritten positions
+    reconstruct_haplotype_from_sparse(
+        np.array([0], dtype=np.int32),        # v_idxs
+        np.array([2], dtype=np.int32),        # v_starts
+        np.array([-5], dtype=np.int32),       # ilens
+        0,                                    # shift
+        np.array([50], dtype=np.uint8),       # alt_alleles
+        np.array([0, 1], dtype=np.int64),     # alt_offsets
+        np.array([1, 2, 3, 4], dtype=np.uint8),  # ref
+        0,                                    # ref_start
+        out,                                  # out
+        0,                                    # pad_char
+    )
+    np.testing.assert_array_equal(out, np.array([1, 2, 50, 0, 0, 0, 0, 0], dtype=np.uint8))

--- a/tests/unit/dataset/test_reconstruct_trailing_fill.py
+++ b/tests/unit/dataset/test_reconstruct_trailing_fill.py
@@ -15,15 +15,17 @@ def test_overshoot_pads_full_tail():
     # out_len=8: [1,2] ref + [50] allele, then ref exhausted -> pad rest with 0.
     out = np.full(8, 255, dtype=np.uint8)  # 0xFF sentinel: catches unwritten positions
     reconstruct_haplotype_from_sparse(
-        np.array([0], dtype=np.int32),        # v_idxs
-        np.array([2], dtype=np.int32),        # v_starts
-        np.array([-5], dtype=np.int32),       # ilens
-        0,                                    # shift
-        np.array([50], dtype=np.uint8),       # alt_alleles
-        np.array([0, 1], dtype=np.int64),     # alt_offsets
+        np.array([0], dtype=np.int32),  # v_idxs
+        np.array([2], dtype=np.int32),  # v_starts
+        np.array([-5], dtype=np.int32),  # ilens
+        0,  # shift
+        np.array([50], dtype=np.uint8),  # alt_alleles
+        np.array([0, 1], dtype=np.int64),  # alt_offsets
         np.array([1, 2, 3, 4], dtype=np.uint8),  # ref
-        0,                                    # ref_start
-        out,                                  # out
-        0,                                    # pad_char
+        0,  # ref_start
+        out,  # out
+        0,  # pad_char
     )
-    np.testing.assert_array_equal(out, np.array([1, 2, 50, 0, 0, 0, 0, 0], dtype=np.uint8))
+    np.testing.assert_array_equal(
+        out, np.array([1, 2, 50, 0, 0, 0, 0, 0], dtype=np.uint8)
+    )


### PR DESCRIPTION
Closes the trailing-fill **overshoot** divergence tracked in #255 — Phase 5 W1 of the Rust migration.

## Problem

When a deletion drives the reconstruction index past the contig/track end (`v_ref_end > contig_len`), the trailing-fill clause was wrong in **both** backends, and the sub-domain was excluded from the differential-parity oracle, masking it:

- **Rust** (`reconstruct/mod.rs`, `tracks/mod.rs`): `out_end_idx = (out_idx + writable_ref).max(0)` could be `< out_idx`, so the right-pad **overwrote the already-written prefix** → all zeros.
- **Numba** (`_genotypes.py`, `_tracks.py`): `writable_ref = min(unfilled_length, len(ref) - ref_idx)` went **negative** → numpy negative-index slice → unwritten tail / `ValueError` inside the njit kernel.

Neither was correct — a "fix both" per the numba-oracle-bug policy.

## Fix

Pad exactly the unfilled tail `out[out_idx..length]`, never the prefix:
- Rust else-branch returns `out_idx` (not `.max(0)`).
- Numba: `writable_ref = max(0, min(unfilled_length, len(ref|track) - idx))`.

Applied consistently to all four kernels (rust + numba × haplotype + track). The rust **track** kernel had the same latent bug (the plan only asked to verify) — found and fixed with a new cargo test.

## Parity gates

Removed the three overshoot-family exclusion guards (`_ref_idx_overshoots_contig`, `try/except SystemError`, `_numba_fully_defined` double-init) from `test_reconstruct_haplotypes_parity.py` and the `SystemError` guard from `test_shift_and_realign_tracks_parity.py`. The overshoot sub-domain is now first-class parity-covered. The separate #242 / `max_jitter` exclusions are **left intact** (W2's scope).

## Verification (against a freshly rebuilt extension)

- Full tree, rust backend: **993 passed / 12 skipped / 5 xfailed / 0 failed**
- Parity subset `tests/dataset tests/unit tests/parity` — rust 709/6/2 == numba 709/6/2 (identical profiles → byte-identical parity)
- New: cargo `overshoot_ref_past_contig`, cargo `overshoot_track_past_end`, pytest `test_reconstruct_trailing_fill.py`
- Cargo: 114 passed. ruff check/format, pyrefly typecheck: clean.

## Commits (no squash — preserve history)

1. `test(reconstruct)` — failing cargo test pinning correct full-tail-pad (TDD red)
2. `fix(reconstruct)` — rust haplotype clamp to `out_idx`
3. `fix(reconstruct,tracks)` — numba haplotype + track `max(0, ...)` clamp
4. `test(parity)` — un-exclude overshoot sub-domain; fix rust track kernel + cargo test
5. `style` — ruff-format the new test file
6. `docs(roadmap)` + `docs` — record W1, link #255, document the maturin-rebuild gotcha

> **Note:** Phase 5 remains 🚧 — W2–W9 still to come. Do not squash on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)