### PR TITLE
Reconcile: merge main into streaming (#281 + coordination docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,7 @@ All work on the write-free `StreamingDataset` effort (anything touching `python/
 
 - **Check the project board first** — it is the source of truth for what is in flight, sequencing (waves), and status. Don't start a piece of streaming work without a tracking issue on the board.
 - **File streaming issues with a `streaming:` title prefix and add them to the StreamingDataset project** (in addition to a `type:` label). Split-out and follow-up issues (e.g. deferred sub-tasks, bugs found in review) go on the board too, cross-linked to their parent.
-- **Open streaming PRs against the stack** described in the project, keep the "Closes/relates to #…" references accurate, and add the PR to the project.
+- **Target the long-lived `streaming` integration branch, not `main`.** Streaming PRs merge into `streaming` (keep the "Closes/relates to #…" references accurate and add the PR to the project). `streaming` accumulates the effort and merges into `main` as one integrated PR at milestone boundaries; periodically merge `main` into `streaming` to keep divergence small. This keeps `main`'s PR queue to a single streaming-facing PR instead of a deep stack.
 - `docs/roadmaps/streaming-dataset.md` holds the technical sequencing (plans/specs tables); the project board holds live status. Keep the two in sync — when a roadmap task splits or its status changes, reflect it on the board and vice versa.
 
 ## Development Notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,15 @@ The auto-generated `docs/source/changelog.md` (built from commit messages via `c
 
 Any task that mentions "rust" (adding or porting Rust code, touching `src/`, or migrating numba/Python hot paths) **must** read `docs/roadmaps/rust-migration.md` before starting and update it as part of the work — tick completed tasks, record measurement results under the relevant checkpoint, and set the phase status marker (⬜/🚧/✅) + PR link. The roadmap is the source of truth for migration sequencing and the byte-identical parity contract.
 
+## Streaming dataset work
+
+All work on the write-free `StreamingDataset` effort (anything touching `python/genvarloader/_dataset/_streaming.py`, `src/stream/`, the SVAR1/SVAR2/VCF/PGEN `StreamBackend` path, or the double-buffer engine) is coordinated through the **StreamingDataset** GitHub Project (`mcvickerlab/GenVarLoader`). Before starting streaming work:
+
+- **Check the project board first** — it is the source of truth for what is in flight, sequencing (waves), and status. Don't start a piece of streaming work without a tracking issue on the board.
+- **File streaming issues with a `streaming:` title prefix and add them to the StreamingDataset project** (in addition to a `type:` label). Split-out and follow-up issues (e.g. deferred sub-tasks, bugs found in review) go on the board too, cross-linked to their parent.
+- **Open streaming PRs against the stack** described in the project, keep the "Closes/relates to #…" references accurate, and add the PR to the project.
+- `docs/roadmaps/streaming-dataset.md` holds the technical sequencing (plans/specs tables); the project board holds live status. Keep the two in sync — when a roadmap task splits or its status changes, reflect it on the board and vice versa.
+
 ## Development Notes
 
 - **Pixi environments**: Use `-e dev` for development, `-e docs` for documentation, `-e py310`/`py311`/`py312`/`py313` for Python version testing. Platform is linux-64.

--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -827,6 +827,13 @@ as a Rust path-dep, the first place gvl's Rust crate depends on genoray's Rust c
       `test_svar2_dataset.py::test_svar2_flanksample_multicontig_matches_svar1`.
 - [x] var_fields → .svar2 store INFO/FORMAT field routing (plan
       2026-07-12-svar2-info-format-field-routing.md).
+- [x] Spliced exonic haplotype output (moved off the guard-matrix list above): read-bound spliced
+      haplotypes are now supported (`Svar2Haps.__call__` splice branch), landed in two steps —
+      #272 (`feat(svar2): support spliced exonic haplotypes` + a vectorized per-row slice/concatenate
+      re-order replacing a byte-level fancy-index gather) and #273 (scatter-write: the kernel now
+      writes each row directly at its final spliced address, deleting the Python re-order pass
+      entirely). Byte-identical to SVAR1 including a new multi-contig scattered-destination
+      regression test. See the 2026-07-16 decisions-log entry below for the perf numbers.
 - [x] Docs/skill audit (this task): `skills/genvarloader/SKILL.md`, `docs/source/{write,format,faq}.md`,
       `README.md`; `api.md` ↔ `__all__` gate confirmed clean (no new public symbol — `svar2=` is a
       parameter, not an exported name).
@@ -897,6 +904,49 @@ conversion/write paths.
 ---
 
 ## Notes & decisions log
+
+- 2026-07-16 (Phase 6a follow-up — SVAR2 spliced haplotype scatter-write; issue
+  [#273](https://github.com/mcvickerlab/GenVarLoader/issues/273); branch
+  `worktree-spike+svar2-splice-profile`; PR: _not yet opened — controller opens after final
+  review_): SVAR2 spliced haplotype reads (added on top of Phase 6a by #272,
+  `feat(svar2): support spliced exonic haplotypes`) now write kernel output directly at each
+  element's final spliced address instead of reconstructing in region order and re-ordering the
+  output bytes in Python afterward — the same "permute metadata, not bytes" trick SVAR1's fused
+  spliced kernel already uses. #272 first replaced a byte-level fancy-index re-order with a
+  per-row slice + `np.concatenate` (189 ms → 23 ms on the chr22 165-transcript × 5-sample
+  benchmark below); a follow-up spike (2026-07-16) profiled the remainder and found the
+  concatenate itself (`_ragged_arange_gather`) was **13.7 ms of the still-remaining 10.2 ms
+  svar2-vs-svar1 gap** — ~9× the memcpy floor for the same 13.2 MB, i.e. per-row numpy dispatch
+  overhead across 6600 rows, not bandwidth. #273 deletes that pass: the Rust core now takes
+  per-row `(start, end)` `out_bounds` instead of a gap-free offsets array (the parallel carve
+  sorts by ascending start so it tolerates gaps from interleaved contig-group destinations), a
+  new out-param FFI entry (`reconstruct_haplotypes_from_svar2_readbound_into`) scatters each
+  contig group straight into one shared Python-allocated buffer and skips the diffs sizing pass
+  entirely (sizes come from the bounds), and RC is folded into the same call via
+  `rc_bounded_rows_inplace`. Byte-identical to SVAR1: existing spliced parity suite plus a new
+  multi-contig regression test (`test_svar2_spliced_haplotypes_match_svar1_multicontig`) — the
+  chr22 benchmark and prior spliced tests are single-contig and never exercised
+  scattered/gapped destinations, which only a multi-contig splice produces.
+
+  **Perf (same-session minimums, both backends in one process,
+  `tests/benchmarks/test_e2e_svar_splice.py`, pytest-benchmark, chr22 165 transcripts × 5
+  samples × ploidy 2, Carter HPC):**
+
+  | Measurement | svar1 min (ms) | svar2 min (ms) | svar2 ÷ svar1 |
+  |---|---|---|---|
+  | Before (spike baseline, 2026-07-16, min of 25 reps) | 25.15 | 35.33 | 1.41× (slower) |
+  | After this change — run 1 | 23.5821 | 16.7493 | **0.71×** (faster) |
+  | After this change — run 2 | 23.4241 | 16.7050 | **0.71×** (faster) |
+
+  Target was ≈1.0× or better (projection ≈0.8×, ~20 ms); the measured result **beats the
+  projection** — svar2 spliced reads are now ~30% *faster* than svar1's minimum, not merely at
+  parity. Two consecutive runs agree closely (svar2 min 16.70–16.75 ms, svar1 min 23.42–23.58 ms),
+  both parity tests (`test_svar1_svar2_spliced_parity`) passing. Deliberately left unmeasured
+  post-change and out of scope (spec §4): the spliced path's double gather (once to size the
+  plan, once to reconstruct; ~3.44 ms pre-change) — flagged only as a follow-up *if* post-change
+  numbers didn't meet target; since the result already beats target, no follow-up is filed.
+  Spec/plan: `docs/superpowers/specs/2026-07-16-svar2-spliced-scatter-write-design.md`,
+  `docs/superpowers/plans/2026-07-16-svar2-spliced-scatter-write.md`.
 
 - 2026-07-13 (Phase 6a — issue [#267](https://github.com/mcvickerlab/GenVarLoader/issues/267)
   multi-contig `FlankSample` fill-seed; branch `svar2-m6b-kernel`): lifted the last read-path guard.

--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -915,9 +915,13 @@ conversion/write paths.
   spliced kernel already uses. #272 first replaced a byte-level fancy-index re-order with a
   per-row slice + `np.concatenate` (189 ms → 23 ms on the chr22 165-transcript × 5-sample
   benchmark below); a follow-up spike (2026-07-16) profiled the remainder and found the
-  concatenate itself (`_ragged_arange_gather`) was **13.7 ms of the still-remaining 10.2 ms
-  svar2-vs-svar1 gap** — ~9× the memcpy floor for the same 13.2 MB, i.e. per-row numpy dispatch
-  overhead across 6600 rows, not bandwidth. #273 deletes that pass: the Rust core now takes
+  concatenate itself (`_ragged_arange_gather`) was **13.7 ms — bigger than the still-remaining
+  10.2 ms svar2-vs-svar1 gap it's a part of.** (Segment and total are each independent
+  minimums-over-reps on a noisy shared node, not a decomposition of one rep, so a sub-segment's
+  minimum can exceed the total's; the substantive point is that this one pass alone cost more
+  than the entire measured gap.) That's ~9× the memcpy floor for the same 13.2 MB, i.e. per-row
+  numpy dispatch overhead across 6600 rows, not bandwidth. #273 deletes that pass: the Rust core
+  now takes
   per-row `(start, end)` `out_bounds` instead of a gap-free offsets array (the parallel carve
   sorts by ascending start so it tolerates gaps from interleaved contig-group destinations), a
   new out-param FFI entry (`reconstruct_haplotypes_from_svar2_readbound_into`) scatters each

--- a/docs/roadmaps/rust-migration.md
+++ b/docs/roadmaps/rust-migration.md
@@ -907,8 +907,8 @@ conversion/write paths.
 
 - 2026-07-16 (Phase 6a follow-up — SVAR2 spliced haplotype scatter-write; issue
   [#273](https://github.com/mcvickerlab/GenVarLoader/issues/273); branch
-  `worktree-spike+svar2-splice-profile`; PR: _not yet opened — controller opens after final
-  review_): SVAR2 spliced haplotype reads (added on top of Phase 6a by #272,
+  `worktree-spike+svar2-splice-profile`; PR
+  [#281](https://github.com/mcvickerlab/GenVarLoader/pull/281)): SVAR2 spliced haplotype reads (added on top of Phase 6a by #272,
   `feat(svar2): support spliced exonic haplotypes`) now write kernel output directly at each
   element's final spliced address instead of reconstructing in region order and re-ordering the
   output bytes in Python afterward — the same "permute metadata, not bytes" trick SVAR1's fused

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -64,6 +64,19 @@
 # Changelog
 
 
+# Changelog
+
+
+## v0.38.0 (2026-07-16)
+
+### Feat
+
+- **svar2**: support spliced exonic haplotypes
+
+### Perf
+
+- **svar2**: vectorize spliced haplotype row reorder
+
 ## v0.37.0 (2026-07-15)
 
 ### BREAKING CHANGE

--- a/docs/superpowers/plans/2026-07-16-svar2-spliced-scatter-write.md
+++ b/docs/superpowers/plans/2026-07-16-svar2-spliced-scatter-write.md
@@ -1,0 +1,950 @@
+# SVAR2 Spliced Scatter-Write Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Parallelism:** Tasks 1, 2, and 3 are independent (different files, no shared symbols) — dispatch them concurrently with superpowers:dispatching-parallel-agents. Task 4 needs 1+2. Task 5 needs 3+4. Task 6 needs 5. Use Sonnet or weaker for implementation.
+>
+> **Spec:** `docs/superpowers/specs/2026-07-16-svar2-spliced-scatter-write-design.md` · **Issue:** #273
+
+**Goal:** Make SVAR2 spliced haplotype reads write kernel output directly into final spliced positions, deleting the 13.7 ms Python re-order pass.
+
+**Architecture:** SVAR1's "fused" spliced kernel permutes *metadata* (O(rows)) rather than *bytes* and hands the kernel `permuted_out_offsets`. SVAR2 can't reuse that directly because it calls the kernel once per contig group, so a group's rows land at non-contiguous destinations. We generalize the SVAR2 core from a gap-free `out_offsets` array to explicit per-row `(start, end)` bounds, and add an out-param FFI entry so every contig group scatters into one shared, Python-allocated buffer.
+
+**Tech Stack:** Rust (PyO3, ndarray, rayon) + Python (numpy), pixi, maturin.
+
+## Global Constraints
+
+- **Byte-identity is the contract.** Output must stay byte-identical to SVAR1 and to the current SVAR2 path. See `docs/roadmaps/rust-migration.md`.
+- **Rebuild the extension before running any Python test:** `pixi run -e dev maturin develop --release`. `pytest` does NOT rebuild; it silently imports the stale `.so` and would validate the old binary.
+- **Run the full tree before pushing** (`pixi run -e dev pytest tests -q`), not just `tests/dataset` — shared code changes and `tests/unit/` is skipped by scoped runs.
+- **Lint covers both trees:** `pixi run -e dev ruff check python/ tests/` and `pixi run -e dev typecheck`.
+- **Cargo tests need libpython on the loader path:** `export LD_LIBRARY_PATH=$PWD/.pixi/envs/dev/lib:$LD_LIBRARY_PATH` or the test binary can't load libpython.
+- **prek hooks must be installed** before committing: `prek install`. First commit is slow (hook env build) — allow ~2 min.
+- Conventional commits (commitizen `check` runs as a hook).
+- Do NOT touch the unspliced path, `_assemble_haps`, annotated haps, tracks, or variants splicing.
+
+---
+
+### Task 1: Generalize the SVAR2 core to per-row destination bounds
+
+The core currently derives each row's output range from a gap-free offsets array (`(out_offsets[k], out_offsets[k+1])`). That makes interleaved destinations unrepresentable. Replace it with explicit `(start, end)` bounds per row.
+
+The parallel path carves disjoint `&mut [u8]` chunks with a `split_at_mut` chain that walks a cursor forward, so it requires rows in **ascending start order**. It already tolerates *gaps* (it skips `s - cursor` bytes) — the only thing tying it to contiguity is that bounds come from an offsets array. Since a contig group's rows arrive in query order but scatter to non-monotonic destinations, sort row indices by start before carving (~6600 rows → tens of µs, negligible).
+
+**Files:**
+- Modify: `src/reconstruct/mod.rs:616-802` (`reconstruct_haplotypes_from_svar2` signature + both dispatch paths)
+- Modify: `src/ffi/mod.rs:893` and `src/ffi/mod.rs:1085` (the two callers)
+- Modify: `src/reconstruct/mod.rs:1570`, `:1622` (two existing tests)
+- Test: `src/reconstruct/mod.rs` (`mod tests`, ~line 805)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `pub fn reconstruct_haplotypes_from_svar2(out: ArrayViewMut1<u8>, out_bounds: ArrayView2<i64>, regions: ArrayView2<i32>, shifts: ArrayView2<i32>, vk_pos: ArrayView1<i32>, vk_key: ArrayView1<i32>, vk_off: ArrayView1<i64>, dense_pos: ArrayView1<i32>, dense_key: ArrayView1<i32>, dense_range: ArrayView2<i32>, dense_present: ArrayView1<u8>, dense_present_off: ArrayView1<i64>, lut_bytes: ArrayView1<u8>, lut_off: ArrayView1<i64>, ref_: ArrayView1<u8>, ref_offsets: ArrayView1<i64>, pad_char: u8, parallel: bool, filter_exonic: bool)` — `out_bounds` is `(n_work, 2)`; `n_work = out_bounds.nrows()` (no longer `regions.nrows() * shifts.ncols()`).
+  - `pub fn bounds_from_offsets(out_offsets: ArrayView1<i64>) -> Array2<i64>`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `src/reconstruct/mod.rs`. This is the case a single-contig test can never reach: two rows whose destinations are interleaved with a gap between them, written out of order.
+
+```rust
+/// Scatter write: rows given non-monotonic, gapped destinations must land exactly
+/// where `out_bounds` says, leaving the gap untouched. Row 0 is written AFTER
+/// row 1 in the buffer, mirroring a multi-contig spliced read where one group's
+/// rows interleave with another's.
+#[test]
+fn svar2_scatter_write_honors_out_bounds() {
+    for parallel in [false, true] {
+        let reference = b"ACGT";
+        let ref_ = arr1(reference.as_ref());
+        let ref_offsets = arr1(&[0i64, 4]);
+        // Two identical single-hap queries on contig 0.
+        let regions = ndarray::arr2(&[[0i32, 0, 4], [0i32, 0, 4]]);
+        let shifts = ndarray::arr2(&[[0i32], [0i32]]);
+
+        // No variants at all -> each row is the bare reference "ACGT".
+        let vk_pos = arr1::<i32>(&[]);
+        let vk_key = arr1::<i32>(&[]);
+        let vk_off = arr1(&[0i64, 0, 0]);
+        let dense_pos = arr1::<i32>(&[]);
+        let dense_key = arr1::<i32>(&[]);
+        let dense_range = ndarray::arr2(&[[0i32, 0], [0i32, 0]]);
+        let dense_present = arr1::<u8>(&[]);
+        let dense_present_off = arr1(&[0i64, 0, 0]);
+        let lut_bytes = arr1::<u8>(&[]);
+        let lut_off = arr1(&[0i64]);
+
+        let pad_char = b'N';
+        // Buffer: [row1 @ 0..4][gap 4..6 = another group's rows][row0 @ 6..10]
+        let mut out = Array1::<u8>::from_elem(10, b'-');
+        let out_bounds = ndarray::arr2(&[[6i64, 10], [0i64, 4]]);
+
+        super::reconstruct_haplotypes_from_svar2(
+            out.view_mut(),
+            out_bounds.view(),
+            regions.view(),
+            shifts.view(),
+            vk_pos.view(),
+            vk_key.view(),
+            vk_off.view(),
+            dense_pos.view(),
+            dense_key.view(),
+            dense_range.view(),
+            dense_present.view(),
+            dense_present_off.view(),
+            lut_bytes.view(),
+            lut_off.view(),
+            ref_.view(),
+            ref_offsets.view(),
+            pad_char,
+            parallel,
+            false,
+        );
+
+        assert_eq!(
+            out.as_slice().unwrap(),
+            b"ACGT--ACGT",
+            "parallel={parallel}: rows must land at their out_bounds, gap untouched"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+export LD_LIBRARY_PATH=$PWD/.pixi/envs/dev/lib:$LD_LIBRARY_PATH
+cargo test svar2_scatter_write_honors_out_bounds 2>&1 | tail -20
+```
+Expected: FAIL to compile — `reconstruct_haplotypes_from_svar2` takes `ArrayView1<i64>`, got `ArrayView2<i64>`.
+
+- [ ] **Step 3: Change the core signature and both dispatch paths**
+
+In `src/reconstruct/mod.rs`, change the parameter (line ~618) from `out_offsets: ArrayView1<i64>` to `out_bounds: ArrayView2<i64>`.
+
+Then at lines ~637-639, which currently read:
+
+```rust
+    let batch_size = regions.nrows();
+    let ploidy = shifts.ncols();
+    let n_work = batch_size * ploidy;
+```
+
+**Keep the `batch_size` and `ploidy` bindings** — `ploidy` is used by `do_work` (`k / ploidy`, `k % ploidy`) and removing it breaks the closure. Replace only the `n_work` line:
+
+```rust
+    let batch_size = regions.nrows();
+    let ploidy = shifts.ncols();
+    // n_work comes from out_bounds: the caller owns the row->destination mapping.
+    let n_work = out_bounds.nrows();
+    debug_assert_eq!(
+        n_work,
+        batch_size * ploidy,
+        "out_bounds must have one row per (query, hap)"
+    );
+```
+
+Replace the parallel carve block (the `if parallel {` branch, lines ~740-777) with:
+
+```rust
+    if parallel {
+        // Build disjoint per-k mutable slices for all active buffers using the
+        // proven split_at_mut chain idiom (mirrors get_reference in reference/mod.rs).
+        // &mut [_] slices are Send, unlike raw *mut pointers — safe for rayon closures.
+        let bounds: Vec<(usize, usize)> = (0..n_work)
+            .map(|k| (out_bounds[[k, 0]] as usize, out_bounds[[k, 1]] as usize))
+            .collect();
+
+        // Destinations are caller-supplied and may be scattered (a spliced read
+        // interleaves this contig group's rows with other groups'), so carve in
+        // ascending-start order rather than row order. The chain's cursor only
+        // moves forward; gaps are bytes owned by another call and are skipped.
+        let mut order: Vec<usize> = (0..n_work).collect();
+        order.sort_unstable_by_key(|&k| bounds[k].0);
+
+        let out_slice = out.as_slice_mut().unwrap();
+        let mut out_chunks: Vec<(usize, &mut [u8])> = Vec::with_capacity(n_work);
+        {
+            let mut rest = &mut out_slice[..];
+            let mut cursor = 0usize;
+            for &k in &order {
+                let (s, e) = bounds[k];
+                // Contract: `out_bounds` rows are pairwise disjoint. Walking them in
+                // ascending-start order then guarantees `s - cursor` does not
+                // underflow and the carved slices are disjoint.
+                debug_assert!(
+                    s >= cursor && e >= s,
+                    "out_bounds must be pairwise disjoint and non-empty (got s={s}, e={e}, cursor={cursor})"
+                );
+                let (_, tail) = rest.split_at_mut(s - cursor);
+                let (mid, tail2) = tail.split_at_mut(e - s);
+                out_chunks.push((k, mid));
+                rest = tail2;
+                cursor = e;
+            }
+        }
+
+        // SVAR2 read-bound haps are never annotated, so dispatch the un-annotated
+        // work items straight across rayon.
+        out_chunks.into_par_iter().for_each(|(k, out_chunk)| {
+            do_work(k, ArrayViewMut1::from(out_chunk));
+        });
+    } else {
+```
+
+Replace the serial loop body (lines ~783-799) with:
+
+```rust
+        for k in 0..n_work {
+            let out_s = out_bounds[[k, 0]] as usize;
+            let out_e = out_bounds[[k, 1]] as usize;
+            debug_assert!(
+                out_e >= out_s,
+                "out_bounds rows must be non-empty (got out_s={out_s}, out_e={out_e})"
+            );
+
+            // SAFETY: `out_bounds` rows are required by the calling contract to be
+            // pairwise disjoint address ranges within the same allocation. Because the
+            // loop is serial there are no concurrent borrows, so constructing a
+            // `&mut [u8]` from each disjoint sub-range is free of aliasing UB.
+            let out_chunk =
+                unsafe { std::slice::from_raw_parts_mut(out_raw.add(out_s), out_e - out_s) };
+            do_work(k, ArrayViewMut1::from(out_chunk));
+        }
+```
+
+- [ ] **Step 4: Add the offsets→bounds helper**
+
+Add near `reconstruct_haplotypes_from_svar2` in `src/reconstruct/mod.rs`:
+
+```rust
+/// Per-row `(start, end)` destination bounds from a gap-free `(n_work + 1,)` offsets
+/// array — the adapter for callers that let the kernel size its own contiguous output.
+pub fn bounds_from_offsets(out_offsets: ArrayView1<i64>) -> Array2<i64> {
+    let n = out_offsets.len() - 1;
+    let mut bounds = Array2::<i64>::zeros((n, 2));
+    for k in 0..n {
+        bounds[[k, 0]] = out_offsets[k];
+        bounds[[k, 1]] = out_offsets[k + 1];
+    }
+    bounds
+}
+```
+
+Ensure `Array2` is imported in that module (`use ndarray::{Array2, ...}`); add it to the existing `use` if missing.
+
+- [ ] **Step 5: Update the two FFI callers**
+
+In `src/ffi/mod.rs` at line ~893 (union path) and line ~1085 (read-bound path), both currently pass `out_offsets_vec.view()`. Change each to pass bounds. Insert before each call:
+
+```rust
+        let out_bounds = reconstruct::bounds_from_offsets(out_offsets_vec.view());
+```
+
+and change the argument `out_offsets_vec.view(),` to `out_bounds.view(),`.
+
+- [ ] **Step 6: Update the two existing core tests**
+
+In `src/reconstruct/mod.rs` at lines ~1567 and ~1618, replace:
+
+```rust
+        let out_offsets = arr1(&[0i64, 8]);
+```
+with
+```rust
+        let out_bounds = ndarray::arr2(&[[0i64, 8]]);
+```
+(and `arr1(&[0i64, 4])` → `ndarray::arr2(&[[0i64, 4]])` in the second test), then change each call's `out_offsets.view(),` argument to `out_bounds.view(),`.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+export LD_LIBRARY_PATH=$PWD/.pixi/envs/dev/lib:$LD_LIBRARY_PATH
+cargo test 2>&1 | tail -20
+```
+Expected: PASS, including `svar2_scatter_write_honors_out_bounds` and both pre-existing `svar2_*` tests. All 125 cargo tests green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/reconstruct/mod.rs src/ffi/mod.rs
+git commit -m "refactor(svar2): per-row destination bounds in the reconstruct core
+
+Generalizes out_offsets to (n_work, 2) out_bounds so callers can scatter
+rows into non-contiguous destinations; carve in ascending-start order.
+No behavior change — both FFI callers adapt via bounds_from_offsets."
+```
+
+---
+
+### Task 2: Scattered-row reverse-complement helper
+
+SVAR1's fused spliced entry RCs negative-strand rows in a separate pass after reconstruct (`rc_flat_rows_inplace`, `src/ffi/mod.rs:1783`). That helper indexes rows via a gap-free offsets array. Add the bounds-addressed counterpart so the SVAR2 scatter path can mirror it. This replaces the Python `reverse_masked` post-pass (1.70 ms measured).
+
+**Files:**
+- Modify: `src/reverse.rs` (add fn after `rc_flat_rows_inplace`, line ~69)
+- Test: `src/reverse.rs` (`mod tests`, ~line 71)
+
+**Interfaces:**
+- Consumes: `rc_row` (existing, `pub(crate)`, `src/reverse.rs:44`).
+- Produces: `pub fn rc_bounded_rows_inplace(data: &mut [u8], bounds: ArrayView2<i64>, to_rc: ArrayView1<bool>)`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `src/reverse.rs`:
+
+```rust
+#[test]
+fn rc_bounded_rows_handles_scattered_rows() {
+    use ndarray::array;
+    // Two rows at scattered destinations with an untouched gap between them.
+    // Layout: [row0 "ACGT" @ 0..4]["--" gap 4..6][row1 "AACC" @ 6..10]
+    let mut data = b"ACGT--AACC".to_vec();
+    let bounds = array![[6i64, 10], [0i64, 4]];
+    let to_rc = array![true, false];
+
+    super::rc_bounded_rows_inplace(&mut data, bounds.view(), to_rc.view());
+
+    // Row 0 of the mask addresses bytes 6..10 ("AACC" -> RC -> "GGTT").
+    // Row 1 is unmasked; the gap must be untouched.
+    assert_eq!(&data, b"ACGT--GGTT");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+export LD_LIBRARY_PATH=$PWD/.pixi/envs/dev/lib:$LD_LIBRARY_PATH
+cargo test rc_bounded_rows_handles_scattered_rows 2>&1 | tail -10
+```
+Expected: FAIL to compile — `cannot find function rc_bounded_rows_inplace`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `src/reverse.rs` after `rc_flat_rows_inplace`, and extend the imports to `use ndarray::{ArrayView1, ArrayView2};`:
+
+```rust
+/// Reverse AND complement bytes within each masked row, addressed by explicit
+/// `(start, end)` bounds. The scattered-destination counterpart of
+/// [`rc_flat_rows_inplace`]: rows need not be contiguous or in ascending order,
+/// which is what a spliced SVAR2 scatter write produces.
+pub fn rc_bounded_rows_inplace(data: &mut [u8], bounds: ArrayView2<i64>, to_rc: ArrayView1<bool>) {
+    for i in 0..to_rc.len() {
+        if !to_rc[i] {
+            continue;
+        }
+        let s = bounds[[i, 0]] as usize;
+        let e = bounds[[i, 1]] as usize;
+        rc_row(&mut data[s..e]);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+export LD_LIBRARY_PATH=$PWD/.pixi/envs/dev/lib:$LD_LIBRARY_PATH
+cargo test reverse:: 2>&1 | tail -10
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/reverse.rs
+git commit -m "feat(reverse): rc_bounded_rows_inplace for scattered rows"
+```
+
+---
+
+### Task 3: Multi-contig spliced parity test (regression guard)
+
+**Write this first and independently: it must pass on the CURRENT code**, then keep passing after Task 5. The chr22 benchmark is single-contig, so nothing in the existing suite exercises a spliced read whose rows scatter across contig groups — exactly the case the new carve handles.
+
+Reuses the existing two-contig fixtures (`_src2`, `svar_fixture2`, `svar2_fixture2`, `tests/dataset/test_svar2_dataset.py:647-692`) and the spliced-test shape at `:169`.
+
+**Files:**
+- Modify: `tests/dataset/test_svar2_dataset.py` (add after `test_svar2_haplotypes_match_svar1_multicontig`, ~line 731)
+
+**Interfaces:**
+- Consumes: fixtures `svar_fixture2`, `svar2_fixture2`, `_src2` (module-scoped, already defined).
+- Produces: nothing.
+
+- [ ] **Step 1: Write the test**
+
+```python
+def test_svar2_spliced_haplotypes_match_svar1_multicontig(
+    tmp_path, svar_fixture2, svar2_fixture2, _src2
+):
+    """Spliced haplotypes byte-identical to SVAR1 when transcripts span TWO contigs.
+
+    Splice order is (splice_row, sample, ploid, element), but SVAR2 reconstructs
+    per contig group — so each group's rows land at NON-contiguous destinations
+    interleaved with the other group's. Single-contig spliced tests (and the chr22
+    benchmark) never produce that layout, so this is the only guard on the
+    scattered-destination path. Minus strand is included so the RC pass is
+    exercised on scattered rows too.
+    """
+    from genoray import SparseVar, SparseVar2
+
+    _bcf, ref = _src2
+    # Interleaved contigs, out of sorted order; Tb is minus-strand and multi-exon.
+    splice_bed = pl.DataFrame(
+        {
+            "chrom": ["chr2", "chr1", "chr2", "chr1"],
+            "chromStart": [0, 0, 20, 5],
+            "chromEnd": [13, 13, 40, 20],
+            "strand": ["+", "-", "+", "-"],
+            "transcript_id": ["Ta", "Tb", "Ta", "Tb"],
+            "exon_number": [1, 1, 2, 2],
+        }
+    )
+    d1 = tmp_path / "mcs1.gvl"
+    d2 = tmp_path / "mcs2.gvl"
+    gvl.write(
+        d1, splice_bed, variants=SparseVar(svar_fixture2), samples=None, overwrite=True
+    )
+    gvl.write(
+        d2,
+        splice_bed,
+        variants=SparseVar2(svar2_fixture2),
+        samples=None,
+        overwrite=True,
+    )
+    settings = {"splice_info": ("transcript_id", "exon_number"), "var_filter": "exonic"}
+    ds1 = gvl.Dataset.open(d1, reference=ref, **settings).with_seqs("haplotypes")
+    ds2 = gvl.Dataset.open(d2, reference=ref, **settings).with_seqs("haplotypes")
+
+    a = ds1[:, :]
+    b = ds2[:, :]
+    assert np.array_equal(np.asarray(a.offsets), np.asarray(b.offsets)), (
+        f"offsets differ: svar1={np.asarray(a.offsets).tolist()} "
+        f"svar2={np.asarray(b.offsets).tolist()}"
+    )
+    assert np.array_equal(a.data.view("u1"), b.data.view("u1"))
+```
+
+- [ ] **Step 2: Run it to verify it passes on current code**
+
+```bash
+pixi run -e dev pytest tests/dataset/test_svar2_dataset.py::test_svar2_spliced_haplotypes_match_svar1_multicontig -v
+```
+Expected: PASS. If it FAILS, **stop and report** — that is a pre-existing multi-contig spliced bug, not something this plan introduces, and it must be triaged before continuing. Check the transcripts really do split across contig groups (`Ta` on chr2, `Tb` on chr1).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/dataset/test_svar2_dataset.py
+git commit -m "test(svar2): multi-contig spliced parity guard
+
+The chr22 benchmark and existing spliced tests are single-contig, so no
+test covers a spliced read whose rows scatter across contig groups."
+```
+
+---
+
+### Task 4: Out-param FFI entry (`..._readbound_into`)
+
+Mirrors `reconstruct_haplotypes_from_svar2_readbound` (`src/ffi/mod.rs:951-1112`) but writes into a caller-supplied buffer at caller-supplied bounds instead of allocating.
+
+**It also skips `hap_diffs_svar2` entirely.** In the allocating entry, the diffs pass exists *only* to size `out_offsets` (`src/ffi/mod.rs:1058-1077`); the reconstruct core takes sizes from the bounds and pads/truncates itself. The caller now supplies bounds, so that whole merge pass disappears from this path — savings on top of the re-order.
+
+The out-param + `py.detach` shape is established: `reconstruct_haplotypes_from_sparse` (`src/ffi/mod.rs:560`) already does exactly this.
+
+**Files:**
+- Modify: `src/ffi/mod.rs` (add after the allocating entry, ~line 1112)
+- Modify: `src/lib.rs:50` (register the pyfunction)
+
+**Interfaces:**
+- Consumes: `reconstruct::reconstruct_haplotypes_from_svar2` with `out_bounds` (Task 1); `crate::reverse::rc_bounded_rows_inplace` (Task 2).
+- Produces: Python symbol `reconstruct_haplotypes_from_svar2_readbound_into(out, out_bounds, store, contig, region_starts, orig_samples, vk_snp_range, vk_indel_range, dense_snp_range, dense_indel_range, region_bounds, shifts, ref_, ref_offsets, pad_char, to_rc, parallel, filter_exonic=False) -> None`. `out` is `uint8 (total,)`, `out_bounds` is `int64 (n_q*ploidy, 2)` in row order `q*ploidy + p`, `to_rc` is `bool (n_q*ploidy,)` or `None`.
+
+- [ ] **Step 1: Write the implementation**
+
+Add to `src/ffi/mod.rs` after `reconstruct_haplotypes_from_svar2_readbound`:
+
+```rust
+/// Scatter-write variant of [`reconstruct_haplotypes_from_svar2_readbound`]: writes
+/// each (query, hap) row into `out` at the caller-supplied `out_bounds[k] = (start, end)`
+/// instead of allocating a contiguous buffer and returning it.
+///
+/// This is how the SVAR2 spliced read reaches SVAR1's "fused" behavior: the Python
+/// splice plan already knows every row's final address, so each contig group scatters
+/// straight into the shared output buffer — no post-kernel re-order, no extra copy.
+/// `out_bounds` rows are pairwise disjoint but NOT contiguous or ordered: a group's
+/// rows interleave with the other contig groups' rows.
+///
+/// Unlike the allocating entry, this skips `hap_diffs_svar2` — that pass exists only
+/// to size the output, and sizes come from `out_bounds` here.
+///
+/// `to_rc` (per row, kernel row order) reverse-complements negative-strand rows in
+/// place after reconstruction, mirroring `reconstruct_haplotypes_spliced_fused`.
+#[pyfunction(signature = (
+    out,
+    out_bounds,
+    store,
+    contig,
+    region_starts,
+    orig_samples,
+    vk_snp_range,
+    vk_indel_range,
+    dense_snp_range,
+    dense_indel_range,
+    region_bounds,
+    shifts,
+    ref_,
+    ref_offsets,
+    pad_char,
+    to_rc,
+    parallel,
+    filter_exonic = false,
+))]
+#[allow(clippy::too_many_arguments)]
+pub fn reconstruct_haplotypes_from_svar2_readbound_into<'py>(
+    py: Python<'py>,
+    mut out: PyReadwriteArray1<u8>,
+    out_bounds: PyReadonlyArray2<i64>,
+    store: PyRef<'py, crate::svar2::store::Svar2Store>,
+    contig: &str,
+    region_starts: PyReadonlyArray1<u32>,
+    orig_samples: PyReadonlyArray1<i64>,
+    vk_snp_range: PyReadonlyArray2<i64>,
+    vk_indel_range: PyReadonlyArray2<i64>,
+    dense_snp_range: PyReadonlyArray2<i64>,
+    dense_indel_range: PyReadonlyArray2<i64>,
+    region_bounds: PyReadonlyArray2<i32>,
+    shifts: PyReadonlyArray2<i32>,
+    ref_: PyReadonlyArray1<u8>,
+    ref_offsets: PyReadonlyArray1<i64>,
+    pad_char: u8,
+    to_rc: Option<PyReadonlyArray1<bool>>,
+    parallel: bool,
+    filter_exonic: bool,
+) -> PyResult<()> {
+    use crate::reconstruct;
+    use crate::svar2;
+
+    let reader = store.reader(contig).ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(format!("contig {contig} not in store"))
+    })?;
+
+    let shifts_a = shifts.as_array();
+    let ploidy = shifts_a.ncols();
+    let region_bounds_a = region_bounds.as_array();
+    let n_q = region_bounds_a.nrows();
+
+    if out_bounds.as_array().nrows() != n_q * ploidy {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "out_bounds must have n_q*ploidy = {} rows, got {}",
+            n_q * ploidy,
+            out_bounds.as_array().nrows()
+        )));
+    }
+
+    // Build `regions` (n_q, 3) as [contig_idx=0, start, end) — `ref_` is the
+    // single contig slice the caller passed in (ref_offsets = [0, len]).
+    let mut regions = Array2::<i32>::zeros((n_q, 3));
+    for q in 0..n_q {
+        regions[[q, 1]] = region_bounds_a[[q, 0]];
+        regions[[q, 2]] = region_bounds_a[[q, 1]];
+    }
+
+    let region_starts_v: Vec<u32> = region_starts.as_array().to_vec();
+    let orig_samples_v: Vec<usize> = orig_samples
+        .as_array()
+        .iter()
+        .map(|&x| x as usize)
+        .collect();
+    let vk_snp_range_v = arr2_to_ranges(vk_snp_range.as_array());
+    let vk_indel_range_v = arr2_to_ranges(vk_indel_range.as_array());
+    let dense_snp_range_v = arr2_to_ranges(dense_snp_range.as_array());
+    let dense_indel_range_v = arr2_to_ranges(dense_indel_range.as_array());
+
+    // See the allocating entry: `ref_` is sliced then `.as_slice().unwrap()`'d inside
+    // the kernel, so a non-contiguous view would panic there.
+    require_contiguous_1d(&ref_, "ref_")?;
+
+    let ref_a = ref_.as_array();
+    let ref_offsets_a = ref_offsets.as_array();
+    let out_bounds_a = out_bounds.as_array();
+    let to_rc_a = to_rc.as_ref().map(|a| a.as_array());
+    let out_a = out.as_array_mut();
+
+    py.detach(move || {
+        let rb = genoray_core::query::HapRanges::new(
+            &region_starts_v,
+            &orig_samples_v,
+            &vk_snp_range_v,
+            &vk_indel_range_v,
+            &dense_snp_range_v,
+            &dense_indel_range_v,
+            ploidy,
+        );
+        let br = genoray_core::query::gather_haps_readbound(reader, &rb);
+
+        let (lut_bytes, lut_off_u64) = reader.lut_arrays();
+        let lut_off: Vec<i64> = lut_off_u64.iter().map(|&x| x as i64).collect();
+
+        let flat = svar2::split_to_flat(&br);
+        let dense_range_a =
+            numpy::ndarray::ArrayView2::from_shape((n_q, 2), &flat.dense_range).unwrap();
+
+        // No sizing pass: `out_bounds` already carries every row's destination, so
+        // `hap_diffs_svar2` (needed only to build out_offsets) is skipped entirely.
+        let mut out_a = out_a;
+        reconstruct::reconstruct_haplotypes_from_svar2(
+            out_a.view_mut(),
+            out_bounds_a,
+            regions.view(),
+            shifts_a,
+            numpy::ndarray::ArrayView1::from(flat.vk_pos.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.vk_key.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.vk_off.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.dense_pos.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.dense_key.as_slice()),
+            dense_range_a,
+            numpy::ndarray::ArrayView1::from(flat.dense_present.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.dense_present_off.as_slice()),
+            numpy::ndarray::ArrayView1::from(lut_bytes.as_slice()),
+            numpy::ndarray::ArrayView1::from(lut_off.as_slice()),
+            ref_a,
+            ref_offsets_a,
+            pad_char,
+            parallel,
+            filter_exonic,
+        );
+
+        // In-place RC of negative-strand rows, mirroring the SVAR1 fused splice entry.
+        if let Some(to_rc) = to_rc_a.as_ref() {
+            crate::reverse::rc_bounded_rows_inplace(
+                out_a.as_slice_mut().unwrap(),
+                out_bounds_a,
+                *to_rc,
+            );
+        }
+    });
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Register the pyfunction**
+
+In `src/lib.rs`, after the existing registration at line ~50:
+
+```rust
+    m.add_function(wrap_pyfunction!(
+        ffi::reconstruct_haplotypes_from_svar2_readbound_into,
+        m
+    )?)?;
+```
+
+- [ ] **Step 3: Build and verify the symbol exists**
+
+```bash
+pixi run -e dev maturin develop --release 2>&1 | tail -5
+pixi run -e dev python -c "
+from genvarloader.genvarloader import reconstruct_haplotypes_from_svar2_readbound_into as f
+print('symbol ok:', f)
+"
+```
+Expected: build succeeds; prints `symbol ok: <builtin_function ...>`.
+
+If the borrow checker rejects `out_a` inside `py.detach` (the `Ungil` bound), take a raw slice before the closure instead — `let out_slice: &mut [u8] = out_a.as_slice_mut().unwrap();` — and rebuild the `ArrayViewMut1` inside via `ArrayViewMut1::from(out_slice)`. `&mut [u8]` is `Send`.
+
+- [ ] **Step 4: Verify nothing regressed**
+
+```bash
+export LD_LIBRARY_PATH=$PWD/.pixi/envs/dev/lib:$LD_LIBRARY_PATH
+cargo test 2>&1 | tail -5
+```
+Expected: PASS (125 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ffi/mod.rs src/lib.rs
+git commit -m "feat(svar2): scatter-write FFI entry for read-bound haplotypes
+
+Writes rows at caller-supplied destinations and skips the diffs sizing
+pass (sizes come from out_bounds). Unused until the Python path lands."
+```
+
+---
+
+### Task 5: Route the spliced Python path through the scatter write
+
+Replaces the re-order + RC post-pass with a single scatter write. `_getitem_spliced` asserts `jitter == 0` and `deterministic`, so shifts are always zero here — no rng, no diffs needed for shift bounding.
+
+`to_rc` arrives in **permuted** (spliced) order — `_getitem_spliced` builds it as `to_rc_flat[plan.permutation]` (`_query.py:270`) — so it must be un-permuted into kernel row order.
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_svar2_haps.py:42-49` (import), `:318-393` (`__call__`), add `_reconstruct_spliced` method
+- Test: `tests/dataset/test_svar2_dataset.py` (Task 3's test + existing spliced tests)
+
+**Interfaces:**
+- Consumes: `reconstruct_haplotypes_from_svar2_readbound_into` (Task 4); `self._contig_groups` (`:1022`), `self._gather_inputs` (`:1035`), `self._ref_for_contig` (`:1081`).
+- Produces: `Svar2Haps._reconstruct_spliced(self, idx, regions, splice_plan, to_rc) -> _Flat[np.bytes_]`.
+
+- [ ] **Step 1: Run the spliced tests to confirm the baseline is green**
+
+```bash
+pixi run -e dev maturin develop --release 2>&1 | tail -2
+pixi run -e dev pytest tests/dataset/test_svar2_dataset.py -k spliced -v
+```
+Expected: PASS (including Task 3's multi-contig test). These are the byte-identity contract — they must stay green through this task.
+
+- [ ] **Step 2: Add the import**
+
+In `python/genvarloader/_dataset/_svar2_haps.py`, add to the `from ..genvarloader import (...)` block (line ~43, keep alphabetical):
+
+```python
+    reconstruct_haplotypes_from_svar2_readbound,
+    reconstruct_haplotypes_from_svar2_readbound_into,
+```
+
+- [ ] **Step 3: Add the `_reconstruct_spliced` method**
+
+Insert after `__call__` (before `haplotype_lengths_for_plan`, line ~396):
+
+```python
+    def _reconstruct_spliced(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.int32],
+        splice_plan: "SplicePlan",
+        to_rc: "NDArray[np.bool_] | None",
+    ) -> _Flat[np.bytes_]:
+        """Reconstruct spliced haplotypes directly into spliced layout (no re-order).
+
+        The splice plan already knows every element's final address, so instead of
+        reconstructing in region order and permuting the OUTPUT BYTES afterwards, we
+        permute the per-row METADATA (O(rows)) and let each contig group's kernel call
+        scatter straight into the shared buffer — the same trick SVAR1's fused spliced
+        entry uses (``reconstruct_haplotypes_spliced_fused``).
+
+        The plan's k-index (``k = query * E + e`` with ``E = ploidy`` for haplotypes,
+        see ``_splice.build_splice_plan``) is exactly the kernel's row index
+        ``k = q * P + p``, so ``plan.permutation`` indexes hap rows with no translation.
+
+        Callers reach this only via ``_getitem_spliced``, which asserts ``jitter == 0``
+        and ``deterministic`` — hence zero shifts.
+        """
+        assert self.store is not None
+        regions = np.asarray(regions, np.int32)
+        P = int(self.genotypes.shape[-2])
+        b = len(idx)
+        R_all, S_all = int(self.genotypes.shape[0]), int(self.genotypes.shape[1])
+        r_q, si_q = np.unravel_index(np.asarray(idx), (R_all, S_all))
+
+        perm = np.asarray(splice_plan.permutation, np.intp)
+        off = np.asarray(splice_plan.permuted_out_offsets, np.int64)
+        n_work = b * P
+        if len(perm) != n_work:
+            raise AssertionError(
+                f"splice permutation length {len(perm)} != n_queries*ploidy {n_work}"
+            )
+
+        # dest_rank[k] = position of kernel row k within the permuted (spliced) layout.
+        dest_rank = np.empty(n_work, np.intp)
+        dest_rank[perm] = np.arange(n_work, dtype=np.intp)
+        bounds_all = np.empty((n_work, 2), np.int64)
+        bounds_all[:, 0] = off[dest_rank]
+        bounds_all[:, 1] = off[dest_rank + 1]
+
+        # to_rc arrives in permuted order (_getitem_spliced builds it as
+        # to_rc_flat[plan.permutation]); the kernel wants it per row.
+        rc_all: NDArray[np.bool_] | None = None
+        if to_rc is not None and bool(np.asarray(to_rc).any()):
+            rc_all = np.empty(n_work, np.bool_)
+            rc_all[perm] = np.asarray(to_rc, np.bool_)
+
+        out = np.empty(int(off[-1]), np.uint8)
+        shifts_all = np.zeros((b, P), np.int32)
+        p_range = np.arange(P, dtype=np.intp)
+
+        for ci, qsel in self._contig_groups(regions[:, 0].astype(np.int64)):
+            gi = self._gather_inputs(r_q[qsel], si_q[qsel], regions[qsel], P)
+            ref_, ref_offsets = self._ref_for_contig(ci)
+            rows = (qsel[:, None] * P + p_range).ravel()
+            g_bounds = np.ascontiguousarray(bounds_all[rows], np.int64)
+            g_rc = (
+                None
+                if rc_all is None
+                else np.ascontiguousarray(rc_all[rows], np.bool_)
+            )
+            g_total = int((g_bounds[:, 1] - g_bounds[:, 0]).sum())
+            reconstruct_haplotypes_from_svar2_readbound_into(
+                out,
+                g_bounds,
+                self.store,
+                self.ds_contigs[ci],
+                gi[0],
+                gi[1],
+                gi[2],
+                gi[3],
+                gi[4],
+                gi[5],
+                gi[6],
+                np.ascontiguousarray(shifts_all[qsel], np.int32),
+                ref_,
+                ref_offsets,
+                np.uint8(self.reference.pad_char),  # type: ignore[union-attr]  # reference guaranteed for haplotypes
+                g_rc,
+                should_parallelize(g_total),
+                self.filter == "exonic",
+            )
+
+        return _Flat.from_offsets(out, (len(perm), None), off).view("S1")
+```
+
+- [ ] **Step 4: Route `__call__` to it**
+
+In `__call__`, immediately after the `RaggedAnnotatedHaps` guard (line ~360, before the `haps, *_ = self.get_haps_and_shifts(` call at line ~365), insert:
+
+```python
+        if splice_plan is not None:
+            return cast(
+                _H,
+                self._reconstruct_spliced(
+                    idx=idx,
+                    regions=np.asarray(regions, np.int32),
+                    splice_plan=splice_plan,
+                    to_rc=to_rc,
+                ),
+            )
+```
+
+Then delete the now-dead splice branch. Replace lines ~376-393 (from `if splice_plan is None and (to_rc is None` through `return cast(_H, flat)`) with:
+
+```python
+        if to_rc is None or not bool(np.asarray(to_rc).any()):
+            return cast(_H, haps)
+
+        flat = _Flat.from_offsets(
+            np.asarray(haps.data), haps.shape, np.asarray(haps.offsets, np.int64)
+        ).view("S1")
+        flat = flat.reverse_masked(np.asarray(to_rc, np.bool_), comp=_COMP)
+        return cast(_H, flat)
+```
+
+- [ ] **Step 5: Run the spliced tests**
+
+```bash
+pixi run -e dev maturin develop --release 2>&1 | tail -2
+pixi run -e dev pytest tests/dataset/test_svar2_dataset.py -k spliced -v
+```
+Expected: PASS — byte-identical to SVAR1 on both the single-contig and multi-contig spliced tests.
+
+If bytes differ, the likely cause is `to_rc` permutation direction. `rc_all[perm] = to_rc` maps permuted→row order; the inverse (`rc_all = to_rc[dest_rank]`) is the same mapping — verify against `_query.py:270` rather than flipping it blind.
+
+- [ ] **Step 6: Verify `_ragged_arange_gather` is no longer used by the splice path**
+
+```bash
+grep -n "_ragged_arange_gather" python/genvarloader/_dataset/_svar2_haps.py
+```
+Expected: definitions (~119, 143) plus uses at ~668, ~826, ~999, ~1143 (unspliced + variants paths — these STAY). The former splice-path call inside `__call__` must be gone.
+
+- [ ] **Step 7: Run the full tree + lint**
+
+```bash
+pixi run -e dev pytest tests -q 2>&1 | tail -5
+pixi run -e dev ruff check python/ tests/ && pixi run -e dev ruff format python/ tests/
+pixi run -e dev typecheck 2>&1 | tail -3
+```
+Expected: all green (~1030 pytest). The full tree matters — `tests/unit/dataset/test_build_reconstructor.py` and friends are skipped by scoped runs.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add python/genvarloader/_dataset/_svar2_haps.py
+git commit -m "perf(svar2): scatter-write spliced haplotypes, no Python re-order
+
+Permutes per-row metadata and lets each contig group's kernel call write
+straight into the final spliced buffer, deleting the O(bytes) concatenate
+and the RC post-pass. Byte-identical to SVAR1."
+```
+
+---
+
+### Task 6: Measure, gate, and update the roadmap
+
+**Files:**
+- Modify: `docs/roadmaps/rust-migration.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing (docs only).
+
+- [ ] **Step 1: Measure before/after in one session**
+
+The node is too noisy for cross-session wall-clock or medians (during the spike svar1's median swung to 45 ms against a 25 ms min). Compare **minimums**, same session, both backends in one process.
+
+```bash
+pixi run -e dev pytest tests/benchmarks/test_e2e_svar_splice.py -v 2>&1 | tail -20
+```
+Expected: parity test PASSES; svar2 spliced benchmark improves against its own baseline.
+
+Baseline to beat (spike, 2026-07-16, minimums of 25 reps): svar1 **25.15 ms**, svar2 **35.33 ms** (1.41×). Target ≈1.0× or better; projection ≈20 ms (≈0.8×).
+
+If the benchmark fixture skips (missing `hg38.fa.bgz` / `plink2` / the uncommitted `chr22_5s_hapsafe.pgen`), say so plainly rather than reporting an unmeasured win.
+
+- [ ] **Step 2: Record results and update the roadmap**
+
+Per the roadmap gate: tick the task, record before/after measurements under the relevant checkpoint, set the phase status marker (⬜/🚧/✅) and PR link. Read `docs/roadmaps/rust-migration.md` first and follow its existing structure — do not invent a new section shape.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/roadmaps/rust-migration.md
+git commit -m "docs(roadmap): record svar2 spliced scatter-write results (#273)"
+```
+
+- [ ] **Step 4: Push and open a draft PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --draft --base main \
+  --title "perf(svar2): scatter-write spliced haplotypes (#273)" \
+  --body "$(cat <<'EOF'
+Closes #273.
+
+Gives SVAR2 spliced reads SVAR1's behavior: the kernel writes bytes at their
+final spliced address instead of Python re-ordering them afterwards.
+
+## What the spike found
+
+The Python re-order (`_ragged_arange_gather`) was **13.7 ms of a 10.2 ms**
+svar2-vs-svar1 gap — and at ~9x the memcpy floor for the same 13.2 MB, it was
+per-row numpy dispatch overhead across 6600 rows, not bandwidth. #272 removed the
+index materialization; per-row dispatch was what remained.
+
+## Approach
+
+SVAR1's "fused" spliced kernel doesn't know about splicing — it permutes per-element
+*metadata* and passes `permuted_out_offsets`. SVAR2 couldn't reuse that because it
+reconstructs per contig group, so a group's rows scatter to non-contiguous
+destinations. So the core now takes per-row `(start, end)` bounds instead of a
+gap-free offsets array, and a new out-param FFI entry scatters each group into one
+shared buffer. It also skips the diffs sizing pass (sizes come from the bounds).
+
+## Verification
+
+- Byte-identical to SVAR1: existing spliced parity tests + a **new multi-contig
+  spliced test** (the chr22 benchmark is single-contig, so nothing previously
+  covered the scattered-destination path).
+- Full pytest tree + cargo tests green.
+- Perf: same-session minimums, both backends in one process.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Notes for the implementer
+
+- **Do not "fix" the double gather.** The spliced path gathers twice (once to size the plan, once to reconstruct). That is a known, measured 3.44 ms, deliberately out of scope (spec §4) — it needs an opaque gather-handle type across the FFI and may be moot after this change. If you think it matters, say so; don't build it.
+- **Do not touch the unspliced path.** Its ragged reads let the kernel self-size; preallocating would force an extra diffs gather and could regress. `_assemble_haps` stays (0.06 ms measured, thanks to #272's single-contig fast path).
+- **The `.so` is the trap.** Every Python test run after a Rust edit needs `maturin develop --release` first, or you are testing the old binary.

--- a/docs/superpowers/specs/2026-07-16-svar2-spliced-scatter-write-design.md
+++ b/docs/superpowers/specs/2026-07-16-svar2-spliced-scatter-write-design.md
@@ -1,0 +1,192 @@
+# SVAR2 spliced haplotypes: scatter-write the kernel output (no Python re-order)
+
+> **Status:** design approved · **Date:** 2026-07-16 · **Issue:** #273 ·
+> **Base:** `main` @ `09d5055` (includes #272)
+>
+> Follow-up to #272. Touches `src/` → the rust-migration roadmap gate
+> (`docs/roadmaps/rust-migration.md`) and its byte-identical parity contract apply.
+
+## 1. Motivation
+
+SVAR1 reconstructs spliced haplotypes with no post-kernel re-order. SVAR2 has no
+equivalent: `Svar2Haps.__call__` reconstructs in region order and then re-orders
+the *output bytes* in Python to reach spliced order.
+
+#272 replaced a byte-level fancy-index with a per-row slice + `np.concatenate`
+(189 ms → 23 ms). This removes the remaining pass entirely.
+
+### How SVAR1 actually does it
+
+Worth stating plainly, because the issue's framing ("fused Rust spliced kernel")
+suggests something more exotic than what is there. `reconstruct_haplotypes_spliced_fused`
+(`src/ffi/mod.rs:1701`) does **not** know about splicing. It permutes the small
+per-element *inputs* in Python (regions, shifts, geno_offset_idx — O(rows)) and
+passes `plan.permuted_out_offsets` as the kernel's output offsets. The kernel then
+writes each element at its final spliced address. The trick is **reordering
+metadata instead of bytes**.
+
+The index spaces already line up: `build_splice_plan` permutes `k = query * E + e`
+with `E = ploidy` for haplotypes (`_splice.py:87`), and SVAR2's kernel row index is
+already `k = q * P + p`. `plan.permutation` indexes SVAR2 hap rows with no
+translation.
+
+The blocker is the contig-group loop: SVAR2 calls the kernel once per contig, each
+call allocating its own contiguous buffer, while splice order interleaves contigs.
+A group's rows therefore land at **non-contiguous** destinations, and the core's
+parallel writer (`src/reconstruct/mod.rs:740`) requires monotone, gap-free
+`out_offsets` for its `split_at_mut` chain.
+
+## 2. Measurement (Phase 0 spike — completed 2026-07-16)
+
+chr22 spliced `ds[:, :]`: 165 transcripts × 5 samples × ploidy 2 = 6600 elements,
+13.2 MB output. Both backends timed in one process. The node is too noisy for
+medians (svar1's median swung to 45 ms against a 25 ms min), so these are
+**minimums over 25 reps**.
+
+| segment | ms | share |
+|---|---|---|
+| svar1 spliced (baseline) | 25.15 | — |
+| **svar2 spliced** | **35.33** | **1.41×; gap 10.2 ms** |
+| `_ragged_arange_gather` (the concatenate) | **13.73** | **39%** |
+| `get_haps_and_shifts` (gather #2 + kernel) | 6.41 | 18% |
+| `plan_sizing` (gather #1) | 3.44 | 10% |
+| `reverse_masked` (RC pass) | 1.70 | 5% |
+| unattributed (plan build, regroup, glue — shared with svar1) | 9.62 | 28% |
+
+**The single re-order pass exceeds the whole svar1 gap.** The mechanism matters:
+a microbenchmark of the same shape gives **8.53 ms** for per-row slice+concatenate
+vs **0.96 ms** for a flat memcpy of the same 13.2 MB. The 13.7 ms is therefore
+**~9× the memory-bandwidth floor** — ~1.3 µs/row of numpy per-slice dispatch across
+6600 rows, not bytes moved. #272 removed the index materialization; per-row dispatch
+is what remains.
+
+A scatter write deletes that cost rather than moving it to Rust: the kernel writes
+those bytes once regardless, just at a different address.
+
+Reproduce: build the datasets via `tests/benchmarks/data/build_svar_splice.py`
+(needs `tests/data/fasta/hg38.fa.bgz` from `pixi run -e dev gen`, `plink2`, and the
+uncommitted `tests/benchmarks/data/chr22_5s_hapsafe.pgen`), then time `ds[:, :]` for
+both backends in one process, taking minimums. Attribution was done by wrapping
+`haplotype_lengths_for_plan`, `get_haps_and_shifts`, `_assemble_haps`,
+`_ragged_arange_gather`, and `_Flat.reverse_masked` with timers.
+
+## 3. Design
+
+One lever: **scatter write**.
+
+Python allocates the full output buffer once (`total = plan.permuted_out_offsets[-1]`).
+Each per-contig kernel call receives that buffer as an out-param plus an
+`(n_group_rows, 2)` int64 array of **global destination bounds**. Row `k` writes to
+`[permuted_out_offsets[j], permuted_out_offsets[j+1])` where `j = dest_rank[k]`, the
+inverse permutation. No re-order, no concatenate, no RC post-pass.
+
+### 3.1 Rust
+
+**Core** (`src/reconstruct/mod.rs`, `reconstruct_haplotypes_from_svar2`): generalize
+`out_offsets: ArrayView1<i64>` to per-row `out_bounds: ArrayView2<i64>` `(n_work, 2)`.
+The parallel path currently carves chunks with a `split_at_mut` chain that assumes
+each row starts where the previous ended; it must instead carve in **ascending-start
+order** (argsort the bounds, O(n_work) rows — negligible) so interleaved
+destinations with gaps are legal. Gaps are rows belonging to *other* contig groups
+and are simply skipped; each call writes only its own rows. The serial path already
+uses raw pointers for disjoint sub-ranges and needs no ordering change.
+
+Contract, to be asserted: bounds are pairwise disjoint and within the buffer. The
+existing gap-free monotone case remains valid input, so the existing allocate-and-
+return FFI keeps working by building `(start, end)` pairs from its computed offsets.
+
+**FFI** (`src/ffi/mod.rs`): new out-param entry alongside
+`reconstruct_haplotypes_from_svar2_readbound`, taking `out: PyReadwriteArray1<u8>`,
+`out_bounds`, and an optional per-row `to_rc` mask; returns nothing. This follows
+the established house pattern — `reconstruct_haplotypes_from_sparse`
+(`src/ffi/mod.rs:560`) already takes an out-param and releases the GIL via
+`py.detach`, so the aliasing/GIL question is settled precedent, not new ground.
+In-kernel per-row RC reuses `crate::reverse::rc_flat_rows_inplace`, as the SVAR1
+fused entry does.
+
+### 3.2 Python (`python/genvarloader/_dataset/_svar2_haps.py`)
+
+`Svar2Haps.__call__` gains a spliced branch that:
+
+1. computes `dest_rank` (inverse of `plan.permutation`) and per-row destination
+   bounds — O(rows);
+2. allocates `out = np.empty(total, np.uint8)`;
+3. loops contig groups, slicing bounds for rows `k = qsel[:, None] * P + arange(P)`
+   and calling the out-param FFI;
+4. wraps with `_Flat.from_offsets(out, (n_perm, None), plan.permuted_out_offsets)`.
+
+`to_rc` un-permutes to per-row order (`_getitem_spliced` builds it permuted) and is
+passed to the kernel; the `reverse_masked` post-pass goes away.
+
+The reconstruct call is currently reached via `get_haps_and_shifts`, which raises on
+`splice_plan is not None`. Factor the group loop into a shared internal helper
+parameterized by destination bounds (`None` = today's allocate-and-return), so the
+spliced and unspliced paths share one obvious code path rather than forking.
+
+Deletes: the splice-path use of `_ragged_arange_gather` (`_svar2_haps.py:384`).
+The helper itself stays — the unspliced and variants paths still use it.
+
+## 4. Out of scope
+
+- **The unspliced path.** Its ragged reads deliberately let the kernel self-size;
+  preallocating would force an extra diffs gather and could regress. `_assemble_haps`
+  stays and measured 0.06 ms thanks to #272's single-contig fast path.
+- **Gather reuse (the "L2" lever).** The spliced path gathers twice — once to size
+  the plan, once to reconstruct. Measured 3.44 ms, and not all of it is excess
+  (svar1 computes diffs before its plan too). It needs an opaque gather-handle type
+  across the FFI: real complexity for a second-order win that this change may make
+  irrelevant. File as a follow-up **only if** post-change numbers justify it.
+- **A single Rust call looping contigs internally** (the literal "fused svar2
+  analog"). Buys one FFI crossing over N, duplicates the group loop that
+  `_haplotype_diffs`/tracks/variants already share, and the crossing is not the cost.
+- Annotated haps, tracks, and variants splicing — all still `NotImplementedError`.
+
+## 5. Testing & acceptance
+
+**Byte-identity is the contract.** Must stay green:
+
+- `tests/dataset/test_svar2_dataset.py::test_svar2_spliced_*`
+- `tests/benchmarks/test_e2e_svar_splice.py::test_svar1_svar2_spliced_parity`
+- full tree (`pixi run -e dev pytest tests -q`) + `cargo test` — shared code changes,
+  so `tests/unit/` must be covered, not just `tests/dataset/`.
+
+New coverage:
+
+- Rust unit test: scattered/interleaved `out_bounds` (a multi-contig destination
+  pattern with gaps) produces the same bytes as the contiguous path, serial and
+  parallel.
+- Python test: a **multi-contig** spliced read. The chr22 benchmark is single-contig
+  and so exercises only the gap-free case; the gap-carving logic is exactly what a
+  single-contig test cannot reach.
+
+**Perf gate** (per the shared-node protocol): same-session before/after on the chr22
+spliced benchmark, comparing **minimums**, both backends in one process. Absolute
+wall-clock across sessions is not a valid signal on this node.
+
+Target: svar2/svar1 ≈ 1.0× or better (projection ≈ 0.8×, i.e. ~20 ms vs 25 ms) with
+no per-getitem Python re-order pass.
+
+**Rebuild the extension before testing** (`pixi run -e dev maturin develop --release`)
+— pytest imports the stale `.so` otherwise, and parity tests would silently validate
+the old binary.
+
+## 6. Risks
+
+- **The ≈0.8× projection assumes the unattributed 9.62 ms is genuinely shared with
+  svar1.** It is plan-build + regroup + indexing glue that both backends run, but
+  svar1's own breakdown was not profiled. If svar2's share there is inflated, the
+  result lands nearer 1.0× than 0.8× — still meeting the issue's target.
+- **Scattered writes and cache locality.** Rows are ~2 KB and written once; the
+  concern is theoretical. The perf gate would catch it.
+- **`out_bounds` disjointness is now a caller-enforced invariant.** Previously the
+  gap-free offsets array made overlap unrepresentable. Mitigate with a debug-mode
+  disjointness assert in the carve, in the spirit of the existing monotonicity
+  `debug_assert`.
+
+## 7. Docs
+
+No public API change: `Dataset`/`gvl.write` signatures, `__all__`, and on-disk format
+are untouched — this is an internal read-path optimization. So no `skills/genvarloader/SKILL.md`
+or `docs/source/api.md` update is triggered. Update `docs/roadmaps/rust-migration.md`
+(tick the task, record before/after measurements under the relevant checkpoint, set the
+phase marker + PR link) as the roadmap gate requires.

--- a/docs/superpowers/specs/2026-07-16-svar2-spliced-scatter-write-design.md
+++ b/docs/superpowers/specs/2026-07-16-svar2-spliced-scatter-write-design.md
@@ -119,9 +119,13 @@ fused entry does.
 passed to the kernel; the `reverse_masked` post-pass goes away.
 
 The reconstruct call is currently reached via `get_haps_and_shifts`, which raises on
-`splice_plan is not None`. Factor the group loop into a shared internal helper
-parameterized by destination bounds (`None` = today's allocate-and-return), so the
-spliced and unspliced paths share one obvious code path rather than forking.
+`splice_plan is not None`. Give the spliced path its own `_reconstruct_spliced`
+method rather than parameterizing `get_haps_and_shifts` by destination bounds: the
+two paths call *different* FFI entries (allocate-and-self-size vs scatter-into) and
+differ on shifts (spliced is always zero — `_getitem_spliced` asserts `jitter == 0`
+and `deterministic`) and on sizing. What they genuinely share — the per-group cache
+slice and reference slice — is already factored into `_gather_inputs` and
+`_ref_for_contig`, so a shared loop helper would add indirection over three lines.
 
 Deletes: the splice-path use of `_ragged_arange_gather` (`_svar2_haps.py:384`).
 The helper itself stays — the unspliced and variants paths still use it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genvarloader"
-version = "0.37.0"
+version = "0.38.0"
 description = "Pipeline for efficient genomic data processing."
 authors = [
     { name = "David Laub", email = "dlaub@ucsd.edu" },

--- a/python/genvarloader/_dataset/_svar2_haps.py
+++ b/python/genvarloader/_dataset/_svar2_haps.py
@@ -45,6 +45,7 @@ from ..genvarloader import (
     decode_variants_from_svar2_readbound,
     hap_diffs_from_svar2_readbound,
     reconstruct_haplotypes_from_svar2_readbound,
+    reconstruct_haplotypes_from_svar2_readbound_into,
     shift_and_realign_tracks_from_svar2_readbound,
 )
 from ._flat_variants import (
@@ -362,6 +363,17 @@ class Svar2Haps(Haps[_H]):
                 "svar2 datasets do not support with_seqs('annotated') yet."
             )
 
+        if splice_plan is not None:
+            return cast(
+                _H,
+                self._reconstruct_spliced(
+                    idx=idx,
+                    regions=np.asarray(regions, np.int32),
+                    splice_plan=splice_plan,
+                    to_rc=to_rc,
+                ),
+            )
+
         haps, *_ = self.get_haps_and_shifts(
             idx=idx,
             regions=regions,
@@ -373,25 +385,101 @@ class Svar2Haps(Haps[_H]):
             need_hap_lengths=False,
         )
 
-        if splice_plan is None and (to_rc is None or not bool(np.asarray(to_rc).any())):
+        if to_rc is None or not bool(np.asarray(to_rc).any()):
             return cast(_H, haps)
 
-        if splice_plan is None:
-            data = np.asarray(haps.data)
-            offsets = np.asarray(haps.offsets, np.int64)
-            shape = haps.shape
-        else:
-            data, offsets = _ragged_arange_gather(
-                np.asarray(haps.data),
-                np.asarray(haps.offsets, np.int64),
-                splice_plan.permutation,
-            )
-            shape = (len(splice_plan.permutation), None)
-
-        flat = _Flat.from_offsets(data, shape, offsets).view("S1")
-        if to_rc is not None and bool(np.asarray(to_rc).any()):
-            flat = flat.reverse_masked(np.asarray(to_rc, np.bool_), comp=_COMP)
+        flat = _Flat.from_offsets(
+            np.asarray(haps.data), haps.shape, np.asarray(haps.offsets, np.int64)
+        ).view("S1")
+        flat = flat.reverse_masked(np.asarray(to_rc, np.bool_), comp=_COMP)
         return cast(_H, flat)
+
+    def _reconstruct_spliced(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.int32],
+        splice_plan: "SplicePlan",
+        to_rc: "NDArray[np.bool_] | None",
+    ) -> _Flat[np.bytes_]:
+        """Reconstruct spliced haplotypes directly into spliced layout (no re-order).
+
+        The splice plan already knows every element's final address, so instead of
+        reconstructing in region order and permuting the OUTPUT BYTES afterwards, we
+        permute the per-row METADATA (O(rows)) and let each contig group's kernel call
+        scatter straight into the shared buffer — the same trick SVAR1's fused spliced
+        entry uses (``reconstruct_haplotypes_spliced_fused``).
+
+        The plan's k-index (``k = query * E + e`` with ``E = ploidy`` for haplotypes,
+        see ``_splice.build_splice_plan``) is exactly the kernel's row index
+        ``k = q * P + p``, so ``plan.permutation`` indexes hap rows with no translation.
+
+        Callers reach this only via ``_getitem_spliced``, which asserts ``jitter == 0``
+        and ``deterministic`` — hence zero shifts.
+        """
+        assert self.store is not None
+        regions = np.asarray(regions, np.int32)
+        P = int(self.genotypes.shape[-2])
+        b = len(idx)
+        R_all, S_all = int(self.genotypes.shape[0]), int(self.genotypes.shape[1])
+        r_q, si_q = np.unravel_index(np.asarray(idx), (R_all, S_all))
+
+        perm = np.asarray(splice_plan.permutation, np.intp)
+        off = np.asarray(splice_plan.permuted_out_offsets, np.int64)
+        n_work = b * P
+        if len(perm) != n_work:
+            raise AssertionError(
+                f"splice permutation length {len(perm)} != n_queries*ploidy {n_work}"
+            )
+
+        # dest_rank[k] = position of kernel row k within the permuted (spliced) layout.
+        dest_rank = np.empty(n_work, np.intp)
+        dest_rank[perm] = np.arange(n_work, dtype=np.intp)
+        bounds_all = np.empty((n_work, 2), np.int64)
+        bounds_all[:, 0] = off[dest_rank]
+        bounds_all[:, 1] = off[dest_rank + 1]
+
+        # to_rc arrives in permuted order (_getitem_spliced builds it as
+        # to_rc_flat[plan.permutation]); the kernel wants it per row.
+        rc_all: NDArray[np.bool_] | None = None
+        if to_rc is not None and bool(np.asarray(to_rc).any()):
+            rc_all = np.empty(n_work, np.bool_)
+            rc_all[perm] = np.asarray(to_rc, np.bool_)
+
+        out = np.empty(int(off[-1]), np.uint8)
+        shifts_all = np.zeros((b, P), np.int32)
+        p_range = np.arange(P, dtype=np.intp)
+
+        for ci, qsel in self._contig_groups(regions[:, 0].astype(np.int64)):
+            gi = self._gather_inputs(r_q[qsel], si_q[qsel], regions[qsel], P)
+            ref_, ref_offsets = self._ref_for_contig(ci)
+            rows = (qsel[:, None] * P + p_range).ravel()
+            g_bounds = np.ascontiguousarray(bounds_all[rows], np.int64)
+            g_rc = (
+                None if rc_all is None else np.ascontiguousarray(rc_all[rows], np.bool_)
+            )
+            g_total = int((g_bounds[:, 1] - g_bounds[:, 0]).sum())
+            reconstruct_haplotypes_from_svar2_readbound_into(
+                out,
+                g_bounds,
+                self.store,
+                self.ds_contigs[ci],
+                gi[0],
+                gi[1],
+                gi[2],
+                gi[3],
+                gi[4],
+                gi[5],
+                gi[6],
+                np.ascontiguousarray(shifts_all[qsel], np.int32),
+                ref_,
+                ref_offsets,
+                np.uint8(self.reference.pad_char),  # type: ignore[union-attr]  # reference guaranteed for haplotypes
+                g_rc,
+                should_parallelize(g_total),
+                self.filter == "exonic",
+            )
+
+        return _Flat.from_offsets(out, (len(perm), None), off).view("S1")
 
     def haplotype_lengths_for_plan(
         self,

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -890,9 +890,10 @@ pub fn reconstruct_haplotypes_from_svar2<'py>(
         let mut out_data: Array1<u8> = uninit_output(total);
 
         // Step 4: reconstruct all haplotypes into the owned buffer.
+        let out_bounds = reconstruct::bounds_from_offsets(out_offsets_vec.view());
         reconstruct::reconstruct_haplotypes_from_svar2(
             out_data.view_mut(),
-            out_offsets_vec.view(),
+            out_bounds.view(),
             regions_a,
             shifts_a,
             vk_pos_a,
@@ -1082,9 +1083,10 @@ pub fn reconstruct_haplotypes_from_svar2_readbound<'py>(
 
         // Step 4: reconstruct — reuse the byte-validated union-path kernel
         // unchanged, now fed the read-bound gather's flat channels.
+        let out_bounds = reconstruct::bounds_from_offsets(out_offsets_vec.view());
         reconstruct::reconstruct_haplotypes_from_svar2(
             out_data.view_mut(),
-            out_offsets_vec.view(),
+            out_bounds.view(),
             regions.view(),
             shifts_a,
             numpy::ndarray::ArrayView1::from(flat.vk_pos.as_slice()),

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -62,6 +62,65 @@ fn require_contiguous_1d<T: numpy::Element>(
     })
 }
 
+/// Validate a caller-supplied `out_bounds` (scatter-write destinations) before it is
+/// handed to `reconstruct::reconstruct_haplotypes_from_svar2`, whose contract
+/// requires rows to be in-range, pairwise-disjoint `(start, end)` byte ranges within
+/// `out`. That kernel does not check this itself (its serial path does
+/// `std::slice::from_raw_parts_mut(out_raw.add(out_s), out_e - out_s)` with no bound
+/// against `out.len()`, and its parallel `split_at_mut` chain only `debug_assert!`s
+/// disjointness) — this is the ONLY read-bound FFI entry whose `out_bounds` values
+/// come straight from Python rather than being computed by Rust itself
+/// (`reconstruct::bounds_from_offsets` over a kernel-sized offsets array), so unlike
+/// every sibling entry they cannot be trusted by construction. An out-of-range row is
+/// a silent out-of-bounds write; an overlapping row is, under the parallel path with
+/// the GIL released (`py.detach`), a silent aliasing race — both genuine UB, not a
+/// clean error, if left unchecked.
+///
+/// Checks, in order:
+/// 1. every row satisfies `0 <= start <= end <= out_len` (cheap, O(n));
+/// 2. rows are pairwise disjoint, via a sort-by-start + running-max-end sweep
+///    (O(n log n) — tens of microseconds at the ~thousands-of-rows scale this path
+///    runs at, negligible next to the reconstruct work it guards).
+///
+/// Pure-Rust core (no `pyo3` error type) so it is unit-testable without a GIL /
+/// initialized interpreter; the `#[pyfunction]` call site maps `Err(String)` to a
+/// `PyValueError`.
+fn check_disjoint_bounds_within(
+    out_bounds: numpy::ndarray::ArrayView2<i64>,
+    out_len: usize,
+) -> Result<(), String> {
+    let out_len = out_len as i64;
+    for k in 0..out_bounds.nrows() {
+        let s = out_bounds[[k, 0]];
+        let e = out_bounds[[k, 1]];
+        if s < 0 || s > e || e > out_len {
+            return Err(format!(
+                "out_bounds[{k}] = ({s}, {e}) is invalid for out.len() = {out_len}; every row must satisfy 0 <= start <= end <= out.len()"
+            ));
+        }
+    }
+
+    let mut order: Vec<usize> = (0..out_bounds.nrows()).collect();
+    order.sort_unstable_by_key(|&k| out_bounds[[k, 0]]);
+    let mut max_end: i64 = i64::MIN;
+    let mut max_end_k: usize = usize::MAX;
+    for &k in &order {
+        let s = out_bounds[[k, 0]];
+        let e = out_bounds[[k, 1]];
+        if s < max_end {
+            return Err(format!(
+                "out_bounds rows must be pairwise disjoint: row {k} = ({s}, {e}) overlaps row {max_end_k} which ends at {max_end}"
+            ));
+        }
+        if e > max_end {
+            max_end = e;
+            max_end_k = k;
+        }
+    }
+
+    Ok(())
+}
+
 /// Per-(query, hap) reference-length diffs (see `genotypes::get_diffs_sparse`).
 /// `geno_offsets` is the normalized (2, n) int64 starts/stops array.
 #[pyfunction]
@@ -1189,6 +1248,23 @@ pub fn reconstruct_haplotypes_from_svar2_readbound_into<'py>(
         )));
     }
 
+    // `out_bounds` values come straight from Python (unlike every sibling entry's
+    // Rust-computed offsets) — validate range + disjointness before `py.detach`, or
+    // a bad row is a silent OOB write / aliasing race instead of a clean error.
+    // See `check_disjoint_bounds_within` for the full rationale.
+    check_disjoint_bounds_within(out_bounds.as_array(), out.as_array().len())
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
+
+    if let Some(to_rc) = to_rc.as_ref() {
+        if to_rc.as_array().len() != n_q * ploidy {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "to_rc must have n_q*ploidy = {} rows, got {}",
+                n_q * ploidy,
+                to_rc.as_array().len()
+            )));
+        }
+    }
+
     // Build `regions` (n_q, 3) as [contig_idx=0, start, end) — `ref_` is the
     // single contig slice the caller passed in (ref_offsets = [0, len]).
     let mut regions = Array2::<i32>::zeros((n_q, 3));
@@ -1211,6 +1287,15 @@ pub fn reconstruct_haplotypes_from_svar2_readbound_into<'py>(
     // See the allocating entry: `ref_` is sliced then `.as_slice().unwrap()`'d inside
     // the kernel, so a non-contiguous view would panic there.
     require_contiguous_1d(&ref_, "ref_")?;
+
+    // NOTE: same reasoning as the allocating entry's NOTE above the pure-DEL anchor
+    // read applies unchanged here — this entry calls the identical
+    // `reconstruct::reconstruct_haplotypes_from_svar2` kernel, fed by the same
+    // `gather_haps_readbound(reader, &rb)` gather off the same `store`/`contig`, so
+    // gathered variants are the same within-contig records (`pos < contig_ref_len`
+    // always holds) and `region_bounds` carries the same jitter-past-contig-end
+    // semantics. The anchor-base read is in-bounds for all valid input; a corrupt
+    // store is caught by the same `debug_assert!` at the read site.
 
     let ref_a = ref_.as_array();
     let ref_offsets_a = ref_offsets.as_array();
@@ -2601,6 +2686,54 @@ mod tests {
         assert_eq!(&bytes, b"CGT");
         assert_eq!(vidx, vec![7, 6, 5]);
         assert_eq!(rpos, vec![102, 101, 100]);
+    }
+
+    // ── guard tests — check_disjoint_bounds_within (Finding 1, PR #273 review) ──
+
+    #[test]
+    fn disjoint_bounds_accepts_in_range_nonoverlapping_rows() {
+        // scattered (not row-ordered), matches the spliced scatter-write shape.
+        let bounds = ndarray::arr2(&[[6i64, 10], [0, 4], [4, 6]]);
+        assert!(super::check_disjoint_bounds_within(bounds.view(), 10).is_ok());
+    }
+
+    #[test]
+    fn disjoint_bounds_accepts_adjacent_zero_length_rows() {
+        // two empty rows at the same offset write zero bytes each — no aliasing.
+        let bounds = ndarray::arr2(&[[3i64, 3], [3, 3], [0, 3]]);
+        assert!(super::check_disjoint_bounds_within(bounds.view(), 5).is_ok());
+    }
+
+    #[test]
+    fn disjoint_bounds_rejects_end_past_out_len() {
+        let bounds = ndarray::arr2(&[[0i64, 4], [4, 11]]);
+        let msg = super::check_disjoint_bounds_within(bounds.view(), 10).unwrap_err();
+        assert!(msg.contains("out_bounds[1] = (4, 11)"), "{msg}");
+        assert!(msg.contains("out.len() = 10"), "{msg}");
+    }
+
+    #[test]
+    fn disjoint_bounds_rejects_negative_start() {
+        let bounds = ndarray::arr2(&[[-1i64, 4]]);
+        let msg = super::check_disjoint_bounds_within(bounds.view(), 10).unwrap_err();
+        assert!(msg.contains("out_bounds[0] = (-1, 4)"));
+    }
+
+    #[test]
+    fn disjoint_bounds_rejects_start_after_end() {
+        let bounds = ndarray::arr2(&[[5i64, 2]]);
+        let msg = super::check_disjoint_bounds_within(bounds.view(), 10).unwrap_err();
+        assert!(msg.contains("out_bounds[0] = (5, 2)"));
+    }
+
+    #[test]
+    fn disjoint_bounds_rejects_overlapping_rows() {
+        // row 0 = [0, 6), row 1 = [4, 8): overlap in [4, 6), a Python-side indexing
+        // bug that would otherwise race under py.detach in the parallel path.
+        let bounds = ndarray::arr2(&[[0i64, 6], [4, 8]]);
+        let msg = super::check_disjoint_bounds_within(bounds.view(), 10).unwrap_err();
+        assert!(msg.contains("pairwise disjoint"), "{msg}");
+        assert!(msg.contains("row 1 = (4, 8)"), "{msg}");
     }
 }
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -62,6 +62,19 @@ fn require_contiguous_1d<T: numpy::Element>(
     })
 }
 
+/// Mutable-array counterpart of [`require_contiguous_1d`] — same rationale, for a
+/// `PyReadwriteArray1` that is consumed via `.as_slice_mut()` downstream. Kept as a
+/// separate function (rather than a generic over read/write) because `numpy`'s
+/// `PyReadonlyArray1`/`PyReadwriteArray1` don't share a trait for `.as_slice()`.
+fn require_contiguous_1d_mut<T: numpy::Element>(
+    arr: &mut PyReadwriteArray1<T>,
+    name: &str,
+) -> PyResult<()> {
+    arr.as_array_mut().as_slice_mut().map(|_| ()).ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(format!("`{name}` must be C-contiguous"))
+    })
+}
+
 /// Validate a caller-supplied `out_bounds` (scatter-write destinations) before it is
 /// handed to `reconstruct::reconstruct_haplotypes_from_svar2`, whose contract
 /// requires rows to be in-range, pairwise-disjoint `(start, end)` byte ranges within
@@ -100,8 +113,12 @@ fn check_disjoint_bounds_within(
         }
     }
 
+    // Tie-break on `(start, end)`, not `start` alone — see the matching comment on
+    // the carve's `order.sort_unstable_by_key` in `reconstruct::reconstruct_haplotypes_from_svar2`
+    // for why (a zero-length row shares its start with the following row in a
+    // gap-free layout) and why the two sweeps' key ordering must stay identical.
     let mut order: Vec<usize> = (0..out_bounds.nrows()).collect();
-    order.sort_unstable_by_key(|&k| out_bounds[[k, 0]]);
+    order.sort_unstable_by_key(|&k| (out_bounds[[k, 0]], out_bounds[[k, 1]]));
     let mut max_end: i64 = i64::MIN;
     let mut max_end_k: usize = usize::MAX;
     for &k in &order {
@@ -1247,6 +1264,13 @@ pub fn reconstruct_haplotypes_from_svar2_readbound_into<'py>(
             out_bounds.as_array().nrows()
         )));
     }
+
+    // `out` is consumed via `.as_slice_mut()` in the kernel's parallel carve
+    // (`reconstruct::reconstruct_haplotypes_from_svar2`) and in the RC pass
+    // (`crate::reverse::rc_bounded_rows_inplace`) below; a non-contiguous view (e.g.
+    // a strided `out[::2]`) would panic there instead of raising. Gate it here per
+    // this file's stated `.as_slice()`-consumer policy (see `require_contiguous_1d`).
+    require_contiguous_1d_mut(&mut out, "out")?;
 
     // `out_bounds` values come straight from Python (unlike every sibling entry's
     // Rust-computed offsets) — validate range + disjointness before `py.detach`, or
@@ -2734,6 +2758,32 @@ mod tests {
         let msg = super::check_disjoint_bounds_within(bounds.view(), 10).unwrap_err();
         assert!(msg.contains("pairwise disjoint"), "{msg}");
         assert!(msg.contains("row 1 = (4, 8)"), "{msg}");
+    }
+
+    /// Guard for Finding 1 (PR #273 review): sorting the overlap sweep by `start`
+    /// alone ties on equal starts, and `sort_unstable`'s tie-break follows original
+    /// row order. When a non-empty row sits at a lower row index than a zero-length
+    /// row sharing its start, the non-empty row is swept first, its end becomes
+    /// `max_end`, and the zero-length row then spuriously fails `s < max_end` even
+    /// though it writes zero bytes and cannot alias anything. Row order here
+    /// (non-empty row 0, zero-length row 1, both starting at 4) is the ordering that
+    /// reproduces the bug pre-fix.
+    #[test]
+    fn disjoint_bounds_accepts_zero_length_row_tied_with_nonempty_start() {
+        let bounds = ndarray::arr2(&[[4i64, 8], [4, 4]]);
+        assert!(super::check_disjoint_bounds_within(bounds.view(), 8).is_ok());
+    }
+
+    /// Guard for Finding 4 (PR #273 review): pins the "running max end, not just
+    /// previous row's end" property. Row 1 = [2, 4) is nested entirely inside row 0
+    /// = [0, 10), so a weaker check that only compares each row's start against the
+    /// PREVIOUS row's end (rather than the running max) would miss the overlap
+    /// between row 0 and row 2 = [6, 8).
+    #[test]
+    fn disjoint_bounds_rejects_nested_interval() {
+        let bounds = ndarray::arr2(&[[0i64, 10], [2, 4], [6, 8]]);
+        let msg = super::check_disjoint_bounds_within(bounds.view(), 10).unwrap_err();
+        assert!(msg.contains("pairwise disjoint"), "{msg}");
     }
 }
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1112,6 +1112,169 @@ pub fn reconstruct_haplotypes_from_svar2_readbound<'py>(
     Ok((out_data.into_pyarray(py), out_offsets_vec.into_pyarray(py)))
 }
 
+/// Scatter-write variant of [`reconstruct_haplotypes_from_svar2_readbound`]: writes
+/// each (query, hap) row into `out` at the caller-supplied `out_bounds[k] = (start, end)`
+/// instead of allocating a contiguous buffer and returning it.
+///
+/// This is how the SVAR2 spliced read reaches SVAR1's "fused" behavior: the Python
+/// splice plan already knows every row's final address, so each contig group scatters
+/// straight into the shared output buffer — no post-kernel re-order, no extra copy.
+/// `out_bounds` rows are pairwise disjoint but NOT contiguous or ordered: a group's
+/// rows interleave with the other contig groups' rows.
+///
+/// Unlike the allocating entry, this skips `hap_diffs_svar2` — that pass exists only
+/// to size the output, and sizes come from `out_bounds` here.
+///
+/// `to_rc` (per row, kernel row order) reverse-complements negative-strand rows in
+/// place after reconstruction, mirroring `reconstruct_haplotypes_spliced_fused`.
+#[pyfunction(signature = (
+    out,
+    out_bounds,
+    store,
+    contig,
+    region_starts,
+    orig_samples,
+    vk_snp_range,
+    vk_indel_range,
+    dense_snp_range,
+    dense_indel_range,
+    region_bounds,
+    shifts,
+    ref_,
+    ref_offsets,
+    pad_char,
+    to_rc,
+    parallel,
+    filter_exonic = false,
+))]
+#[allow(clippy::too_many_arguments)]
+pub fn reconstruct_haplotypes_from_svar2_readbound_into<'py>(
+    py: Python<'py>,
+    mut out: PyReadwriteArray1<u8>,
+    out_bounds: PyReadonlyArray2<i64>,
+    store: PyRef<'py, crate::svar2::store::Svar2Store>,
+    contig: &str,
+    region_starts: PyReadonlyArray1<u32>,
+    orig_samples: PyReadonlyArray1<i64>,
+    vk_snp_range: PyReadonlyArray2<i64>,
+    vk_indel_range: PyReadonlyArray2<i64>,
+    dense_snp_range: PyReadonlyArray2<i64>,
+    dense_indel_range: PyReadonlyArray2<i64>,
+    region_bounds: PyReadonlyArray2<i32>,
+    shifts: PyReadonlyArray2<i32>,
+    ref_: PyReadonlyArray1<u8>,
+    ref_offsets: PyReadonlyArray1<i64>,
+    pad_char: u8,
+    to_rc: Option<PyReadonlyArray1<bool>>,
+    parallel: bool,
+    filter_exonic: bool,
+) -> PyResult<()> {
+    use crate::reconstruct;
+    use crate::svar2;
+
+    let reader = store.reader(contig).ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(format!("contig {contig} not in store"))
+    })?;
+
+    let shifts_a = shifts.as_array();
+    let ploidy = shifts_a.ncols();
+    let region_bounds_a = region_bounds.as_array();
+    let n_q = region_bounds_a.nrows();
+
+    if out_bounds.as_array().nrows() != n_q * ploidy {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "out_bounds must have n_q*ploidy = {} rows, got {}",
+            n_q * ploidy,
+            out_bounds.as_array().nrows()
+        )));
+    }
+
+    // Build `regions` (n_q, 3) as [contig_idx=0, start, end) — `ref_` is the
+    // single contig slice the caller passed in (ref_offsets = [0, len]).
+    let mut regions = Array2::<i32>::zeros((n_q, 3));
+    for q in 0..n_q {
+        regions[[q, 1]] = region_bounds_a[[q, 0]];
+        regions[[q, 2]] = region_bounds_a[[q, 1]];
+    }
+
+    let region_starts_v: Vec<u32> = region_starts.as_array().to_vec();
+    let orig_samples_v: Vec<usize> = orig_samples
+        .as_array()
+        .iter()
+        .map(|&x| x as usize)
+        .collect();
+    let vk_snp_range_v = arr2_to_ranges(vk_snp_range.as_array());
+    let vk_indel_range_v = arr2_to_ranges(vk_indel_range.as_array());
+    let dense_snp_range_v = arr2_to_ranges(dense_snp_range.as_array());
+    let dense_indel_range_v = arr2_to_ranges(dense_indel_range.as_array());
+
+    // See the allocating entry: `ref_` is sliced then `.as_slice().unwrap()`'d inside
+    // the kernel, so a non-contiguous view would panic there.
+    require_contiguous_1d(&ref_, "ref_")?;
+
+    let ref_a = ref_.as_array();
+    let ref_offsets_a = ref_offsets.as_array();
+    let out_bounds_a = out_bounds.as_array();
+    let to_rc_a = to_rc.as_ref().map(|a| a.as_array());
+    let out_a = out.as_array_mut();
+
+    py.detach(move || {
+        let rb = genoray_core::query::HapRanges::new(
+            &region_starts_v,
+            &orig_samples_v,
+            &vk_snp_range_v,
+            &vk_indel_range_v,
+            &dense_snp_range_v,
+            &dense_indel_range_v,
+            ploidy,
+        );
+        let br = genoray_core::query::gather_haps_readbound(reader, &rb);
+
+        let (lut_bytes, lut_off_u64) = reader.lut_arrays();
+        let lut_off: Vec<i64> = lut_off_u64.iter().map(|&x| x as i64).collect();
+
+        let flat = svar2::split_to_flat(&br);
+        let dense_range_a =
+            numpy::ndarray::ArrayView2::from_shape((n_q, 2), &flat.dense_range).unwrap();
+
+        // No sizing pass: `out_bounds` already carries every row's destination, so
+        // `hap_diffs_svar2` (needed only to build out_offsets) is skipped entirely.
+        let mut out_a = out_a;
+        reconstruct::reconstruct_haplotypes_from_svar2(
+            out_a.view_mut(),
+            out_bounds_a,
+            regions.view(),
+            shifts_a,
+            numpy::ndarray::ArrayView1::from(flat.vk_pos.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.vk_key.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.vk_off.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.dense_pos.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.dense_key.as_slice()),
+            dense_range_a,
+            numpy::ndarray::ArrayView1::from(flat.dense_present.as_slice()),
+            numpy::ndarray::ArrayView1::from(flat.dense_present_off.as_slice()),
+            numpy::ndarray::ArrayView1::from(lut_bytes.as_slice()),
+            numpy::ndarray::ArrayView1::from(lut_off.as_slice()),
+            ref_a,
+            ref_offsets_a,
+            pad_char,
+            parallel,
+            filter_exonic,
+        );
+
+        // In-place RC of negative-strand rows, mirroring the SVAR1 fused splice entry.
+        if let Some(to_rc) = to_rc_a.as_ref() {
+            crate::reverse::rc_bounded_rows_inplace(
+                out_a.as_slice_mut().unwrap(),
+                out_bounds_a,
+                *to_rc,
+            );
+        }
+    });
+
+    Ok(())
+}
+
 /// Read-bound SVAR2 per-hap ilen diffs: the same gather
 /// (`genoray_core::query::gather_haps_readbound` + [`crate::svar2::split_to_flat`]) as
 /// [`reconstruct_haplotypes_from_svar2_readbound`], but stops after

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,10 @@ fn genvarloader(m: &Bound<'_, PyModule>) -> PyResult<()> {
         ffi::reconstruct_haplotypes_from_svar2_readbound,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        ffi::reconstruct_haplotypes_from_svar2_readbound_into,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(ffi::hap_diffs_from_svar2_readbound, m)?)?;
     m.add_function(wrap_pyfunction!(
         ffi::reconstruct_annotated_haplotypes_fused,

--- a/src/reconstruct/mod.rs
+++ b/src/reconstruct/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Mirrors `reconstruct_haplotype_from_sparse` in
 //! `python/genvarloader/_dataset/_genotypes.py:277-465` statement-by-statement.
-use ndarray::{s, ArrayView1, ArrayView2, ArrayViewMut1};
+use ndarray::{s, Array2, ArrayView1, ArrayView2, ArrayViewMut1};
 use rayon::prelude::*;
 
 /// Single-haplotype inner kernel, generic over the variant source.
@@ -615,7 +615,7 @@ pub fn reconstruct_haplotypes_from_sparse(
 #[allow(clippy::too_many_arguments)]
 pub fn reconstruct_haplotypes_from_svar2(
     mut out: ArrayViewMut1<u8>,
-    out_offsets: ArrayView1<i64>,
+    out_bounds: ArrayView2<i64>,
     regions: ArrayView2<i32>,
     shifts: ArrayView2<i32>,
     vk_pos: ArrayView1<i32>,
@@ -636,7 +636,13 @@ pub fn reconstruct_haplotypes_from_svar2(
 ) {
     let batch_size = regions.nrows();
     let ploidy = shifts.ncols();
-    let n_work = batch_size * ploidy;
+    // n_work comes from out_bounds: the caller owns the row->destination mapping.
+    let n_work = out_bounds.nrows();
+    debug_assert_eq!(
+        n_work,
+        batch_size * ploidy,
+        "out_bounds must have one row per (query, hap)"
+    );
 
     // Hoist contiguous-slice pointers once, exactly as SVAR1's do_work captures
     // read-only views — these are Send+Sync so the rayon parallel path is unchanged.
@@ -743,26 +749,33 @@ pub fn reconstruct_haplotypes_from_svar2(
         // proven split_at_mut chain idiom (mirrors get_reference in reference/mod.rs).
         // &mut [_] slices are Send, unlike raw *mut pointers — safe for rayon closures.
         let bounds: Vec<(usize, usize)> = (0..n_work)
-            .map(|k| (out_offsets[k] as usize, out_offsets[k + 1] as usize))
+            .map(|k| (out_bounds[[k, 0]] as usize, out_bounds[[k, 1]] as usize))
             .collect();
 
+        // Destinations are caller-supplied and may be scattered (a spliced read
+        // interleaves this contig group's rows with other groups'), so carve in
+        // ascending-start order rather than row order. The chain's cursor only
+        // moves forward; gaps are bytes owned by another call and are skipped.
+        let mut order: Vec<usize> = (0..n_work).collect();
+        order.sort_unstable_by_key(|&k| bounds[k].0);
+
         let out_slice = out.as_slice_mut().unwrap();
-        let mut out_chunks: Vec<&mut [u8]> = Vec::with_capacity(n_work);
+        let mut out_chunks: Vec<(usize, &mut [u8])> = Vec::with_capacity(n_work);
         {
             let mut rest = &mut out_slice[..];
             let mut cursor = 0usize;
-            for &(s, e) in &bounds {
-                // Contract: `out_offsets` is monotonically non-decreasing, so each
-                // work item's range starts at or after the previous one's end. This
-                // guarantees `s - cursor` does not underflow and the carved slices
-                // are disjoint. The same `bounds` drives the annotation carves below.
+            for &k in &order {
+                let (s, e) = bounds[k];
+                // Contract: `out_bounds` rows are pairwise disjoint. Walking them in
+                // ascending-start order then guarantees `s - cursor` does not
+                // underflow and the carved slices are disjoint.
                 debug_assert!(
                     s >= cursor && e >= s,
-                    "out_offsets must be monotonically non-decreasing (got s={s}, e={e}, cursor={cursor})"
+                    "out_bounds must be pairwise disjoint and non-empty (got s={s}, e={e}, cursor={cursor})"
                 );
                 let (_, tail) = rest.split_at_mut(s - cursor);
                 let (mid, tail2) = tail.split_at_mut(e - s);
-                out_chunks.push(mid);
+                out_chunks.push((k, mid));
                 rest = tail2;
                 cursor = e;
             }
@@ -770,35 +783,43 @@ pub fn reconstruct_haplotypes_from_svar2(
 
         // SVAR2 read-bound haps are never annotated, so dispatch the un-annotated
         // work items straight across rayon.
-        out_chunks
-            .into_par_iter()
-            .enumerate()
-            .for_each(|(k, out_chunk)| {
-                do_work(k, ArrayViewMut1::from(out_chunk));
-            });
+        out_chunks.into_par_iter().for_each(|(k, out_chunk)| {
+            do_work(k, ArrayViewMut1::from(out_chunk));
+        });
     } else {
         // Serial path: use raw pointers for disjoint sub-range access, exactly as before.
         // The serial loop prevents concurrent aliasing.
         let out_raw: *mut u8 = out.as_mut_ptr();
 
         for k in 0..n_work {
-            let out_s = out_offsets[k] as usize;
-            let out_e = out_offsets[k + 1] as usize;
+            let out_s = out_bounds[[k, 0]] as usize;
+            let out_e = out_bounds[[k, 1]] as usize;
             debug_assert!(
                 out_e >= out_s,
-                "out_offsets must be monotonically non-decreasing (got out_s={out_s}, out_e={out_e})"
+                "out_bounds rows must be non-empty (got out_s={out_s}, out_e={out_e})"
             );
 
-            // SAFETY: `out_offsets` is required by the calling contract to be monotonically
-            // non-decreasing, so consecutive (out_s, out_e) pairs are strictly non-overlapping
-            // address ranges within the same allocation.  Because the loop is serial there are
-            // no concurrent borrows, so constructing a `&mut [u8]` from each disjoint sub-range
-            // is free of aliasing UB.
+            // SAFETY: `out_bounds` rows are required by the calling contract to be
+            // pairwise disjoint address ranges within the same allocation. Because the
+            // loop is serial there are no concurrent borrows, so constructing a
+            // `&mut [u8]` from each disjoint sub-range is free of aliasing UB.
             let out_chunk =
                 unsafe { std::slice::from_raw_parts_mut(out_raw.add(out_s), out_e - out_s) };
             do_work(k, ArrayViewMut1::from(out_chunk));
         }
     }
+}
+
+/// Per-row `(start, end)` destination bounds from a gap-free `(n_work + 1,)` offsets
+/// array — the adapter for callers that let the kernel size its own contiguous output.
+pub fn bounds_from_offsets(out_offsets: ArrayView1<i64>) -> Array2<i64> {
+    let n = out_offsets.len() - 1;
+    let mut bounds = Array2::<i64>::zeros((n, 2));
+    for k in 0..n {
+        bounds[[k, 0]] = out_offsets[k];
+        bounds[[k, 1]] = out_offsets[k + 1];
+    }
+    bounds
 }
 
 #[cfg(test)]
@@ -1563,13 +1584,13 @@ mod tests {
         let lut_bytes = arr1::<u8>(&[]);
         let lut_off = arr1(&[0i64]);
 
-        let out_offsets = arr1(&[0i64, 8]);
+        let out_bounds = ndarray::arr2(&[[0i64, 8]]);
         let pad_char = b'N';
         let mut out = Array1::<u8>::from_elem(8, pad_char);
 
         super::reconstruct_haplotypes_from_svar2(
             out.view_mut(),
-            out_offsets.view(),
+            out_bounds.view(),
             regions.view(),
             shifts.view(),
             vk_pos.view(),
@@ -1615,13 +1636,13 @@ mod tests {
         let dense_present_off = arr1(&[0i64, 1]);
         let lut_bytes = arr1::<u8>(&[]);
         let lut_off = arr1(&[0i64]);
-        let out_offsets = arr1(&[0i64, 4]);
+        let out_bounds = ndarray::arr2(&[[0i64, 4]]);
         let pad_char = b'N';
         let mut out = Array1::<u8>::from_elem(4, pad_char);
 
         super::reconstruct_haplotypes_from_svar2(
             out.view_mut(),
-            out_offsets.view(),
+            out_bounds.view(),
             regions.view(),
             shifts.view(),
             vk_pos.view(),
@@ -1642,5 +1663,66 @@ mod tests {
         );
 
         assert_eq!(out.as_slice().unwrap(), b"ACTN");
+    }
+
+    /// Scatter write: rows given non-monotonic, gapped destinations must land exactly
+    /// where `out_bounds` says, leaving the gap untouched. Row 0 is written AFTER
+    /// row 1 in the buffer, mirroring a multi-contig spliced read where one group's
+    /// rows interleave with another's.
+    #[test]
+    fn svar2_scatter_write_honors_out_bounds() {
+        for parallel in [false, true] {
+            let reference = b"ACGT";
+            let ref_ = arr1(reference.as_ref());
+            let ref_offsets = arr1(&[0i64, 4]);
+            // Two identical single-hap queries on contig 0.
+            let regions = ndarray::arr2(&[[0i32, 0, 4], [0i32, 0, 4]]);
+            let shifts = ndarray::arr2(&[[0i32], [0i32]]);
+
+            // No variants at all -> each row is the bare reference "ACGT".
+            let vk_pos = arr1::<i32>(&[]);
+            let vk_key = arr1::<i32>(&[]);
+            let vk_off = arr1(&[0i64, 0, 0]);
+            let dense_pos = arr1::<i32>(&[]);
+            let dense_key = arr1::<i32>(&[]);
+            let dense_range = ndarray::arr2(&[[0i32, 0], [0i32, 0]]);
+            let dense_present = arr1::<u8>(&[]);
+            let dense_present_off = arr1(&[0i64, 0, 0]);
+            let lut_bytes = arr1::<u8>(&[]);
+            let lut_off = arr1(&[0i64]);
+
+            let pad_char = b'N';
+            // Buffer: [row1 @ 0..4][gap 4..6 = another group's rows][row0 @ 6..10]
+            let mut out = Array1::<u8>::from_elem(10, b'-');
+            let out_bounds = ndarray::arr2(&[[6i64, 10], [0i64, 4]]);
+
+            super::reconstruct_haplotypes_from_svar2(
+                out.view_mut(),
+                out_bounds.view(),
+                regions.view(),
+                shifts.view(),
+                vk_pos.view(),
+                vk_key.view(),
+                vk_off.view(),
+                dense_pos.view(),
+                dense_key.view(),
+                dense_range.view(),
+                dense_present.view(),
+                dense_present_off.view(),
+                lut_bytes.view(),
+                lut_off.view(),
+                ref_.view(),
+                ref_offsets.view(),
+                pad_char,
+                parallel,
+                false,
+            );
+
+            assert_eq!(
+                out.as_slice().unwrap(),
+                b"ACGT--ACGT",
+                "parallel={parallel}: rows must land at their out_bounds, gap untouched"
+            );
+        }
     }
 }

--- a/src/reconstruct/mod.rs
+++ b/src/reconstruct/mod.rs
@@ -589,8 +589,12 @@ pub fn reconstruct_haplotypes_from_sparse(
 /// 1.0's `reconstruct_haplotype[s]_from_sparse` are untouched by this function.
 ///
 /// # Parameters
-/// - `out` – flat output buffer, length = out_offsets[-1] (u8); written in place
-/// - `out_offsets` – shape (batch*ploidy + 1,) offsets into `out`
+/// - `out` – flat output buffer (u8); written in place at each row's `out_bounds`
+/// - `out_bounds` – shape (batch*ploidy, 2) as `[start, end)` byte ranges into `out`,
+///   one row per flat work index `k = query * ploidy + hap`; rows are pairwise
+///   disjoint but need not be contiguous or in row order (see
+///   [`bounds_from_offsets`] for the gap-free adapter, and the scatter-write FFI
+///   entry for the caller-supplied-destinations case)
 /// - `regions` – shape (batch, 3) as (contig_idx, start, end) i32
 /// - `shifts` – shape (batch, ploidy) i32
 /// - `vk_pos` / `vk_key` – this hap's `var_key` channel: position + uniform key (i32)
@@ -756,8 +760,19 @@ pub fn reconstruct_haplotypes_from_svar2(
         // interleaves this contig group's rows with other groups'), so carve in
         // ascending-start order rather than row order. The chain's cursor only
         // moves forward; gaps are bytes owned by another call and are skipped.
+        //
+        // Tie-break on `(start, end)`, not `start` alone: `sort_unstable` gives no
+        // guarantee for equal keys, and equal starts are exactly what a zero-length
+        // row produces in a gap-free layout (its bounds are `(off[j], off[j])`, same
+        // start as the following row `(off[j], off[j+1])`). If the tie happens to
+        // sort the non-empty row first, its end advances the cursor past the
+        // zero-length row's start, which then underflows `s - cursor` below. Sorting
+        // by `(start, end)` puts the zero-length row first deterministically,
+        // matching `check_disjoint_bounds_within` in `ffi/mod.rs`, whose overlap
+        // sweep MUST use the identical tie-break for the two to keep agreeing on
+        // which layouts are valid.
         let mut order: Vec<usize> = (0..n_work).collect();
-        order.sort_unstable_by_key(|&k| bounds[k].0);
+        order.sort_unstable_by_key(|&k| bounds[k]);
 
         let out_slice = out.as_slice_mut().unwrap();
         let mut out_chunks: Vec<(usize, &mut [u8])> = Vec::with_capacity(n_work);
@@ -1722,6 +1737,77 @@ mod tests {
                 out.as_slice().unwrap(),
                 b"ACGT--ACGT",
                 "parallel={parallel}: rows must land at their out_bounds, gap untouched"
+            );
+        }
+    }
+
+    /// Guard for Finding 1 (PR #273 review): a zero-length row sharing its `start`
+    /// with a non-empty row must carve correctly regardless of the two rows'
+    /// relative `k` (work-item) order. Sorting the carve order by `start` alone ties
+    /// on equal starts; `sort_unstable` breaks such ties by original position, so
+    /// when the NON-empty row happens to sit at a lower `k` than the zero-length row
+    /// sharing its start, the non-empty row is carved first, its end becomes the
+    /// running cursor, and the zero-length row then computes `s - cursor` with
+    /// `s == cursor`'s old value < the advanced cursor — an underflow panic in the
+    /// parallel `split_at_mut` chain (the serial path's `debug_assert!` would fire
+    /// identically in a debug build). Row order here is deliberately: k=0 non-empty
+    /// "ACGT" landing at [4, 8), k=1 zero-length region landing at [4, 4) — exactly
+    /// the ordering that reproduces the bug pre-fix (see the code review finding for
+    /// why the naive `[[X,X],[X,Y]]` ordering can pass "by luck").
+    #[test]
+    fn svar2_scatter_write_accepts_zero_length_row_tied_with_nonempty_start() {
+        for parallel in [false, true] {
+            let reference = b"ACGT";
+            let ref_ = arr1(reference.as_ref());
+            let ref_offsets = arr1(&[0i64, 4]);
+            // k=0: full-window query -> "ACGT" (non-empty, dest starts at 4).
+            // k=1: zero-width region (start == end) -> empty hap (dest is [4, 4),
+            // tied with k=0's start).
+            let regions = ndarray::arr2(&[[0i32, 0, 4], [0i32, 2, 2]]);
+            let shifts = ndarray::arr2(&[[0i32], [0i32]]);
+
+            let vk_pos = arr1::<i32>(&[]);
+            let vk_key = arr1::<i32>(&[]);
+            let vk_off = arr1(&[0i64, 0, 0]);
+            let dense_pos = arr1::<i32>(&[]);
+            let dense_key = arr1::<i32>(&[]);
+            let dense_range = ndarray::arr2(&[[0i32, 0], [0i32, 0]]);
+            let dense_present = arr1::<u8>(&[]);
+            let dense_present_off = arr1(&[0i64, 0, 0]);
+            let lut_bytes = arr1::<u8>(&[]);
+            let lut_off = arr1(&[0i64]);
+
+            let pad_char = b'N';
+            // Buffer: [gap 0..4 = another group's rows][k=0 "ACGT" @ 4..8][k=1 empty @ 4..4]
+            let mut out = Array1::<u8>::from_elem(8, b'-');
+            let out_bounds = ndarray::arr2(&[[4i64, 8], [4i64, 4]]);
+
+            super::reconstruct_haplotypes_from_svar2(
+                out.view_mut(),
+                out_bounds.view(),
+                regions.view(),
+                shifts.view(),
+                vk_pos.view(),
+                vk_key.view(),
+                vk_off.view(),
+                dense_pos.view(),
+                dense_key.view(),
+                dense_range.view(),
+                dense_present.view(),
+                dense_present_off.view(),
+                lut_bytes.view(),
+                lut_off.view(),
+                ref_.view(),
+                ref_offsets.view(),
+                pad_char,
+                parallel,
+                false,
+            );
+
+            assert_eq!(
+                out.as_slice().unwrap(),
+                b"----ACGT",
+                "parallel={parallel}: nonempty row must carve correctly with a tied zero-length row present"
             );
         }
     }

--- a/src/reverse.rs
+++ b/src/reverse.rs
@@ -2,7 +2,7 @@
 //! buffer. Used by the read-path kernels to emit negative-strand output already
 //! reverse-complemented, replacing the Python RC post-pass on the rust backend.
 
-use ndarray::ArrayView1;
+use ndarray::{ArrayView1, ArrayView2};
 
 /// ACGT<->TGCA complement, identity for every other byte. Mirrors
 /// `bytes.maketrans(b"ACGT", b"TGCA")` (python/genvarloader/_ragged.py).
@@ -64,6 +64,21 @@ pub fn rc_flat_rows_inplace(
         }
         let s = offsets[i] as usize;
         let e = offsets[i + 1] as usize;
+        rc_row(&mut data[s..e]);
+    }
+}
+
+/// Reverse AND complement bytes within each masked row, addressed by explicit
+/// `(start, end)` bounds. The scattered-destination counterpart of
+/// [`rc_flat_rows_inplace`]: rows need not be contiguous or in ascending order,
+/// which is what a spliced SVAR2 scatter write produces.
+pub fn rc_bounded_rows_inplace(data: &mut [u8], bounds: ArrayView2<i64>, to_rc: ArrayView1<bool>) {
+    for i in 0..to_rc.len() {
+        if !to_rc[i] {
+            continue;
+        }
+        let s = bounds[[i, 0]] as usize;
+        let e = bounds[[i, 1]] as usize;
         rc_row(&mut data[s..e]);
     }
 }
@@ -144,5 +159,21 @@ mod tests {
             rc_flat_rows_inplace(&mut row, off.view(), array![true].view());
             assert_eq!(row[0], COMP[b as usize], "byte {b}");
         }
+    }
+
+    #[test]
+    fn rc_bounded_rows_handles_scattered_rows() {
+        use ndarray::arr2;
+        // Two rows at scattered destinations with an untouched gap between them.
+        // Layout: [row0 "ACGT" @ 0..4]["--" gap 4..6][row1 "AACC" @ 6..10]
+        let mut data = b"ACGT--AACC".to_vec();
+        let bounds = arr2(&[[6i64, 10], [0i64, 4]]);
+        let to_rc = array![true, false];
+
+        super::rc_bounded_rows_inplace(&mut data, bounds.view(), to_rc.view());
+
+        // Row 0 of the mask addresses bytes 6..10 ("AACC" -> RC -> "GGTT").
+        // Row 1 is unmasked; the gap must be untouched.
+        assert_eq!(&data, b"ACGT--GGTT");
     }
 }

--- a/tests/dataset/test_svar2_dataset.py
+++ b/tests/dataset/test_svar2_dataset.py
@@ -728,6 +728,57 @@ def test_svar2_haplotypes_match_svar1_multicontig(
     assert np.array_equal(a.data.view("u1"), b.data.view("u1"))
 
 
+def test_svar2_spliced_haplotypes_match_svar1_multicontig(
+    tmp_path, svar_fixture2, svar2_fixture2, _src2
+):
+    """Spliced haplotypes byte-identical to SVAR1 when transcripts span TWO contigs.
+
+    Splice order is (splice_row, sample, ploid, element), but SVAR2 reconstructs
+    per contig group — so each group's rows land at NON-contiguous destinations
+    interleaved with the other group's. Single-contig spliced tests (and the chr22
+    benchmark) never produce that layout, so this is the only guard on the
+    scattered-destination path. Minus strand is included so the RC pass is
+    exercised on scattered rows too.
+    """
+    from genoray import SparseVar, SparseVar2
+
+    _bcf, ref = _src2
+    # Interleaved contigs, out of sorted order; Tb is minus-strand and multi-exon.
+    splice_bed = pl.DataFrame(
+        {
+            "chrom": ["chr2", "chr1", "chr2", "chr1"],
+            "chromStart": [0, 0, 20, 5],
+            "chromEnd": [13, 13, 40, 20],
+            "strand": ["+", "-", "+", "-"],
+            "transcript_id": ["Ta", "Tb", "Ta", "Tb"],
+            "exon_number": [1, 1, 2, 2],
+        }
+    )
+    d1 = tmp_path / "mcs1.gvl"
+    d2 = tmp_path / "mcs2.gvl"
+    gvl.write(
+        d1, splice_bed, variants=SparseVar(svar_fixture2), samples=None, overwrite=True
+    )
+    gvl.write(
+        d2,
+        splice_bed,
+        variants=SparseVar2(svar2_fixture2),
+        samples=None,
+        overwrite=True,
+    )
+    settings = {"splice_info": ("transcript_id", "exon_number"), "var_filter": "exonic"}
+    ds1 = gvl.Dataset.open(d1, reference=ref, **settings).with_seqs("haplotypes")
+    ds2 = gvl.Dataset.open(d2, reference=ref, **settings).with_seqs("haplotypes")
+
+    a = ds1[:, :]
+    b = ds2[:, :]
+    assert np.array_equal(np.asarray(a.offsets), np.asarray(b.offsets)), (
+        f"offsets differ: svar1={np.asarray(a.offsets).tolist()} "
+        f"svar2={np.asarray(b.offsets).tolist()}"
+    )
+    assert np.array_equal(a.data.view("u1"), b.data.view("u1"))
+
+
 # --------------------------------------------------------------------------
 # variant-windows (Task 1): ref_window pinned to SVAR1; alt_window validated via
 # ref-flank decomposition + tokenized variants.alt; multi-contig stitch, dummy

--- a/tests/dataset/test_svar2_dataset.py
+++ b/tests/dataset/test_svar2_dataset.py
@@ -734,24 +734,32 @@ def test_svar2_spliced_haplotypes_match_svar1_multicontig(
     """Spliced haplotypes byte-identical to SVAR1 when transcripts span TWO contigs.
 
     Splice order is (splice_row, sample, ploid, element), but SVAR2 reconstructs
-    per contig group — so each group's rows land at NON-contiguous destinations
-    interleaved with the other group's. Single-contig spliced tests (and the chr22
-    benchmark) never produce that layout, so this is the only guard on the
-    scattered-destination path. Minus strand is included so the RC pass is
-    exercised on scattered rows too.
+    per contig group — so each group's rows land at destinations that are both
+    non-monotonic AND gapped: the chr2 group (Ta + Tc) is split into two blocks
+    with the chr1 group's (Tb) block sandwiched between them, because splice
+    order runs Ta -> Tb -> Tc. The Rust carve must tolerate destination gaps
+    (bytes owned by another call interleaved within a single contig group's
+    scatter), and that's only exercised with 3+ transcripts alternating contigs.
+    A single-contig fast path or a plain 2-transcript, 2-contig bed never
+    produces a gap — each contig's block stays contiguous, just reordered
+    relative to the other contig. Tb and Tc are both minus-strand, and Tc's
+    rows land in the gapped (chr2) group, so the RC pass (rc_bounded_rows_inplace)
+    is exercised on genuinely gapped destinations, not just scattered ones.
     """
     from genoray import SparseVar, SparseVar2
 
     _bcf, ref = _src2
-    # Interleaved contigs, out of sorted order; Tb is minus-strand and multi-exon.
+    # 3 transcripts alternating contigs (Ta:chr2, Tb:chr1, Tc:chr2) so splice
+    # order (Ta -> Tb -> Tc) splits chr2's group (Ta ∪ Tc) around chr1's (Tb)
+    # block -> gapped destinations. Tb and Tc are minus-strand.
     splice_bed = pl.DataFrame(
         {
-            "chrom": ["chr2", "chr1", "chr2", "chr1"],
-            "chromStart": [0, 0, 20, 5],
-            "chromEnd": [13, 13, 40, 20],
-            "strand": ["+", "-", "+", "-"],
-            "transcript_id": ["Ta", "Tb", "Ta", "Tb"],
-            "exon_number": [1, 1, 2, 2],
+            "chrom": ["chr2", "chr1", "chr2", "chr1", "chr2", "chr2"],
+            "chromStart": [0, 0, 20, 5, 5, 25],
+            "chromEnd": [13, 13, 40, 20, 18, 45],
+            "strand": ["+", "-", "+", "-", "-", "-"],
+            "transcript_id": ["Ta", "Tb", "Ta", "Tb", "Tc", "Tc"],
+            "exon_number": [1, 1, 2, 2, 1, 2],
         }
     )
     d1 = tmp_path / "mcs1.gvl"


### PR DESCRIPTION
Merges `main` into the long-lived `streaming` integration branch to close the divergence that opened when PR #281 (svar2 spliced scatter-write) and PR #287 (StreamingDataset board coordination) landed on `main` after the streaming stack was cut.

## What comes in
- **#281 — svar2 spliced scatter-write.** Overlaps the streaming engine in `src/ffi/mod.rs`, `src/reconstruct/mod.rs`, `src/reverse.rs`, `src/lib.rs`. Git auto-merged these **textually** (non-overlapping regions) — **CI is the semantic gate** here, which is the whole reason this is a PR and not a direct push to `streaming`.
- **#287 — CLAUDE.md board-coordination section**, merged alongside the stack's own CLAUDE.md edits.
- **`rust-migration.md` rename/modify** resolved via git rename detection: the streaming stack moved it to `docs/archive/roadmaps/`, #281 modified it in place, and #281's edits landed in the archived copy (verified).

## Why a PR
The merge is textually conflict-free, but a clean text-merge of two features that both edit the FFI/reconstruct hot path does not prove semantic correctness. This runs the same full build + pytest (py310–313) + cargo matrix that gates everything else before it lands on the long-lived branch.

Merge method: **merge commit** (no squash) to preserve history. Do **not** delete the head — `main` divergence is expected to recur and be reconciled the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)