### PR TITLE
test+docs: close out #242 with max_jitter>0 dataset-parity coverage (Phase 5 W2)

### DIFF
--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -743,6 +743,27 @@ narrowed to genoray (variant IO) only.
 
 ## Notes & decisions log
 
+- 2026-06-26 (Phase 5 W2 — #242 stale landmine comments corrected + max_jitter>0 parity gate; branch `phase-5-w2`):
+  Investigation (`.superpowers/sdd/w2-investigation.md`) confirmed that #242 was already
+  root-caused and fully fixed end-to-end: both ``intervals_to_tracks`` kernels (Rust and
+  numba) apply the left-clip ``s = max(itv.start - query_start, 0); e = min(end, length)``
+  merged via PR #244 (ancestor of ``rust-migration``); #242 is CLOSED. The clip is
+  functionally correct — the stored jitter-expanded write window always fully covers any
+  jittered query of the original region length, so the clip never truncates real signal.
+  The upstream coordinate rewrite (storing intervals at ``chromStart`` rather than
+  ``chromStart - max_jitter``) was intentionally SKIPPED: the clip is the correct fix, not
+  a mask over a remaining defect. W2 added the end-to-end max_jitter>0 numba-vs-rust
+  dataset parity test with a hand-computed oracle
+  (``test_tracks_max_jitter_intervals_parity_and_oracle``, Task 1, commit ``5d3aa7d``).
+  W2 also corrected three stale "PanicException landmine" / "violates the contract" comment
+  blocks in ``tests/parity/_fixtures.py`` (``build_haps_tracks_dataset`` and
+  ``build_strand_mixed_dataset`` docstrings + inline comment) and
+  ``tests/parity/test_dataset_parity.py``
+  (``test_tracks_realign_getitem_identical_across_backends`` fixture-geometry note): the
+  accurate framing is that #242 is fixed and ``max_jitter=0`` in those fixtures is retained
+  only for the simplest deterministic geometry, not because of any live panic. Phase 5 🚧
+  (W3–W9 remain).
+
 - 2026-06-26 (Phase 5 W1 — trailing-fill overshoot fix + parity gate; branch `phase-5-w1`):
   Fixed the trailing-fill overshoot divergence in **all four kernels** that advance `ref_idx`
   past the contig end (deletion whose `v_ref_end > contig_len`):

--- a/docs/superpowers/plans/2026-06-26-rust-migration-phase-5-w2.md
+++ b/docs/superpowers/plans/2026-06-26-rust-migration-phase-5-w2.md
@@ -1,0 +1,67 @@
+# Rust Migration Phase 5 — PR2 (W2): close out #242 with max_jitter>0 dataset-parity coverage
+
+> **For agentic workers:** executed via superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** The #242 `intervals_to_tracks` store-vs-query divergence was already root-caused and FIXED end-to-end (kernel left-clip `s = max(itv.start - query_start, 0); e = min(end, length)` in both backends, merged via PR #244, ancestor of `rust-migration`; issue #242 CLOSED). The investigation (`.superpowers/sdd/w2-investigation.md`) showed the clip is functionally CORRECT, not merely masking. The ONLY residue is that the dataset-level parity suite still pins `max_jitter=0` with **stale** "PanicException landmine" comments, so numba-vs-rust byte-identity is not gated end-to-end over the jittered-track domain. This PR adds that coverage with a hand-computed oracle and de-stales the comments. **No kernel/write-path changes** (user decision: skip the unnecessary upstream coordinate rewrite).
+
+**Branch:** `phase-5-w2`, stacked on `phase-5-w1` (so roadmap edits don't conflict with the open W1 PR #256).
+
+## Global Constraints
+
+- Byte-identical numba/rust parity is the gate. Test work only — do NOT touch `_intervals.py`, `src/intervals.rs`, the write path, or any kernel.
+- The new dataset-parity case MUST be deterministic across backends: write with `max_jitter > 0` but READ at the default `jitter = 0` (a freshly opened dataset has `jitter=0`, `Deterministic: True`, even when `max_jitter>0`). Random read-jitter would desync the two backend reads — do not enable it.
+- The case MUST genuinely exercise the #242 condition: assert that a stored interval start is strictly LESS than its query start (i.e. `regions.npy` expanded start `< input_regions.arrow` original chromStart) for the fixture, so the test is non-vacuous.
+- Backend switching follows the established pattern in `tests/parity/test_dataset_parity.py`: `monkeypatch.setenv("GVL_BACKEND", "rust"|"numba")` then re-read.
+- pytest commands MUST include `--basetemp=$(pwd)/.pytest_tmp` (os.link Errno 18 otherwise). Rust changes need `maturin develop --release` first — but this PR has NO rust changes.
+- Conventional commits; co-author trailer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+## Empirically verified facts (from the W2 investigation probe)
+- For region chromStart=100, max_jitter=4: `regions.npy[:, :3] = [[0, 96, 114]]`; `input_regions.arrow` chromStart = 100; default `ds.jitter = 0`.
+- Track-only dataset, constant-5.0 BigWig over chr1:[0,1000), region chr1:100-110, max_jitter=4, jitter=0 read → both backends return `[5.]*10` byte-identically; deterministic across re-reads. Stored start 96 < query 100 (condition hit).
+
+---
+
+## Task 1: Add track-only max_jitter>0 dataset-parity + oracle test
+
+**Files:**
+- Modify: `tests/parity/_fixtures.py` — add a `build_track_dataset_jittered(work_dir, max_jitter)` builder: a track-only dataset with a CONTROLLED BigWig (deterministic, hand-computable signal) and `max_jitter > 0`. Reuse the existing `build_track_dataset` pattern but (a) take `max_jitter` and (b) use a BigWig whose signal over each region is exactly known (e.g. a constant value per contig, or a known piecewise-constant pattern) so the expected painted track is hand-computable.
+- Modify: `tests/parity/test_dataset_parity.py` — add `test_tracks_max_jitter_intervals_parity_and_oracle`.
+
+**Test requirements (the new test):**
+- [ ] Build the jittered track-only dataset with `max_jitter = 4` (or similar > 0).
+- [ ] **Non-vacuity / condition guard:** load `regions.npy` and `input_regions.arrow`; assert at least one stored region start (`regions.npy[:,1]`) is strictly `<` the corresponding original `chromStart` (proves the #242 sub-query condition is exercised). Assert `ds.jitter == 0` after open (deterministic read).
+- [ ] Open `Dataset.open(ds_dir).with_tracks("signal")`. Read `ds[:, :]` under `GVL_BACKEND=rust`, then under `GVL_BACKEND=numba`.
+- [ ] **Byte-identity:** `assert_array_equal` on both track `.data` (float32) and `.offsets` (int64) across backends.
+- [ ] **Hand-computed oracle:** for each (region, sample), the expected track is the known BigWig signal over the ORIGINAL region window `[chromStart, chromEnd)` (jitter=0). Assert the rust output equals this oracle exactly. Keep the BigWig signal simple enough to compute in the test (e.g. constant per contig, or a single known interval covering each region).
+- [ ] **Non-triviality:** assert some output value is non-zero (not a vacuous all-zero match).
+
+- [ ] **Step 1 (TDD-ish):** Write the test. It PASSES on the current (fixed) tree — this is regression coverage for a previously-untested domain, not red→green. The non-vacuity guard (stored start < query start + correct nonzero oracle) is the evidence it would have caught the pre-fix bug (which over-padded/wrapped on exactly this condition).
+- [ ] **Step 2:** Run: `pixi run -e dev pytest tests/parity/test_dataset_parity.py::test_tracks_max_jitter_intervals_parity_and_oracle -v --basetemp=$(pwd)/.pytest_tmp`. Expected PASS, both backends compared, oracle matched.
+- [ ] **Step 3:** Commit.
+  ```
+  test(parity): cover max_jitter>0 intervals_to_tracks end-to-end (numba==rust + oracle, #242)
+  ```
+
+## Task 2: De-stale the landmine comments + roadmap + full verification
+
+**Files:**
+- Modify: `tests/parity/_fixtures.py` — fix the stale "PanicException landmine" docstrings on `build_haps_tracks_dataset` and `build_strand_mixed_dataset`. The `max_jitter=0` there is now retained ONLY because those fixtures compare `ds[:,:]` across backends and want the SIMPLEST deterministic geometry — NOT because of any panic (the kernel left-clip fixed #242, PR #244). Rewrite the comment to state the accurate reason and point to the new `test_tracks_max_jitter_intervals_parity_and_oracle` for the max_jitter>0 coverage. Do NOT change `max_jitter=0` in those builders (lifting them would desync nothing since jitter defaults to 0, but it would change output-length geometry and is out of scope — leave the values, fix only the comments).
+- Modify: `tests/parity/test_dataset_parity.py` — fix the identical stale landmine comment block in `test_tracks_realign_getitem_identical_across_backends` (lines ~150-156).
+- Modify: `docs/roadmaps/rust-migration.md` — add a dated Phase 5 W2 entry: #242 was already fixed (clip, PR #244) and is now end-to-end parity-covered at max_jitter>0 (new test); the stale landmine comments were corrected; #242 stays CLOSED; the upstream coordinate rewrite was intentionally skipped (clip is functionally correct per the W2 investigation). Phase 5 stays 🚧 (W3–W9 remain). Reference `.superpowers/sdd/w2-investigation.md`.
+
+- [ ] **Step 1:** Rewrite the three stale comment blocks accurately (no "PanicException"/"landmine"/"violates the contract" language implying a live bug).
+- [ ] **Step 2:** Add the roadmap W2 entry.
+- [ ] **Step 3:** Full parity suite, both backends:
+  - `pixi run -e dev pytest tests/parity -q --basetemp=$(pwd)/.pytest_tmp`
+  - `GVL_BACKEND=numba pixi run -e dev pytest tests/parity -q --basetemp=$(pwd)/.pytest_tmp`
+  Expected: green, matching profiles.
+- [ ] **Step 4:** Lint + typecheck: `pixi run -e dev ruff check python/ tests/ && pixi run -e dev ruff format --check python/ tests/ && pixi run -e dev typecheck`. (No rust → cargo not required, but harmless.)
+- [ ] **Step 5:** Commit.
+  ```
+  docs(parity,roadmap): correct stale #242 landmine comments; record W2 closure
+  ```
+
+---
+
+## Finish (controller, after final review + user confirm)
+- Open PR `phase-5-w2` → base `phase-5-w1` (stacked) OR `rust-migration` if W1 has merged by then. No squash. Reference #242 (keep closed) + the W2 investigation.

--- a/tests/parity/_fixtures.py
+++ b/tests/parity/_fixtures.py
@@ -16,6 +16,76 @@ _SESSION_CONTIGS = {"chr1": 1_300_000, "chr2": 1_300_000}
 _SESSION_SAMPLES = ["s0", "s1", "s2"]
 
 
+# Contigs and samples for the jittered-track fixture (§242 regression coverage).
+_JITTER_CONTIGS = {"chr21": 200_000, "chr22": 150_000}
+_JITTER_SAMPLES = ["s0", "s1", "s2"]
+# Constant BigWig signal value per sample: s0→1.0, s1→2.0, s2→3.0.
+# Hand-computable: for any region [start, end), sample j yields [j+1.0] * (end-start).
+_JITTER_SIGNAL_PER_SAMPLE: dict[str, float] = {
+    s: float(i + 1) for i, s in enumerate(_JITTER_SAMPLES)
+}
+
+
+def build_track_dataset_jittered(work_dir: Path, max_jitter: int) -> Path:
+    """Write a track-only GVL dataset with ``max_jitter > 0`` for #242 parity coverage.
+
+    Signal design
+    -------------
+    Each sample has a SINGLE constant BigWig interval covering the ENTIRE contig
+    (s0=1.0, s1=2.0, s2=3.0).  Any read window is fully covered, so the expected
+    track over any region [start, end) with jitter=0 is just the per-sample constant
+    repeated for ``(end - start)`` positions — trivially hand-computable.
+
+    #242 condition
+    --------------
+    ``gvl.write`` clips BigWig intervals to the jitter-EXPANDED window
+    ``[chromStart - max_jitter, chromEnd + max_jitter]``, so the stored interval
+    start is ``chromStart - max_jitter < chromStart``.  ``Dataset.open`` queries
+    at the ORIGINAL ``chromStart``.  This means ``itv.start < query_start`` — the
+    exact boundary condition that PR #244 fixed in both kernels.
+
+    Regions are placed well inside contig bounds so the expanded write window
+    ``[chromStart - max_jitter, chromEnd + max_jitter]`` never underflows (all
+    chromStarts ≥ 1000, so expanded start ≥ 996 ≥ 0 for max_jitter ≤ 1000).
+    """
+    import polars as pl
+
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    bw_dir = work_dir / "bw"
+    bw_dir.mkdir(exist_ok=True)
+
+    header = [(c, length) for c, length in _JITTER_CONTIGS.items()]
+    sample_to_bw: dict[str, str] = {}
+    for sample, value in _JITTER_SIGNAL_PER_SAMPLE.items():
+        bw_path = bw_dir / f"{sample}.bw"
+        with pyBigWig.open(str(bw_path), "w") as bw:
+            bw.addHeader(header, maxZooms=0)
+            for contig, length in _JITTER_CONTIGS.items():
+                # Single interval covering the entire contig → constant signal everywhere.
+                bw.addEntries([contig], [0], ends=[int(length)], values=[float(value)])
+        sample_to_bw[sample] = str(bw_path)
+
+    track = gvl.BigWigs("signal", sample_to_bw)
+
+    # Three regions spanning two contigs, already in natural sort order
+    # (chr21 before chr22, ascending chromStart within contig).  This keeps
+    # regions.npy and input_regions.arrow in the same row order so the
+    # r_idx_map alignment in the test is trivially [0, 1, 2].
+    bed = pl.DataFrame(
+        {
+            "chrom": ["chr21", "chr21", "chr22"],
+            "chromStart": [1000, 5000, 1000],
+            "chromEnd": [1020, 5020, 1020],
+        }
+    )
+
+    out = work_dir / "jittered_ds.gvl"
+    gvl.write(path=out, bed=bed, tracks=track, max_jitter=max_jitter, overwrite=True)
+    return out
+
+
 def build_track_dataset(work_dir: Path) -> Path:
     """Write a small track-only GVL dataset and return its path.
 

--- a/tests/parity/_fixtures.py
+++ b/tests/parity/_fixtures.py
@@ -163,8 +163,13 @@ def build_strand_mixed_dataset(work_dir: Path, svar_path: Path) -> Path:
     sequence so the non-vacuity assertion in
     ``test_negative_strand_actually_reverse_complements`` reliably fires.
 
-    ``max_jitter=0`` satisfies the ``intervals_to_tracks`` Rust kernel contract
-    (stored interval starts must equal the query region starts).
+    ``max_jitter=0`` is used here for the simplest deterministic geometry (no
+    jitter expansion, so stored interval starts equal query starts).  The #242
+    boundary condition (stored interval starts preceding the query start) was
+    fixed in both ``intervals_to_tracks`` kernels via the left-clip
+    ``s = max(itv.start - query_start, 0)`` (PR #244; #242 CLOSED).
+    End-to-end max_jitter>0 parity is covered by
+    ``test_tracks_max_jitter_intervals_parity_and_oracle``.
     """
     from genoray import SparseVar
     import polars as pl
@@ -204,25 +209,22 @@ def build_haps_tracks_dataset(work_dir: Path, svar_path: Path) -> Path:
     Uses the caller-supplied SparseVar file (which must cover chr1/chr2
     with samples s0/s1/s2, as produced by the session-level build_case
     fixture).  Synthetic BigWig tracks are written with matching samples
-    and contigs.  The dataset is written with **max_jitter=0** to ensure
-    that stored interval starts always equal the region query starts,
-    satisfying the ``intervals_to_tracks`` Rust contract
-    (``itv_start >= query_start``).
+    and contigs.  The dataset is written with **max_jitter=0** for the
+    simplest deterministic geometry: no jitter expansion, so stored
+    interval starts equal the query starts.  This keeps the fixture
+    focused on what it exists to test — variants (including indels) that
+    trigger ``shift_and_realign_tracks_sparse``.
 
-    Background on the landmine
-    --------------------------
-    When ``max_jitter > 0``, ``gvl.write`` / ``gvl.update`` clip BigWig
-    intervals to the jitter-**expanded** boundaries stored in
-    ``regions.npy`` (``chromStart - max_jitter``).  But
-    ``Dataset.open`` derives ``_full_regions`` from the **original**
-    ``input_regions.arrow`` boundaries (``chromStart``).  The gap of
-    ``max_jitter`` bp means stored interval starts are
-    ``chromStart - max_jitter < chromStart = query_start``, which
-    violates the contract and triggers a ``PanicException`` in the Rust
-    ``intervals_to_tracks`` kernel.  Setting ``max_jitter=0`` eliminates
-    the gap.  The variants (including indels) still trigger
-    ``shift_and_realign_tracks_sparse``, which is what this fixture exists
-    to test.
+    #242 / PR #244
+    --------------
+    The boundary condition where stored interval starts precede the query
+    start (``itv.start < query_start``) was root-caused and fixed in both
+    ``intervals_to_tracks`` kernels via the left-clip
+    ``s = max(itv.start - query_start, 0)`` (PR #244; #242 CLOSED).
+    ``max_jitter=0`` here is retained only for the simplest deterministic
+    geometry, not because of any live panic or contract violation.
+    End-to-end max_jitter>0 parity is covered by
+    ``test_tracks_max_jitter_intervals_parity_and_oracle``.
 
     Returns the path to the written dataset directory.
     """
@@ -263,8 +265,11 @@ def build_haps_tracks_dataset(work_dir: Path, svar_path: Path) -> Path:
     )
 
     out = work_dir / "ds.gvl"
-    # max_jitter=0: no jitter expansion → interval starts == query starts
-    # → the intervals_to_tracks Rust contract is satisfied.
+    # max_jitter=0: simplest deterministic geometry (no jitter expansion).
+    # #242 is fixed via the intervals_to_tracks left-clip (PR #244, #242 CLOSED);
+    # max_jitter=0 here keeps interval starts == query starts for straightforward
+    # indel-realignment testing. See test_tracks_max_jitter_intervals_parity_and_oracle
+    # for max_jitter>0 end-to-end parity coverage.
     gvl.write(
         path=out,
         bed=bed,

--- a/tests/parity/test_dataset_parity.py
+++ b/tests/parity/test_dataset_parity.py
@@ -29,9 +29,11 @@ import numpy as np
 import pytest
 
 from tests.parity._fixtures import (
+    _JITTER_SIGNAL_PER_SAMPLE,
     build_haps_tracks_dataset,
     build_strand_mixed_dataset,
     build_track_dataset,
+    build_track_dataset_jittered,
 )
 
 pytestmark = pytest.mark.parity
@@ -117,6 +119,136 @@ def test_track_getitem_identical_across_backends(tmp_path, monkeypatch):
     assert np.any(data_n != 0.0), (
         "Track data is all-zero — regions may not overlap synthetic intervals. "
         "Non-zero signal is required to prove the comparison is meaningful."
+    )
+
+
+# ---------------------------------------------------------------------------
+# max_jitter > 0 end-to-end parity + oracle (#242 regression)
+# ---------------------------------------------------------------------------
+
+
+def test_tracks_max_jitter_intervals_parity_and_oracle(tmp_path, monkeypatch):
+    """End-to-end regression for #242: max_jitter>0 track reads are byte-identical
+    across backends and match the hand-computed oracle.
+
+    Bug #242 root cause
+    -------------------
+    ``gvl.write`` clips BigWig intervals to the jitter-expanded write window
+    ``[chromStart - max_jitter, chromEnd + max_jitter]``, so stored interval
+    starts equal ``chromStart - max_jitter``.  ``Dataset.open`` derives query
+    starts from the ORIGINAL ``chromStart`` (``input_regions.arrow``), so
+    ``itv_start - query_start = -max_jitter`` — a negative offset.
+    Fix (PR #244): both kernels now clip ``s = max(itv_start - query_start, 0)``.
+
+    Guards
+    ------
+    - **Non-vacuity**: at least one ``regions.npy[:,1]`` (stored start) is
+      strictly ``<`` the corresponding ``input_regions.arrow`` chromStart
+      (original start), proving the #242 boundary condition is exercised.
+    - **Byte-identity**: numba and rust produce identical ``.data`` and
+      ``.offsets`` for the whole dataset read.
+    - **Positional oracle**: each individual (region, sample) track SLICE
+      exactly equals ``np.full(REGION_LEN, sample_constant)`` — catches sample
+      misordering / spatial misplacement that a count-based check would miss.
+    - **Non-triviality**: at least one output value is non-zero.
+    """
+    import polars as pl
+
+    import genvarloader as gvl
+
+    MAX_JITTER = 4
+    REGION_LEN = 20   # chromEnd - chromStart for every fixture region
+    N_REGIONS = 3
+    N_SAMPLES = 3     # s0, s1, s2
+
+    ds_dir = build_track_dataset_jittered(tmp_path, max_jitter=MAX_JITTER)
+
+    # --- Non-vacuity guard: stored start < original chromStart (#242 condition) ---
+    # regions.npy[:,1] = chromStart - max_jitter (expanded at write time).
+    # input_regions.arrow chromStart = original un-expanded chromStart.
+    # r_idx_map[i] = sorted position (row in regions.npy) of original input row i.
+    regions = np.load(ds_dir / "regions.npy")        # shape (N_REGIONS, 4), int32
+    input_bed = pl.read_ipc(ds_dir / "input_regions.arrow")
+    r_idx_map = input_bed["r_idx_map"].to_numpy()     # original_row → sorted_pos
+    orig_starts = input_bed["chromStart"].to_numpy()
+    stored_starts_aligned = regions[r_idx_map, 1]     # stored starts per original row
+    assert np.any(stored_starts_aligned < orig_starts), (
+        "Non-vacuity guard FAILED: no stored region start is < the original chromStart. "
+        f"stored (aligned)={stored_starts_aligned.tolist()}, orig={orig_starts.tolist()}. "
+        "The max_jitter expansion is not exercising the #242 boundary condition."
+    )
+
+    # --- Open dataset; assert default jitter == 0 (deterministic read) ---
+    ds = gvl.Dataset.open(ds_dir)
+    ds = ds.with_tracks("signal")
+    assert ds.jitter == 0, (
+        f"Expected ds.jitter == 0 after Dataset.open (deterministic default), "
+        f"got {ds.jitter}."
+    )
+
+    # --- Backend reads (rust FIRST — rust is the oracle-reference output) ---
+    monkeypatch.setenv("GVL_BACKEND", "rust")
+    result_rust = ds[:, :]
+    rust_t = result_rust[1] if isinstance(result_rust, tuple) else result_rust
+    data_r = np.asarray(rust_t.data, dtype=np.float32)
+    off_r = np.asarray(rust_t.offsets, dtype=np.int64)
+
+    monkeypatch.setenv("GVL_BACKEND", "numba")
+    result_numba = ds[:, :]
+    numba_t = result_numba[1] if isinstance(result_numba, tuple) else result_numba
+    data_n = np.asarray(numba_t.data, dtype=np.float32)
+    off_n = np.asarray(numba_t.offsets, dtype=np.int64)
+
+    # --- Byte-identical comparison ---
+    np.testing.assert_array_equal(
+        off_n, off_r, err_msg="track offsets differ across backends"
+    )
+    assert data_n.dtype == data_r.dtype == np.float32, (
+        f"dtype mismatch: numba={data_n.dtype}, rust={data_r.dtype}"
+    )
+    np.testing.assert_array_equal(
+        data_n, data_r, err_msg="track data differs across backends"
+    )
+
+    # --- Positional, hand-computed oracle ---
+    # Each sample has a single constant BigWig interval [0, contig_len) at a
+    # distinct value (s0=1.0, s1=2.0, s2=3.0).  With jitter=0 every read window
+    # [chromStart, chromStart+REGION_LEN) is fully covered, so each (region,
+    # sample) slice is exactly REGION_LEN copies of the sample's constant.
+    #
+    # ds[:, :] returns a Ragged of shape (n_regions, n_samples, n_tracks=1, None);
+    # the leading dims flatten in C-order, so with one track the flat row index
+    # is `region * N_SAMPLES + sample` (verified against .offsets / .shape).
+    sample_consts = [np.float32(v) for v in _JITTER_SIGNAL_PER_SAMPLE.values()]
+    assert off_r.size - 1 == N_REGIONS * N_SAMPLES, (
+        f"Expected {N_REGIONS * N_SAMPLES} track rows, got {off_r.size - 1}; "
+        "the (region, sample) layout assumption is wrong."
+    )
+    for region in range(N_REGIONS):
+        for sample in range(N_SAMPLES):
+            row = region * N_SAMPLES + sample
+            seg = data_r[off_r[row] : off_r[row + 1]]
+            expected = np.full(REGION_LEN, sample_consts[sample], dtype=np.float32)
+            np.testing.assert_array_equal(
+                seg,
+                expected,
+                err_msg=(
+                    f"Positional oracle mismatch at region {region}, sample "
+                    f"{sample} (row {row}): expected constant "
+                    f"{sample_consts[sample]} over {REGION_LEN} positions."
+                ),
+            )
+
+    # Total output size = N_REGIONS × N_SAMPLES × REGION_LEN
+    total_expected = N_REGIONS * N_SAMPLES * REGION_LEN  # 3 × 3 × 20 = 180
+    assert data_r.size == total_expected, (
+        f"Output data size {data_r.size} != expected {total_expected} "
+        f"({N_REGIONS} regions × {N_SAMPLES} samples × {REGION_LEN} positions)."
+    )
+
+    # --- Non-triviality ---
+    assert np.any(data_r != 0.0), (
+        "All track values are 0.0 — constant BigWig signal is not reaching the output."
     )
 
 

--- a/tests/parity/test_dataset_parity.py
+++ b/tests/parity/test_dataset_parity.py
@@ -157,9 +157,9 @@ def test_tracks_max_jitter_intervals_parity_and_oracle(tmp_path, monkeypatch):
     import genvarloader as gvl
 
     MAX_JITTER = 4
-    REGION_LEN = 20   # chromEnd - chromStart for every fixture region
+    REGION_LEN = 20  # chromEnd - chromStart for every fixture region
     N_REGIONS = 3
-    N_SAMPLES = 3     # s0, s1, s2
+    N_SAMPLES = 3  # s0, s1, s2
 
     ds_dir = build_track_dataset_jittered(tmp_path, max_jitter=MAX_JITTER)
 
@@ -167,11 +167,11 @@ def test_tracks_max_jitter_intervals_parity_and_oracle(tmp_path, monkeypatch):
     # regions.npy[:,1] = chromStart - max_jitter (expanded at write time).
     # input_regions.arrow chromStart = original un-expanded chromStart.
     # r_idx_map[i] = sorted position (row in regions.npy) of original input row i.
-    regions = np.load(ds_dir / "regions.npy")        # shape (N_REGIONS, 4), int32
+    regions = np.load(ds_dir / "regions.npy")  # shape (N_REGIONS, 4), int32
     input_bed = pl.read_ipc(ds_dir / "input_regions.arrow")
-    r_idx_map = input_bed["r_idx_map"].to_numpy()     # original_row → sorted_pos
+    r_idx_map = input_bed["r_idx_map"].to_numpy()  # original_row → sorted_pos
     orig_starts = input_bed["chromStart"].to_numpy()
-    stored_starts_aligned = regions[r_idx_map, 1]     # stored starts per original row
+    stored_starts_aligned = regions[r_idx_map, 1]  # stored starts per original row
     assert np.any(stored_starts_aligned < orig_starts), (
         "Non-vacuity guard FAILED: no stored region start is < the original chromStart. "
         f"stored (aligned)={stored_starts_aligned.tolist()}, orig={orig_starts.tolist()}. "
@@ -279,13 +279,13 @@ def test_tracks_realign_getitem_identical_across_backends(
     - A fresh GVL dataset is built in tmp_path via gvl.write with both the
       session SparseVar variants (which contain indels on chr1/chr2) and a
       synthetic BigWig ``signal`` track for samples s0/s1/s2.
-    - max_jitter=0 is used to avoid the pre-existing intervals_to_tracks
-      landmine: with max_jitter>0, gvl.write clips BigWig intervals to the
-      jitter-expanded region boundaries (chromStart - max_jitter), but
-      Dataset.open derives _full_regions from the original chromStart.  The
-      gap of max_jitter bp causes stored interval starts to precede the
-      query start, violating the Rust kernel contract and triggering a
-      PanicException.  With max_jitter=0 the boundaries match exactly.
+    - max_jitter=0 is used for the simplest deterministic geometry.  Bug
+      #242 (stored interval starts < query start when max_jitter>0) was
+      fixed in both ``intervals_to_tracks`` kernels via the left-clip
+      ``s = max(itv_start - query_start, 0)`` (PR #244; #242 CLOSED).
+      max_jitter=0 here keeps interval starts == query starts so the test
+      stays focused on the indel-realignment path; max_jitter>0 end-to-end
+      parity is covered by ``test_tracks_max_jitter_intervals_parity_and_oracle``.
 
     Fill strategies covered: all 5 (Repeat5p, Repeat5pNormalized, Constant,
     FlankSample, Interpolate).  Each is set via with_insertion_fill and the


### PR DESCRIPTION
Phase 5 W2 of the Rust migration. **Test + docs only — no production code changes.**

## Background

Issue #242 (`intervals_to_tracks` store-vs-query divergence: BigWig intervals stored at the jitter-expanded boundary `chromStart − max_jitter` but the read path queries at original `chromStart`, so `itv.start < query_start`) was already root-caused and **fixed** by the kernel left-clip `s = max(itv.start − query_start, 0); e = min(end, length)` in both backends (merged via PR #244, ancestor of `rust-migration`; #242 closed).

A systematic-debugging investigation (`.superpowers/sdd/w2-investigation.md`) confirmed that clip is **functionally correct, not merely masking**: the stored jitter-expanded interval window `[chromStart−max_jitter, chromEnd+max_jitter]` always covers any jittered query window `[chromStart+j, chromEnd+j]` (|j|≤max_jitter) of the original length, so clipping restricts the paint to exactly the query window — reproducing the issue author's own hand-computed oracle. The upstream coordinate rewrite is therefore **intentionally skipped**.

## What this PR does

The only residue was that the dataset-level parity suite still pinned `max_jitter=0` with stale "PanicException landmine" comments, so numba-vs-rust byte-identity was never gated end-to-end over the jittered-track domain.

- **New `test_tracks_max_jitter_intervals_parity_and_oracle`** (`tests/parity/test_dataset_parity.py`): writes a track-only dataset at `max_jitter=4`, reads deterministically at the default `jitter=0`, and asserts:
  - **non-vacuity** — a stored region start (96) is strictly `<` its query start (100), proving the #242 sub-query condition is exercised;
  - `ds.jitter == 0` (deterministic read across backends);
  - **byte-identity** between `GVL_BACKEND=rust` and `numba` on track `.data` (float32) and `.offsets` (int64);
  - a **positional hand-computed oracle** — each region×sample slice equals its constant signal (`[1.0]/[2.0]/[3.0]` per sample);
  - non-triviality.
  Plus a new `build_track_dataset_jittered` fixture (`tests/parity/_fixtures.py`).
- **Corrected the stale comments** in `_fixtures.py` and `test_dataset_parity.py` — the panic was fixed; `max_jitter=0` is retained in those existing fixtures only for the simplest deterministic geometry, not because of any live bug.
- **Roadmap** W2 entry recording the investigation outcome + the deliberate skip. Phase 5 stays 🚧 (W3–W9 remain).

## Verification

- `tests/parity` both backends: rust 78 / numba 78 (matching, +1 from the new test).
- ruff check/format + pyrefly typecheck: clean. No rust changes.

## Commits (no squash)
1. `docs` — W2 plan (reduced scope)
2. `test(parity)` — max_jitter>0 end-to-end parity + positional oracle
3. `docs(parity,roadmap)` — correct stale #242 comments; record W2 closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)