### PR TITLE
fix(deps): bump genoray to Windows-compatible rev (fixes release pipeline)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "genoray"
 version = "0.1.0"
-source = "git+https://github.com/d-laub/genoray.git?rev=4ec0216bdaae0ac34212f07c13e60355d320ad74#4ec0216bdaae0ac34212f07c13e60355d320ad74"
+source = "git+https://github.com/d-laub/genoray.git?rev=66ba734b85fcf1326008d66b33c052c7cf278a9f#66ba734b85fcf1326008d66b33c052c7cf278a9f"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -1478,7 +1478,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "svar2-codec"
 version = "0.1.0"
-source = "git+https://github.com/d-laub/genoray.git?rev=4ec0216bdaae0ac34212f07c13e60355d320ad74#4ec0216bdaae0ac34212f07c13e60355d320ad74"
+source = "git+https://github.com/d-laub/genoray.git?rev=66ba734b85fcf1326008d66b33c052c7cf278a9f#66ba734b85fcf1326008d66b33c052c7cf278a9f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ seqpro-core = "0.1"
 # genoray crates are pulled straight from GitHub (no crates.io publish). Cargo finds
 # each package by name inside the repo — no in-repo path is given or needed. Bump `rev`
 # to pull newer genoray code; both crates must share the same rev (one clone, one repo).
-svar2-codec = { git = "https://github.com/d-laub/genoray.git", rev = "4ec0216bdaae0ac34212f07c13e60355d320ad74" }
-genoray_core = { git = "https://github.com/d-laub/genoray.git", rev = "4ec0216bdaae0ac34212f07c13e60355d320ad74", package = "genoray", default-features = false }
+svar2-codec = { git = "https://github.com/d-laub/genoray.git", rev = "66ba734b85fcf1326008d66b33c052c7cf278a9f" }
+genoray_core = { git = "https://github.com/d-laub/genoray.git", rev = "66ba734b85fcf1326008d66b33c052c7cf278a9f", package = "genoray", default-features = false }
 
 [features]
 extension-module = ["pyo3/extension-module"]


### PR DESCRIPTION
## Problem

The **release pipeline is failing** — the `publish / windows` jobs (arm64, x86, x64) all fail at "Build wheels". The pinned genoray rev (`4ec0216`) introduced the svar2 `LongAlleleReader` in `genoray/src/nrvk.rs`, which uses `std::os::unix::fs::FileExt::read_exact_at` — Unix-only. Windows compilation fails with:

```
error[E0433]: cannot find `unix` in `os`            (use std::os::unix::fs::FileExt;)
error[E0599]: no method named `read_exact_at` ...   (two call sites)
error: could not compile `genoray` (lib)
```

Every non-Windows target built fine; Windows wheels had shipped without issue until the svar2 codec landed, so this is a regression, not an intentional platform drop.

## Fix

Bump the pinned genoray rev (both `svar2-codec` and `genoray_core`) from `4ec0216` → `66ba734`, which makes the long-allele positioned reads cross-platform (Unix `read_exact_at`, Windows `seek_read` loop). See **d-laub/genoray#112**.

## Verification

- `cargo check --lib --target x86_64-pc-windows-gnu` (with `PYO3_CROSS`) — **previously reproduced the exact CI errors; now builds clean** (`Finished`).
- Native `cargo check --lib` — still builds clean.
- Cargo.lock updated to the new rev.

## Merge order

Merge **d-laub/genoray#112** first (the fix commit `66ba734` is already this branch's pinned rev, so it stays valid after a merge-commit merge). Then merge this PR and re-run the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)