### PR TITLE
perf(streaming): overlap producer I/O with consumer generation via Svar1StreamEngine (#283)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ scripts/
 .ruff_cache/
 .benchmarks/
 .custom_benchmarks/
-benchmarking/
+benchmarking/*
+!benchmarking/streaming/
 genvarloader*.tar.gz
 .nfs*
 commit_msg.txt

--- a/benchmarking/streaming/cold_cache_overlap.py
+++ b/benchmarking/streaming/cold_cache_overlap.py
@@ -284,6 +284,11 @@ def main() -> None:
     )
 
     strategies = ["engine", "readahead"]
+    # FIXED per-strategy seed offset (Minor 2): `hash(strategy)` is randomized per
+    # process by PYTHONHASHSEED, so it made engine vs. readahead see differently-seeded
+    # stores run-to-run. A stable offset keeps each strategy's per-rep store
+    # deterministic while still differing between strategies.
+    strategy_seed_offset = {s: i * 50 for i, s in enumerate(strategies)}
     timings: dict[str, list[float]] = {s: [] for s in strategies}
     proxy_rows: list[tuple[float, float, float]] = []
 
@@ -297,7 +302,7 @@ def main() -> None:
                     args.n_variants,
                     args.n_samples,
                     args.contig_len,
-                    seed=args.seed + rep * 1000 + hash(strategy) % 100,
+                    seed=args.seed + rep * 1000 + strategy_seed_offset[strategy],
                 )
                 bed = _make_bed(args.n_regions, args.region_len, args.contig_len)
 

--- a/benchmarking/streaming/cold_cache_overlap.py
+++ b/benchmarking/streaming/cold_cache_overlap.py
@@ -1,0 +1,368 @@
+"""Cold-cache A-vs-C measurement harness (issue #283).
+
+Compares Design A (the landed producer-thread `Svar1StreamEngine`, the default
+``_prefetch_strategy="engine"``) against Design C (single-thread read-ahead-one-
+window, ``_prefetch_strategy="readahead"``) for a full
+``list(sds.to_iter(batch_size=...))`` sweep over a SVAR1 store. This harness only
+MEASURES -- it does not pick a winner; PR 2 ships whichever design a cold-cache
+measurement favors (the controller reads this harness's output and makes that call
+in a separate task, per ``.superpowers/sdd/task-9-design-note.md``).
+
+COLD CACHE, NO ROOT
+--------------------
+This harness does NOT (and, unprivileged, cannot) drop the kernel page cache via
+``echo 3 > /proc/sys/vm/drop_caches``. Instead every timed run gets its OWN
+freshly-built ``.svar`` store (new inode, under a fresh ``tempfile.mkdtemp()``
+directory, never read by this process before the timed sweep touches it) --
+"cold" here means "never-faulted", not "guaranteed absent from the page cache".
+A store's own build (writing the VCF/BCF/``.svar`` files) does populate the page
+cache with the pages it just wrote, so a store that is too small can still read
+back partially warm. To make the timed read dominated by genuinely cold I/O
+rather than a warm hit off the build's own write-back cache, size the store
+(``--n-variants`` x ``--n-samples`` x ``--contig-len``) so a full sweep's variant
+footprint is large relative to typical page-cache residency -- the CLI defaults
+aim for "thousands of variants, hundreds of samples, a contig long enough to
+spread many read windows across it", per the design note; bump the flags up for a
+more convincing cold-cache measurement on a quieter box.
+
+NODE IS SHARED / NOISY
+-----------------------
+This runs on a shared, noisy node (see the project's perf-gate convention in
+CLAUDE.md / docs/roadmaps/streaming-dataset.md). Report best-of-N (N>=3,
+``--repeats``) per strategy, not a single sample, and treat the reported ratio as
+secondary color, NOT a pass/fail gate.
+
+Run:
+    pixi run -e dev python benchmarking/streaming/cold_cache_overlap.py
+    pixi run -e dev python benchmarking/streaming/cold_cache_overlap.py --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+
+import genvarloader as gvl
+
+_CONTIG = "chr1"
+
+
+def _make_vcf(
+    path: Path, n_variants: int, n_samples: int, contig_len: int, seed: int
+) -> None:
+    """A SNP-only, biallelic VCF -- same shape as `test_streaming_scale.py`'s
+    fixture, just parameterized. SNP-only keeps haplotype length independent of
+    genotype, which isn't needed here (this harness doesn't check parity) but
+    keeps generation simple and fast."""
+    if n_variants > contig_len - 4:
+        raise ValueError(
+            f"n_variants ({n_variants}) must be < contig_len - 4 ({contig_len - 4})"
+        )
+    rng = np.random.default_rng(seed)
+    header = [
+        "##fileformat=VCFv4.2",
+        f"##contig=<ID={_CONTIG},length={contig_len}>",
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t"
+        + "\t".join(f"S{i}" for i in range(n_samples)),
+    ]
+    positions = np.sort(
+        rng.choice(np.arange(2, contig_len - 2), n_variants, replace=False)
+    )
+    # Vectorized genotype generation: (n_variants, n_samples, 2) alleles -> "a|b"
+    # strings, joined per-row. A per-cell Python loop over n_variants*n_samples
+    # (which can be in the hundreds of thousands to millions at realistic sizes)
+    # is slow enough to matter here.
+    alleles = rng.integers(0, 2, size=(n_variants, n_samples, 2))
+    gt_rows = np.char.add(
+        np.char.add(alleles[:, :, 0].astype("U1"), "|"), alleles[:, :, 1].astype("U1")
+    )
+    lines = header
+    for i, pos in enumerate(positions):
+        lines.append(
+            f"{_CONTIG}\t{pos}\t.\tA\tG\t.\t.\t.\tGT\t" + "\t".join(gt_rows[i])
+        )
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _build_store(
+    tmp_dir: Path, n_variants: int, n_samples: int, contig_len: int, seed: int
+) -> tuple[Path, Path]:
+    """Build a FRESH reference FASTA + SparseVar (.svar) store under `tmp_dir`.
+    `tmp_dir` must be a directory this process has never read from before
+    (a fresh `tempfile.mkdtemp()` per timed run) -- see the module docstring."""
+    from genoray import VCF, SparseVar
+
+    ref = tmp_dir / "ref.fa"
+    rng = np.random.default_rng(seed + 1)
+    seq = "".join(rng.choice(list("ACGT"), contig_len))
+    ref.write_text(f">{_CONTIG}\n{seq}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True, capture_output=True)
+
+    vcf = tmp_dir / "in.vcf"
+    _make_vcf(vcf, n_variants, n_samples, contig_len, seed)
+    bcf = tmp_dir / "in.bcf"
+    subprocess.run(
+        ["bcftools", "view", "-Ob", "-o", str(bcf), str(vcf)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["bcftools", "index", str(bcf)], check=True, capture_output=True)
+
+    svar = tmp_dir / "store.svar"
+    SparseVar.from_vcf(
+        svar,
+        VCF(bcf),
+        max_mem="1g",
+        samples=[f"S{i}" for i in range(n_samples)],
+        overwrite=True,
+    )
+    return svar, ref
+
+
+def _make_bed(n_regions: int, region_len: int, contig_len: int) -> pl.DataFrame:
+    """`n_regions` non-overlapping regions spread across the contig, so a full
+    sweep spans many read windows (the window plan chunks both regions and
+    samples -- see `StreamingDataset._plan`)."""
+    if n_regions * region_len > contig_len:
+        raise ValueError(
+            f"n_regions * region_len ({n_regions * region_len}) exceeds "
+            f"contig_len ({contig_len}); reduce --n-regions or --region-len, or "
+            "raise --contig-len"
+        )
+    starts = np.linspace(0, contig_len - region_len, n_regions).astype(np.int64)
+    starts = np.unique(starts)
+    return pl.DataFrame(
+        {
+            "chrom": [_CONTIG] * len(starts),
+            "chromStart": starts,
+            "chromEnd": starts + region_len,
+        }
+    )
+
+
+def _time_sweep(
+    bed: pl.DataFrame,
+    ref: Path,
+    svar: Path,
+    batch_size: int,
+    max_mem: str,
+    strategy: str,
+) -> float:
+    """Time one full `list(sds.to_iter(...))` sweep under `strategy`. Construction
+    (which reads the store's static variant table) happens OUTSIDE the timed
+    region -- only the sweep itself (window reads + prefetch + generation) is
+    timed, matching what a training loop actually pays per epoch."""
+    sds = gvl.StreamingDataset(
+        bed, reference=ref, variants=svar, max_mem=max_mem
+    ).with_seqs("haplotypes")
+    object.__setattr__(sds, "_prefetch_strategy", strategy)
+
+    t0 = time.perf_counter()
+    n_rows = 0
+    for _data, r_idx, _s_idx in sds.to_iter(batch_size=batch_size):
+        n_rows += len(r_idx)
+    elapsed = time.perf_counter() - t0
+    assert n_rows == sds.shape[0] * sds.shape[1], (
+        f"sweep yielded {n_rows} rows, expected {sds.shape[0] * sds.shape[1]} "
+        "(shape[0]*shape[1]) -- harness is not exercising the full dataset"
+    )
+    return elapsed
+
+
+def _time_readahead_with_overlap_proxy(
+    bed: pl.DataFrame, ref: Path, svar: Path, batch_size: int, max_mem: str
+) -> tuple[float, float, float]:
+    """Re-drives the SAME Design C loop `_iter_batches` runs (read_window /
+    svar1_prefetch_runs / generate_batch), but with timers around the prefetch and
+    generate calls separately, to give a CRUDE proxy for how much of the total
+    time is prefetch vs. generation. This is NOT a measurement of cross-thread
+    overlap (Design C is single-threaded) -- it can only show whether the kernel's
+    own readahead had time to act between the prefetch fold and the following
+    generate() call touching the same pages; treat it as color, not a hard number.
+    Returns (total_wall, prefetch_time_sum, generate_time_sum).
+    """
+    from genvarloader.genvarloader import svar1_prefetch_runs
+
+    sds = gvl.StreamingDataset(
+        bed, reference=ref, variants=svar, max_mem=max_mem
+    ).with_seqs("haplotypes")
+    backend = sds._backend
+    assert backend is not None
+
+    plan = list(sds._plan())
+    t_prefetch = 0.0
+    t_generate = 0.0
+    t0 = time.perf_counter()
+    if plan:
+        cur = backend.read_window(*plan[0])
+        for i, (r_idx, s_idx) in enumerate(plan):
+            if i + 1 < len(plan):
+                nxt = backend.read_window(*plan[i + 1])
+                t_pf0 = time.perf_counter()
+                svar1_prefetch_runs(backend._store, nxt[0], nxt[1])
+                t_prefetch += time.perf_counter() - t_pf0
+            else:
+                nxt = None
+            n_rows = len(r_idx) * len(s_idx)
+            for lo in range(0, n_rows, batch_size):
+                hi = min(lo + batch_size, n_rows)
+                t_g0 = time.perf_counter()
+                backend.generate_batch(r_idx, s_idx, cur[0], cur[1], lo, hi)
+                t_generate += time.perf_counter() - t_g0
+            cur = nxt
+    total = time.perf_counter() - t0
+    return total, t_prefetch, t_generate
+
+
+def _fmt(vals: list[float]) -> str:
+    return f"best={min(vals):.3f}s median={sorted(vals)[len(vals) // 2]:.3f}s"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description=(
+            "Cold-cache A-vs-C measurement for StreamingDataset's SVAR1 prefetch "
+            "strategies (engine vs. readahead), issue #283. See the module "
+            "docstring for the cold-cache-without-root methodology and its caveats."
+        ),
+    )
+    p.add_argument("--n-variants", type=int, default=4000, help="variants in the store")
+    p.add_argument("--n-samples", type=int, default=300, help="samples in the store")
+    p.add_argument(
+        "--contig-len", type=int, default=1_000_000, help="contig length (bp)"
+    )
+    p.add_argument(
+        "--n-regions", type=int, default=128, help="BED regions swept per run"
+    )
+    p.add_argument(
+        "--region-len", type=int, default=500, help="length of each BED region (bp)"
+    )
+    p.add_argument("--batch-size", type=int, default=64, help="to_iter batch_size")
+    p.add_argument(
+        "--max-mem", type=str, default="64MB", help="StreamingDataset max_mem"
+    )
+    p.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="timed runs per strategy (best-of-N reported); each run builds its "
+        "OWN fresh store, so N>=1 always costs N store builds per strategy",
+    )
+    p.add_argument("--seed", type=int, default=0, help="base RNG seed")
+    p.add_argument(
+        "--overlap-proxy",
+        action="store_true",
+        help="also report the crude prefetch-vs-generate timing breakdown for "
+        "the readahead strategy (re-drives the sweep once more per repeat)",
+    )
+    p.add_argument(
+        "--keep-tmp",
+        action="store_true",
+        help="keep the per-run tmp dirs (stores) instead of deleting them after "
+        "each timed run; useful for inspecting store size / debugging",
+    )
+    args = p.parse_args()
+
+    print(
+        f"cold_cache_overlap: n_variants={args.n_variants} n_samples={args.n_samples} "
+        f"contig_len={args.contig_len} n_regions={args.n_regions} "
+        f"region_len={args.region_len} batch_size={args.batch_size} "
+        f"max_mem={args.max_mem} repeats={args.repeats}"
+    )
+    print(
+        "NOTE: this node is shared/noisy -- best-of-N per strategy is reported; "
+        "treat the ratio as secondary color, not a pass/fail gate.\n"
+    )
+
+    strategies = ["engine", "readahead"]
+    timings: dict[str, list[float]] = {s: [] for s in strategies}
+    proxy_rows: list[tuple[float, float, float]] = []
+
+    kept_dirs: list[Path] = []
+    for rep in range(args.repeats):
+        for strategy in strategies:
+            tmp_dir = Path(tempfile.mkdtemp(prefix="gvl_cold_cache_"))
+            try:
+                svar, ref = _build_store(
+                    tmp_dir,
+                    args.n_variants,
+                    args.n_samples,
+                    args.contig_len,
+                    seed=args.seed + rep * 1000 + hash(strategy) % 100,
+                )
+                bed = _make_bed(args.n_regions, args.region_len, args.contig_len)
+
+                if strategy == "readahead" and args.overlap_proxy:
+                    elapsed, t_pf, t_gen = _time_readahead_with_overlap_proxy(
+                        bed, ref, svar, args.batch_size, args.max_mem
+                    )
+                    proxy_rows.append((elapsed, t_pf, t_gen))
+                else:
+                    elapsed = _time_sweep(
+                        bed, ref, svar, args.batch_size, args.max_mem, strategy
+                    )
+            finally:
+                if args.keep_tmp:
+                    kept_dirs.append(tmp_dir)
+                else:
+                    shutil.rmtree(tmp_dir, ignore_errors=True)
+
+            timings[strategy].append(elapsed)
+            print(f"[rep {rep + 1}/{args.repeats}] {strategy:>10s}: {elapsed:.3f}s")
+
+    print()
+    print("=" * 60)
+    print(f"{'strategy':>10s}  {'runs (s)':<40s}")
+    print("-" * 60)
+    for strategy in strategies:
+        vals = timings[strategy]
+        runs_str = " ".join(f"{v:.3f}" for v in vals)
+        print(f"{strategy:>10s}  [{runs_str}]  ({_fmt(vals)})")
+    print("-" * 60)
+
+    best_engine = min(timings["engine"])
+    best_readahead = min(timings["readahead"])
+    ratio_e_over_c = (
+        best_engine / best_readahead if best_readahead > 0 else float("nan")
+    )
+    ratio_c_over_e = best_readahead / best_engine if best_engine > 0 else float("nan")
+    print(
+        f"best-of-{args.repeats}: engine={best_engine:.3f}s readahead={best_readahead:.3f}s"
+    )
+    print(
+        f"ratio: engine/readahead={ratio_e_over_c:.3f}  "
+        f"readahead/engine={ratio_c_over_e:.3f}"
+    )
+    print("=" * 60)
+
+    if proxy_rows:
+        print()
+        print(
+            "readahead crude overlap proxy (prefetch-call time vs. generate-call "
+            "time; single-threaded, see docstring caveat):"
+        )
+        for i, (total, t_pf, t_gen) in enumerate(proxy_rows):
+            other = total - t_pf - t_gen
+            print(
+                f"  rep {i + 1}: total={total:.3f}s prefetch={t_pf:.3f}s "
+                f"generate={t_gen:.3f}s other/overhead={other:.3f}s"
+            )
+
+    if kept_dirs:
+        print()
+        print("kept tmp dirs (--keep-tmp):")
+        for d in kept_dirs:
+            print(f"  {d}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/roadmaps/streaming-dataset.md
+++ b/docs/roadmaps/streaming-dataset.md
@@ -76,7 +76,7 @@ only** (no map-style random access).
 | Plan | Scope | Status |
 |---|---|---|
 | `docs/superpowers/plans/2026-07-15-streaming-dataset-svar1-walking-skeleton.md` | Walking skeleton: SVAR1 → haplotypes end-to-end, parity-verified (no double-buffer) | ✅ done — PR [#274](https://github.com/mcvickerlab/GenVarLoader/pull/274) |
-| `docs/superpowers/plans/2026-07-16-streaming-svar1-window-engine.md` | **Re-scoped:** genoray ungated `svar1_query` → gvl window-granular SVAR1 reads + double-buffer engine + `to_iter` surface. Issue [#275](https://github.com/mcvickerlab/GenVarLoader/issues/275). Spec: `2026-07-16-streaming-svar1-window-engine-design.md` | 🚧 Tasks 2-4 done; Task 5's generic `StreamBackend`/`run_windows` engine done, SVAR1 wiring split to follow-up issue [#283](https://github.com/mcvickerlab/GenVarLoader/issues/283) |
+| `docs/superpowers/plans/2026-07-16-streaming-svar1-window-engine.md` | **Re-scoped:** genoray ungated `svar1_query` → gvl window-granular SVAR1 reads + double-buffer engine + `to_iter` surface. Issue [#275](https://github.com/mcvickerlab/GenVarLoader/issues/275). Spec: `2026-07-16-streaming-svar1-window-engine-design.md` | 🚧 Tasks 2-4 done; Task 5's generic `StreamBackend`/`run_windows` engine done; SVAR1 wiring (issue [#283](https://github.com/mcvickerlab/GenVarLoader/issues/283)) done — 8a (Rust engine) + 8b (Python wiring, `to_iter()` now overlaps producer I/O with consumer generation) both landed; follow-up [#296](https://github.com/mcvickerlab/GenVarLoader/issues/296) for a throughput-gate observability gap |
 | _TBD (Plan 3/4)_ — issue [#276](https://github.com/mcvickerlab/GenVarLoader/issues/276) | VCF backend / PGEN backend | ⬜ |
 | _TBD (Plan 5)_ — issue [#277](https://github.com/mcvickerlab/GenVarLoader/issues/277) | Output-mode breadth (annotated/variants, `with_len`, `min_af`/`max_af`, `var_fields`, jitter) | ⬜ |
 
@@ -195,6 +195,30 @@ only** (no map-style random access).
       split (offsets-only vs. fully-reconstructed) as its first step, since that
       decision shapes the GIL-crossing design. Cold-page-cache overlap measurement
       (the deferred Step 6) belongs to this follow-up, not to #275.
+    - ✅ **Task 8a (Rust engine): `Svar1StreamEngine` pyclass** — `src/ffi/stream_engine.rs`,
+      producer/consumer overlap copying `run_windows`'s discipline (2-slot ping-pong
+      `crossbeam_channel`, shutdown-by-`Sender`-drop, join-then-classify-panics), plus a
+      per-contig-reference deviation from the original design note (byte-parity
+      requirement for multi-contig plans — see the design note and task-8-report.md for
+      the reasoning). Commit `814df7db`.
+    - ✅ **Task 8b (Python wiring): `_streaming.py` drives the engine** — `_Svar1Backend`
+      now caches per-contig meta (`_contig_meta`) and the store path (`_svar_path`) at
+      construction, and gained `build_engine(jobs, batch_size)`; `_iter_batches`'s real
+      (`self._backend is not None`) branch materializes `plan = list(self._plan())`
+      once, builds one engine job per window from it (translating `s_idx` to physical
+      sample indices the same way `read_window` does), and drives `engine.next_batch()`
+      in lockstep with the SAME plan so job order and per-window batching can't diverge.
+      `n_slots` bumped 1→2 (ping-pong residency). Byte-identical parity holds
+      (`test_streaming_matches_written_all_cells`, `test_scale_parity_still_byte_identical`
+      both green). **Known gap, deliberately left unfixed (Python-only scope):** the
+      `#275` `svar1_csr_entries_touched()` throughput gate's `thread_local!` counter is
+      blind to the engine's background producer thread (increments happen on a thread
+      Python's main thread never reads from), failing
+      `test_entries_touched_scales_with_window_not_store` — filed as
+      [#296](https://github.com/mcvickerlab/GenVarLoader/issues/296) (Rust-side fix:
+      make the counter cross the thread boundary, e.g. a process-wide atomic).
+      Design note: `.superpowers/sdd/task-8b-design-note.md`; full report:
+      `.superpowers/sdd/task-8-report.md`.
   - ⚠️ **Inherited perf/scale debt from the walking skeleton — DELETED, not fixed, by Task 2.**
     All of it was downstream of the one wrong dependency above, so the rewrite removed it rather
     than optimizing it. (a) `Svar1RecordSource::new` was **O(all CSR entries)** — it eagerly

--- a/docs/roadmaps/streaming-dataset.md
+++ b/docs/roadmaps/streaming-dataset.md
@@ -212,6 +212,21 @@ only** (no map-style random access).
       (`test_streaming_matches_written_all_cells`, `test_scale_parity_still_byte_identical`
       both green). Design note: `.superpowers/sdd/task-8b-design-note.md`; full report:
       `.superpowers/sdd/task-8-report.md`.
+    - ✅ **Final-review Finding 1 fixed in-branch — engine job residency is now genuinely
+      cohort-independent.** The first cut materialized `list(self._plan())` and one
+      `WindowJob { phys_samples: Vec<usize> }` per window: `O(n_windows × window_samples)`
+      ≈ cohort × regions sample-index metadata (~1–2 GB at 50k regions × 100k samples),
+      resident in three places and unbounded by `max_mem` — eroding #284's guarantee, and
+      the "cohort-independent" claim in `stream_engine.rs` was false. Because `_plan`
+      always yields a CONTIGUOUS `arange(s_lo, s_hi)` sample chunk, the engine now holds
+      the public→physical map (`phys_sample_idx`) ONCE (`O(n_samples)`) and each job
+      carries only `(contig_idx, regions, s_lo, s_hi)` (region-scale); the producer
+      borrows `&phys_sample_idx[s_lo..s_hi]` per window (zero-copy). Both drives
+      (`_iter_batches` engine + readahead) stopped materializing `list(self._plan())`,
+      building one compact region-scale plan instead. Total residency
+      `O(n_windows × window_regions) + O(n_samples)`, never `O(n_windows × n_samples)`.
+      Parity byte-identical under both strategies; 20× race-stable. Fix note:
+      `.superpowers/sdd/task-8-fix2-note.md`; report: `.superpowers/sdd/task-8-report.md`.
     - ✅ **[#296](https://github.com/mcvickerlab/GenVarLoader/issues/296) fixed
       (commit `b2c5af90`).** The `#275` `svar1_csr_entries_touched()` throughput gate's
       `thread_local!` counter was blind to the engine's background producer thread

--- a/docs/roadmaps/streaming-dataset.md
+++ b/docs/roadmaps/streaming-dataset.md
@@ -76,7 +76,7 @@ only** (no map-style random access).
 | Plan | Scope | Status |
 |---|---|---|
 | `docs/superpowers/plans/2026-07-15-streaming-dataset-svar1-walking-skeleton.md` | Walking skeleton: SVAR1 → haplotypes end-to-end, parity-verified (no double-buffer) | ✅ done — PR [#274](https://github.com/mcvickerlab/GenVarLoader/pull/274) |
-| `docs/superpowers/plans/2026-07-16-streaming-svar1-window-engine.md` | **Re-scoped:** genoray ungated `svar1_query` → gvl window-granular SVAR1 reads + double-buffer engine + `to_iter` surface. Issue [#275](https://github.com/mcvickerlab/GenVarLoader/issues/275). Spec: `2026-07-16-streaming-svar1-window-engine-design.md` | 🚧 Tasks 2-4 done; Task 5's generic `StreamBackend`/`run_windows` engine done; SVAR1 wiring (issue [#283](https://github.com/mcvickerlab/GenVarLoader/issues/283)) done — 8a (Rust engine) + 8b (Python wiring, `to_iter()` now overlaps producer I/O with consumer generation) both landed; follow-up [#296](https://github.com/mcvickerlab/GenVarLoader/issues/296) for a throughput-gate observability gap |
+| `docs/superpowers/plans/2026-07-16-streaming-svar1-window-engine.md` | **Re-scoped:** genoray ungated `svar1_query` → gvl window-granular SVAR1 reads + double-buffer engine + `to_iter` surface. Issue [#275](https://github.com/mcvickerlab/GenVarLoader/issues/275). Spec: `2026-07-16-streaming-svar1-window-engine-design.md` | 🚧 Tasks 2-4 done; Task 5's generic `StreamBackend`/`run_windows` engine done; SVAR1 wiring (issue [#283](https://github.com/mcvickerlab/GenVarLoader/issues/283)) done — 8a (Rust engine) + 8b (Python wiring, `to_iter()` now overlaps producer I/O with consumer generation) both landed; cold-cache A-vs-C measured (producer-thread engine wins 1.46×, ships as default); [#296](https://github.com/mcvickerlab/GenVarLoader/issues/296) throughput-gate observability gap fixed (`b2c5af90`) |
 | _TBD (Plan 3/4)_ — issue [#276](https://github.com/mcvickerlab/GenVarLoader/issues/276) | VCF backend / PGEN backend | ⬜ |
 | _TBD (Plan 5)_ — issue [#277](https://github.com/mcvickerlab/GenVarLoader/issues/277) | Output-mode breadth (annotated/variants, `with_len`, `min_af`/`max_af`, `var_fields`, jitter) | ⬜ |
 
@@ -210,15 +210,33 @@ only** (no map-style random access).
       in lockstep with the SAME plan so job order and per-window batching can't diverge.
       `n_slots` bumped 1→2 (ping-pong residency). Byte-identical parity holds
       (`test_streaming_matches_written_all_cells`, `test_scale_parity_still_byte_identical`
-      both green). **Known gap, deliberately left unfixed (Python-only scope):** the
-      `#275` `svar1_csr_entries_touched()` throughput gate's `thread_local!` counter is
-      blind to the engine's background producer thread (increments happen on a thread
-      Python's main thread never reads from), failing
-      `test_entries_touched_scales_with_window_not_store` — filed as
-      [#296](https://github.com/mcvickerlab/GenVarLoader/issues/296) (Rust-side fix:
-      make the counter cross the thread boundary, e.g. a process-wide atomic).
-      Design note: `.superpowers/sdd/task-8b-design-note.md`; full report:
+      both green). Design note: `.superpowers/sdd/task-8b-design-note.md`; full report:
       `.superpowers/sdd/task-8-report.md`.
+    - ✅ **[#296](https://github.com/mcvickerlab/GenVarLoader/issues/296) fixed
+      (commit `b2c5af90`).** The `#275` `svar1_csr_entries_touched()` throughput gate's
+      `thread_local!` counter was blind to the engine's background producer thread
+      (`read_window` now runs there), which failed
+      `test_entries_touched_scales_with_window_not_store` **and** silently vacuum-passed
+      `test_entries_touched_is_flat_across_batch_size` (0 == 0 == 0). Made the counter a
+      process-wide `AtomicUsize`; both gates are meaningful again (146/3978 entries;
+      `[472, 472, 472]` flat across batch_size).
+    - ✅ **Task 9 (Design C + cold-cache A-vs-C measurement): SHIP DESIGN A.** Built
+      Design C (single-thread read-ahead-one-window read-through prefetch, `svar1_prefetch_runs`
+      FFI) behind an internal `_prefetch_strategy` toggle (`"engine"` default | `"readahead"`),
+      byte-identical parity under both. Cold-cache (fresh-store-per-run, no root) A-vs-C on
+      the shared node, best-of-3: **engine 0.286s vs readahead 0.417s — a 1.46× win for the
+      producer-thread engine**, with non-overlapping run ranges (engine [0.286–0.335],
+      readahead [0.417–0.432]) so it is well outside node noise. The readahead overlap proxy
+      shows why: the single-thread read-through call is ~0.001s and cannot hide I/O (the
+      fault cost is paid lazily inside `generate`), whereas the producer thread genuinely
+      overlaps window N+1's read with window N's generation. Per the spec's decision rule
+      (*A ≫ C ⇒ the producer thread pays for itself on I/O alone*), **Design A ships as the
+      SVAR1 default** (already wired). **#276 implication:** the thread is justified for SVAR1
+      I/O overlap directly (not merely reserved for #276), and it will additionally hide
+      #276's decode CPU, which `madvise`/read-through cannot. Design C + the harness
+      (`benchmarking/streaming/cold_cache_overlap.py`) are kept as off-by-default internal
+      experimental infrastructure for #276 re-measurement. Harness/design:
+      `.superpowers/sdd/task-9-design-note.md`; report: `.superpowers/sdd/task-9-report.md`.
   - ⚠️ **Inherited perf/scale debt from the walking skeleton — DELETED, not fixed, by Task 2.**
     All of it was downstream of the one wrong dependency above, so the rewrite removed it rather
     than optimizing it. (a) `Svar1RecordSource::new` was **O(all CSR entries)** — it eagerly

--- a/python/genvarloader/_dataset/_streaming.py
+++ b/python/genvarloader/_dataset/_streaming.py
@@ -222,7 +222,10 @@ class StreamingDataset:
         # independent of cohort size, keeping whole sample sets when they fit and
         # holding regions at the measured amortization knee (REGION_TARGET=64).
         max_mem_bytes = _parse_max_mem(max_mem)
-        n_slots = 1  # PR 1 is single-window-resident; PR 2 (engine) sets 2 (ping-pong).
+        # The engine (#283) double-buffers windows -- the producer reads the NEXT
+        # window's offsets while the consumer generates batches from the CURRENT one --
+        # so two windows' offsets can be resident at once; size the budget for that.
+        n_slots = 2
         cell_bytes = (
             int(ploidy) * 16
         )  # o_start + o_stop, i64 each, per (region,sample,ploid)
@@ -279,25 +282,58 @@ class StreamingDataset:
         """Drive the plan; generate each window PER BATCH so output is batch-bounded.
 
         The window is the READ granularity; a batch is the GENERATION granularity. For
-        the real SVAR1 backend this reads a window's offsets once, then reconstructs
-        each batch_size slice separately (issue #284). The injected `_reconstruct_window`
-        path (tests) reconstructs the whole window and slices -- memory-unbounded, but
-        only ever used with tiny fixtures.
+        the real SVAR1 backend this drives a `Svar1StreamEngine` (#283) that overlaps
+        producer I/O (reading the next window) with consumer generation (reconstructing
+        the current one) -- output is still batch_size-bounded (issue #284). The
+        injected `_reconstruct_window` path (tests) reconstructs the whole window and
+        slices -- memory-unbounded, but only ever used with tiny fixtures.
         """
-        for r_idx, s_idx in self._plan():
-            n_s = len(s_idx)
-            flat_r = np.repeat(self._sort_order[r_idx], n_s)
-            flat_s = np.tile(s_idx, len(r_idx))
-            n_rows = len(flat_r)
-            if self._backend is not None:
-                o_starts, o_stops = self._backend.read_window(r_idx, s_idx)
+        if self._backend is not None:
+            # Materialize the plan ONCE and use it for BOTH the engine's job list and
+            # the drive loop below, so job order and per-window batching cannot diverge
+            # from what `_plan()` would yield if called twice.
+            plan = list(self._plan())
+            jobs = []
+            for r_idx, s_idx in plan:
+                contig_idx = int(self._regions[r_idx[0], 0])
+                region_bounds = self._regions[r_idx, 1:3]
+                starts = np.ascontiguousarray(region_bounds[:, 0], np.uint32)
+                ends = np.ascontiguousarray(region_bounds[:, 1], np.uint32)
+                phys = np.ascontiguousarray(
+                    self._backend._phys_sample_idx[s_idx], np.int64
+                )
+                jobs.append((contig_idx, starts, ends, phys))
+            engine = self._backend.build_engine(jobs, batch_size)
+            for r_idx, s_idx in plan:
+                n_s = len(s_idx)
+                flat_r = np.repeat(self._sort_order[r_idx], n_s)
+                flat_s = np.tile(s_idx, len(r_idx))
+                n_rows = len(flat_r)
                 for lo in range(0, n_rows, batch_size):
                     hi = min(lo + batch_size, n_rows)
-                    data = self._backend.generate_batch(
-                        r_idx, s_idx, o_starts, o_stops, lo, hi
+                    nxt = engine.next_batch()
+                    assert nxt is not None, (
+                        "Svar1StreamEngine exhausted before the plan did"
                     )
-                    yield data, flat_r[lo:hi], flat_s[lo:hi]
-            else:
+                    data, offsets = nxt
+                    yield (
+                        Ragged.from_offsets(
+                            np.asarray(data).view("S1"),
+                            (hi - lo, self._backend.ploidy, None),
+                            np.asarray(offsets, np.int64),
+                        ),
+                        flat_r[lo:hi],
+                        flat_s[lo:hi],
+                    )
+            assert engine.next_batch() is None, (
+                "Svar1StreamEngine had extra batches beyond the plan"
+            )
+        else:
+            for r_idx, s_idx in self._plan():
+                n_s = len(s_idx)
+                flat_r = np.repeat(self._sort_order[r_idx], n_s)
+                flat_s = np.tile(s_idx, len(r_idx))
+                n_rows = len(flat_r)
                 data = self._reconstruct_window(r_idx, s_idx)
                 for lo in range(0, n_rows, batch_size):
                     hi = min(lo + batch_size, n_rows)
@@ -518,6 +554,7 @@ class _Svar1Backend:
         self._alt_alleles = np.ascontiguousarray(alt.data.view(np.uint8), np.uint8)
         self._alt_offsets = np.ascontiguousarray(alt.offsets, np.int64)
 
+        self._svar_path = str(svar_path)
         self._store = Svar1Store(str(svar_path), self.n_samples, self.ploidy)
 
         # Per contig: register three scalars and cache the contig-local u32 arrays the
@@ -542,6 +579,10 @@ class _Svar1Backend:
         self._contig_arrays: dict[
             str, tuple[NDArray[np.uint32], NDArray[np.uint32]]
         ] = {}
+        # Parallel cache of the three scalars also passed to `set_contig_meta`, so
+        # `build_engine` (Step 2) can assemble the engine's per-contig arrays later
+        # without re-deriving them from the index table.
+        self._contig_meta: dict[str, tuple[int, int, int]] = {}
 
         for c in self._contigs:
             mask = chrom == c
@@ -552,6 +593,7 @@ class _Svar1Backend:
                     np.empty(0, np.uint32),
                     np.empty(0, np.uint32),
                 )
+                self._contig_meta[c] = (0, 0, 0)
                 continue
 
             first = int(np.argmax(mask))
@@ -587,6 +629,75 @@ class _Svar1Backend:
 
             self._store.set_contig_meta(c, contig_start, n_local, max_v_len)
             self._contig_arrays[c] = (vs_c, ve_c)
+            self._contig_meta[c] = (contig_start, n_local, max_v_len)
+
+    def build_engine(
+        self,
+        jobs: list[
+            tuple[int, NDArray[np.uint32], NDArray[np.uint32], NDArray[np.int64]]
+        ],
+        batch_size: int,
+    ) -> object:
+        """Construct a `Svar1StreamEngine` (Rust producer/consumer engine, #283) that
+        overlaps window I/O with batch generation. `jobs` is one entry per WINDOW,
+        `(contig_idx, region_starts, region_ends, phys_samples)`, in the SAME order
+        `_iter_batches` will drive `.next_batch()` -- see `_iter_batches`'s
+        `plan = list(self._plan())` (materialized once and reused for both the job
+        build and the drive, so job order and per-window batching cannot diverge from
+        what this call assembles).
+
+        `phys_samples` must already be PHYSICAL sample indices (this method does not
+        translate -- callers cross `self._phys_sample_idx[s_idx]` themselves, same as
+        `read_window` does internally).
+        """
+        from ..genvarloader import Svar1StreamEngine
+
+        contig_names = list(self._contigs)
+        contig_starts: list[int] = []
+        n_locals: list[int] = []
+        max_v_lens: list[int] = []
+        v_starts_c: list[NDArray[np.uint32]] = []
+        v_ends_c: list[NDArray[np.uint32]] = []
+        contig_ref_bytes: list[NDArray[np.uint8]] = []
+        for i, c in enumerate(contig_names):
+            cs, nl, mv = self._contig_meta[c]
+            vs_c, ve_c = self._contig_arrays[c]
+            contig_starts.append(cs)
+            n_locals.append(nl)
+            max_v_lens.append(mv)
+            v_starts_c.append(vs_c)
+            v_ends_c.append(ve_c)
+            ref_bytes_i, _ref_off = self._ref._contig_slice(i)
+            contig_ref_bytes.append(ref_bytes_i)
+
+        job_contig_idx = [int(j[0]) for j in jobs]
+        job_region_starts = [np.ascontiguousarray(j[1], np.uint32) for j in jobs]
+        job_region_ends = [np.ascontiguousarray(j[2], np.uint32) for j in jobs]
+        job_phys_samples = [np.ascontiguousarray(j[3], np.int64) for j in jobs]
+
+        return Svar1StreamEngine(
+            self._svar_path,
+            self.n_samples,
+            self.ploidy,
+            contig_names,
+            contig_starts,
+            n_locals,
+            max_v_lens,
+            v_starts_c,
+            v_ends_c,
+            contig_ref_bytes,
+            job_contig_idx,
+            job_region_starts,
+            job_region_ends,
+            job_phys_samples,
+            self._v_starts,
+            self._ilens,
+            self._alt_alleles,
+            self._alt_offsets,
+            self._ref.pad_char,
+            True,
+            batch_size,
+        )
 
     def read_window(
         self, r_idx: NDArray[np.intp], s_idx: NDArray[np.intp]

--- a/python/genvarloader/_dataset/_streaming.py
+++ b/python/genvarloader/_dataset/_streaming.py
@@ -306,32 +306,46 @@ class StreamingDataset:
         """
         if self._backend is not None:
             if self._prefetch_strategy == "engine":
-                # Materialize the plan ONCE and use it for BOTH the engine's job list
-                # and the drive loop below, so job order and per-window batching cannot
-                # diverge from what `_plan()` would yield if called twice.
-                plan = list(self._plan())
-                jobs = []
-                for r_idx, s_idx in plan:
+                # Build a COMPACT, region-scale plan ONCE and drive off THAT (never a
+                # second `list(self._plan())`). `_plan` always yields a CONTIGUOUS sample
+                # chunk `arange(s_lo, s_hi)`, so each window is captured losslessly by
+                # `(contig_idx, r_idx, s_lo, s_hi)` -- r_idx is `window_regions`-scale and
+                # (s_lo, s_hi) is two ints. Total residency is O(n_windows x window_regions)
+                # (region-scale), NEVER O(n_windows x n_samples): the engine holds the
+                # public->physical map ONCE and its producer slices it per window (issue
+                # #284 / final-review Finding 1).
+                plan_jobs: list[tuple[int, NDArray[np.intp], int, int]] = []
+                for r_idx, s_idx in self._plan():
                     contig_idx = int(self._regions[r_idx[0], 0])
-                    region_bounds = self._regions[r_idx, 1:3]
-                    starts = np.ascontiguousarray(region_bounds[:, 0], np.uint32)
-                    ends = np.ascontiguousarray(region_bounds[:, 1], np.uint32)
-                    phys = np.ascontiguousarray(
-                        self._backend._phys_sample_idx[s_idx], np.int64
+                    plan_jobs.append(
+                        (contig_idx, r_idx, int(s_idx[0]), int(s_idx[-1]) + 1)
                     )
-                    jobs.append((contig_idx, starts, ends, phys))
-                engine = self._backend.build_engine(jobs, batch_size)
-                for r_idx, s_idx in plan:
-                    n_s = len(s_idx)
+                # Region bounds (u32) per window for the engine constructor; transient
+                # (dropped after `build_engine`), also region-scale.
+                engine_jobs = [
+                    (
+                        contig_idx,
+                        np.ascontiguousarray(self._regions[r_idx, 1], np.uint32),
+                        np.ascontiguousarray(self._regions[r_idx, 2], np.uint32),
+                        s_lo,
+                        s_hi,
+                    )
+                    for (contig_idx, r_idx, s_lo, s_hi) in plan_jobs
+                ]
+                engine = self._backend.build_engine(engine_jobs, batch_size)
+                del engine_jobs
+                for _contig_idx, r_idx, s_lo, s_hi in plan_jobs:
+                    n_s = s_hi - s_lo
                     flat_r = np.repeat(self._sort_order[r_idx], n_s)
-                    flat_s = np.tile(s_idx, len(r_idx))
+                    flat_s = np.tile(np.arange(s_lo, s_hi, dtype=np.intp), len(r_idx))
                     n_rows = len(flat_r)
                     for lo in range(0, n_rows, batch_size):
                         hi = min(lo + batch_size, n_rows)
                         nxt = engine.next_batch()
-                        assert nxt is not None, (
-                            "Svar1StreamEngine exhausted before the plan did"
-                        )
+                        if nxt is None:
+                            raise RuntimeError(
+                                "Svar1StreamEngine exhausted before the plan did"
+                            )
                         data, offsets = nxt
                         yield (
                             Ragged.from_offsets(
@@ -342,9 +356,12 @@ class StreamingDataset:
                             flat_r[lo:hi],
                             flat_s[lo:hi],
                         )
-                assert engine.next_batch() is None, (
-                    "Svar1StreamEngine had extra batches beyond the plan"
-                )
+                # `-O`-safe (Minor 3): a bare `assert` is stripped under `python -O`,
+                # silently dropping this end-of-plan invariant.
+                if engine.next_batch() is not None:
+                    raise RuntimeError(
+                        "Svar1StreamEngine had extra batches beyond the plan"
+                    )
             elif self._prefetch_strategy == "readahead":
                 # Design C (issue #283): single-thread read-ahead-one-window drive.
                 # Reuses the SAME `_Svar1Backend.read_window`/`generate_batch` calls
@@ -354,20 +371,36 @@ class StreamingDataset:
                 # "readahead" parity variant.
                 from ..genvarloader import svar1_prefetch_runs
 
-                plan = list(self._plan())
-                if not plan:
+                # Compact, region-scale plan (same treatment as the engine branch): hold
+                # only `(r_idx, s_lo, s_hi)` per window, NOT the per-window `s_idx` arrays.
+                # `_plan` yields contiguous `arange(s_lo, s_hi)` chunks, so `s_idx` is
+                # reconstructed per window on demand (only ~2 windows live at once under
+                # the 1-ahead readahead) -- never O(n_windows x n_samples) resident.
+                ra_jobs: list[tuple[NDArray[np.intp], int, int]] = [
+                    (r_idx, int(s_idx[0]), int(s_idx[-1]) + 1)
+                    for r_idx, s_idx in self._plan()
+                ]
+                if not ra_jobs:
                     return
+
+                def _read(job: tuple[NDArray[np.intp], int, int]):
+                    r_idx, s_lo, s_hi = job
+                    return self._backend.read_window(
+                        r_idx, np.arange(s_lo, s_hi, dtype=np.intp)
+                    )
+
                 # Read window 0's offsets up front; then for each window, prefetch the
                 # NEXT window's runs before generating the CURRENT one so kernel
                 # readahead of the next window's pages overlaps this window's
                 # generation.
-                cur = self._backend.read_window(*plan[0])
-                for i, (r_idx, s_idx) in enumerate(plan):
-                    if i + 1 < len(plan):
-                        nxt = self._backend.read_window(*plan[i + 1])
+                cur = _read(ra_jobs[0])
+                for i, (r_idx, s_lo, s_hi) in enumerate(ra_jobs):
+                    if i + 1 < len(ra_jobs):
+                        nxt = _read(ra_jobs[i + 1])
                         svar1_prefetch_runs(self._backend._store, nxt[0], nxt[1])
                     else:
                         nxt = None
+                    s_idx = np.arange(s_lo, s_hi, dtype=np.intp)
                     n_s = len(s_idx)
                     flat_r = np.repeat(self._sort_order[r_idx], n_s)
                     flat_s = np.tile(s_idx, len(r_idx))
@@ -689,22 +722,22 @@ class _Svar1Backend:
 
     def build_engine(
         self,
-        jobs: list[
-            tuple[int, NDArray[np.uint32], NDArray[np.uint32], NDArray[np.int64]]
-        ],
+        jobs: list[tuple[int, NDArray[np.uint32], NDArray[np.uint32], int, int]],
         batch_size: int,
     ) -> object:
         """Construct a `Svar1StreamEngine` (Rust producer/consumer engine, #283) that
         overlaps window I/O with batch generation. `jobs` is one entry per WINDOW,
-        `(contig_idx, region_starts, region_ends, phys_samples)`, in the SAME order
-        `_iter_batches` will drive `.next_batch()` -- see `_iter_batches`'s
-        `plan = list(self._plan())` (materialized once and reused for both the job
-        build and the drive, so job order and per-window batching cannot diverge from
-        what this call assembles).
+        `(contig_idx, region_starts, region_ends, s_lo, s_hi)`, in the SAME order
+        `_iter_batches` will drive `.next_batch()`.
 
-        `phys_samples` must already be PHYSICAL sample indices (this method does not
-        translate -- callers cross `self._phys_sample_idx[s_idx]` themselves, same as
-        `read_window` does internally).
+        Cohort-independent job residency (issue #284 / final-review Finding 1): the
+        full public->physical sample map `self._phys_sample_idx` crosses ONCE (length
+        `n_samples`); each job carries only its contiguous physical-sample sub-range
+        `[s_lo, s_hi)` (two ints), NOT a per-window copy of that window's physical
+        samples. `_plan` always yields a contiguous `arange(s_lo, s_hi)` sample chunk,
+        so the engine's producer reconstructs the window's physical samples on the fly
+        as `phys_sample_idx[s_lo..s_hi]`. Total job metadata is region-scale
+        (`O(n_windows * window_regions)`), never `O(n_windows * n_samples)`.
         """
         from ..genvarloader import Svar1StreamEngine
 
@@ -729,7 +762,11 @@ class _Svar1Backend:
         job_contig_idx = [int(j[0]) for j in jobs]
         job_region_starts = [np.ascontiguousarray(j[1], np.uint32) for j in jobs]
         job_region_ends = [np.ascontiguousarray(j[2], np.uint32) for j in jobs]
-        job_phys_samples = [np.ascontiguousarray(j[3], np.int64) for j in jobs]
+        job_s_lo = [int(j[3]) for j in jobs]
+        job_s_hi = [int(j[4]) for j in jobs]
+        # The full public->physical sample map, crossed ONCE (n_samples-scale). Each
+        # job's (s_lo, s_hi) slices into this on the producer thread -- no per-window copy.
+        phys_sample_idx = self._phys_sample_idx.astype(np.int64, copy=False).tolist()
 
         return Svar1StreamEngine(
             self._svar_path,
@@ -742,10 +779,12 @@ class _Svar1Backend:
             v_starts_c,
             v_ends_c,
             contig_ref_bytes,
+            phys_sample_idx,
             job_contig_idx,
             job_region_starts,
             job_region_ends,
-            job_phys_samples,
+            job_s_lo,
+            job_s_hi,
             self._v_starts,
             self._ilens,
             self._alt_alleles,

--- a/python/genvarloader/_dataset/_streaming.py
+++ b/python/genvarloader/_dataset/_streaming.py
@@ -111,6 +111,19 @@ class StreamingDataset:
     # generates per batch (output bounded by batch_size). The injected
     # `_reconstruct_window` remains a whole-window TEST seam used when `_backend` is None.
     _backend: _Svar1Backend | None = None
+    # INTERNAL/EXPERIMENTAL (issue #283) -- not a public `__init__` kwarg, set only via
+    # `object.__setattr__`. Selects which prefetch drive `_iter_batches` uses when
+    # `_backend is not None`:
+    #   - "engine" (default): the landed producer-thread `Svar1StreamEngine` (Design A).
+    #   - "readahead": a single-thread read-ahead-one-window drive (Design C) that reuses
+    #     the SAME `_Svar1Backend.read_window`/`generate_batch` calls the engine's
+    #     consumer makes, just prefetching the next window's pages inline before
+    #     generating the current one (no background thread). Output-identical to
+    #     "engine" -- prefetch only warms pages, never changes what is generated.
+    # This toggle exists ONLY for the cold-cache A-vs-C measurement
+    # (`benchmarking/streaming/cold_cache_overlap.py`); it will be removed once a winner
+    # is chosen (see docs/roadmaps/streaming-dataset.md).
+    _prefetch_strategy: str = "engine"
 
     def __init__(
         self,
@@ -213,6 +226,9 @@ class StreamingDataset:
         object.__setattr__(self, "_reconstruct_window", _reconstruct_window)
         object.__setattr__(self, "_samples", list(samples))
         object.__setattr__(self, "_backend", _backend_obj)
+        # See the field's comment: internal/experimental, flipped only by the
+        # cold-cache A-vs-C harness via `object.__setattr__`.
+        object.__setattr__(self, "_prefetch_strategy", "engine")
         # Derive the read-window sizing from `max_mem`, NOT from the field defaults
         # above (those are just fallback literals for `__dataclass_fields__`; `slots=True`
         # means there's no class attribute to fall back on at runtime, and this class
@@ -289,45 +305,85 @@ class StreamingDataset:
         slices -- memory-unbounded, but only ever used with tiny fixtures.
         """
         if self._backend is not None:
-            # Materialize the plan ONCE and use it for BOTH the engine's job list and
-            # the drive loop below, so job order and per-window batching cannot diverge
-            # from what `_plan()` would yield if called twice.
-            plan = list(self._plan())
-            jobs = []
-            for r_idx, s_idx in plan:
-                contig_idx = int(self._regions[r_idx[0], 0])
-                region_bounds = self._regions[r_idx, 1:3]
-                starts = np.ascontiguousarray(region_bounds[:, 0], np.uint32)
-                ends = np.ascontiguousarray(region_bounds[:, 1], np.uint32)
-                phys = np.ascontiguousarray(
-                    self._backend._phys_sample_idx[s_idx], np.int64
+            if self._prefetch_strategy == "engine":
+                # Materialize the plan ONCE and use it for BOTH the engine's job list
+                # and the drive loop below, so job order and per-window batching cannot
+                # diverge from what `_plan()` would yield if called twice.
+                plan = list(self._plan())
+                jobs = []
+                for r_idx, s_idx in plan:
+                    contig_idx = int(self._regions[r_idx[0], 0])
+                    region_bounds = self._regions[r_idx, 1:3]
+                    starts = np.ascontiguousarray(region_bounds[:, 0], np.uint32)
+                    ends = np.ascontiguousarray(region_bounds[:, 1], np.uint32)
+                    phys = np.ascontiguousarray(
+                        self._backend._phys_sample_idx[s_idx], np.int64
+                    )
+                    jobs.append((contig_idx, starts, ends, phys))
+                engine = self._backend.build_engine(jobs, batch_size)
+                for r_idx, s_idx in plan:
+                    n_s = len(s_idx)
+                    flat_r = np.repeat(self._sort_order[r_idx], n_s)
+                    flat_s = np.tile(s_idx, len(r_idx))
+                    n_rows = len(flat_r)
+                    for lo in range(0, n_rows, batch_size):
+                        hi = min(lo + batch_size, n_rows)
+                        nxt = engine.next_batch()
+                        assert nxt is not None, (
+                            "Svar1StreamEngine exhausted before the plan did"
+                        )
+                        data, offsets = nxt
+                        yield (
+                            Ragged.from_offsets(
+                                np.asarray(data).view("S1"),
+                                (hi - lo, self._backend.ploidy, None),
+                                np.asarray(offsets, np.int64),
+                            ),
+                            flat_r[lo:hi],
+                            flat_s[lo:hi],
+                        )
+                assert engine.next_batch() is None, (
+                    "Svar1StreamEngine had extra batches beyond the plan"
                 )
-                jobs.append((contig_idx, starts, ends, phys))
-            engine = self._backend.build_engine(jobs, batch_size)
-            for r_idx, s_idx in plan:
-                n_s = len(s_idx)
-                flat_r = np.repeat(self._sort_order[r_idx], n_s)
-                flat_s = np.tile(s_idx, len(r_idx))
-                n_rows = len(flat_r)
-                for lo in range(0, n_rows, batch_size):
-                    hi = min(lo + batch_size, n_rows)
-                    nxt = engine.next_batch()
-                    assert nxt is not None, (
-                        "Svar1StreamEngine exhausted before the plan did"
-                    )
-                    data, offsets = nxt
-                    yield (
-                        Ragged.from_offsets(
-                            np.asarray(data).view("S1"),
-                            (hi - lo, self._backend.ploidy, None),
-                            np.asarray(offsets, np.int64),
-                        ),
-                        flat_r[lo:hi],
-                        flat_s[lo:hi],
-                    )
-            assert engine.next_batch() is None, (
-                "Svar1StreamEngine had extra batches beyond the plan"
-            )
+            elif self._prefetch_strategy == "readahead":
+                # Design C (issue #283): single-thread read-ahead-one-window drive.
+                # Reuses the SAME `_Svar1Backend.read_window`/`generate_batch` calls
+                # the engine's consumer makes (Task 3, parity-green) -- prefetch is a
+                # pure page-warming no-op on output, so this is byte-identical to the
+                # "engine" branch above. See `test_streaming_matches_written_all_cells`'s
+                # "readahead" parity variant.
+                from ..genvarloader import svar1_prefetch_runs
+
+                plan = list(self._plan())
+                if not plan:
+                    return
+                # Read window 0's offsets up front; then for each window, prefetch the
+                # NEXT window's runs before generating the CURRENT one so kernel
+                # readahead of the next window's pages overlaps this window's
+                # generation.
+                cur = self._backend.read_window(*plan[0])
+                for i, (r_idx, s_idx) in enumerate(plan):
+                    if i + 1 < len(plan):
+                        nxt = self._backend.read_window(*plan[i + 1])
+                        svar1_prefetch_runs(self._backend._store, nxt[0], nxt[1])
+                    else:
+                        nxt = None
+                    n_s = len(s_idx)
+                    flat_r = np.repeat(self._sort_order[r_idx], n_s)
+                    flat_s = np.tile(s_idx, len(r_idx))
+                    n_rows = len(flat_r)
+                    for lo in range(0, n_rows, batch_size):
+                        hi = min(lo + batch_size, n_rows)
+                        data = self._backend.generate_batch(
+                            r_idx, s_idx, cur[0], cur[1], lo, hi
+                        )
+                        yield data, flat_r[lo:hi], flat_s[lo:hi]
+                    cur = nxt
+            else:
+                raise ValueError(
+                    f"StreamingDataset._prefetch_strategy={self._prefetch_strategy!r} "
+                    'is not recognized; expected "engine" or "readahead".'
+                )
         else:
             for r_idx, s_idx in self._plan():
                 n_s = len(s_idx)

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -9,6 +9,8 @@ use std::ops::Range;
 
 use crate::variants::windows::{assemble_variants_mode, assemble_windows_mode, VariantBufs};
 
+pub(crate) mod stream_engine;
+
 use crate::genotypes;
 use crate::intervals;
 use crate::reference;
@@ -907,11 +909,134 @@ pub fn svar1_read_window<'py>(
     Ok((o_starts.into_pyarray(py), o_stops.into_pyarray(py)))
 }
 
+/// GIL-free core that generates haplotypes for ONE batch of window rows. Shared by the
+/// [`svar1_generate_batch`] FFI entry AND the streaming engine's consumer
+/// ([`crate::ffi::stream_engine::Svar1StreamEngine`]) so there is ONE implementation
+/// (DRY). Both call it inside a GIL-released context — the FFI wraps it in `py.detach`,
+/// the engine calls it from `next_batch_core` (itself run under `py.detach`).
+///
+/// `o_starts_b`/`o_stops_b` are the CSR-row offsets for exactly this batch (length
+/// `n_rows * ploidy`, ABSOLUTE indices into `variant_idxs`); `region_bounds_b` is
+/// `(n_rows, 2)`, already expanded per (region, sample). Output is `n_rows`-bounded —
+/// the #284 fix. Sparse input IS the store's `variant_idxs` mmap (zero copy). `ref_` /
+/// `ref_offsets` are the ACTIVE contig's slice (`ref_offsets = [0, contig_len]`), since
+/// the per-row `regions` this builds carry `contig_idx = 0`. Ragged output only,
+/// jitter=0.
+///
+/// This function does not touch Python and takes no GIL token; callers own the
+/// `into_pyarray` marshaling. It is infallible (all inputs are pre-validated by the
+/// caller / the store contract), so it returns the owned arrays directly.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn generate_batch_core(
+    store: &crate::svar1::store::Svar1Store,
+    o_starts_b: &[i64],
+    o_stops_b: &[i64],
+    region_bounds_b: ndarray::ArrayView2<i32>,
+    v_starts: ndarray::ArrayView1<i32>,
+    ilens: ndarray::ArrayView1<i32>,
+    alt_alleles: ndarray::ArrayView1<u8>,
+    alt_offsets: ndarray::ArrayView1<i64>,
+    ref_: ndarray::ArrayView1<u8>,
+    ref_offsets: ndarray::ArrayView1<i64>,
+    pad_char: u8,
+    parallel: bool,
+) -> (Array1<u8>, Array1<i64>) {
+    use crate::genotypes;
+    use crate::reconstruct;
+
+    let batch = region_bounds_b.nrows();
+    let ploidy = store.ploidy();
+    let n_work = batch * ploidy;
+
+    // Per-row region bounds (already (region, sample)-expanded by the caller).
+    let mut regions_arr = Array2::<i32>::zeros((batch, 3));
+    for bi in 0..batch {
+        regions_arr[[bi, 1]] = region_bounds_b[[bi, 0]];
+        regions_arr[[bi, 2]] = region_bounds_b[[bi, 1]];
+    }
+    let shifts_arr = Array2::<i32>::zeros((batch, ploidy)); // jitter=0
+
+    // Local identity map over THIS batch's rows: batch row bi, hap p -> local CSR row
+    // bi*ploidy + p, indexing o_starts_b/o_stops_b (which are already the batch slice).
+    let mut geno_offset_idx = Array2::<i64>::zeros((batch, ploidy));
+    for bi in 0..batch {
+        for p in 0..ploidy {
+            geno_offset_idx[[bi, p]] = (bi * ploidy + p) as i64;
+        }
+    }
+
+    let o_starts_a = ndarray::ArrayView1::from(o_starts_b);
+    let o_stops_a = ndarray::ArrayView1::from(o_stops_b);
+
+    // ZERO COPY: kernel sparse input IS the store's mmap (see geno_v_idxs contract).
+    let geno_v_idxs = store.geno_v_idxs();
+    let geno_v_idxs_view = numpy::ndarray::ArrayView1::from(geno_v_idxs);
+
+    let q_starts_owned: Array1<i32> = regions_arr.column(1).to_owned();
+    let q_ends_owned: Array1<i32> = regions_arr.column(2).to_owned();
+    let diffs = genotypes::get_diffs_sparse(
+        geno_offset_idx.view(),
+        geno_v_idxs_view,
+        o_starts_a,
+        o_stops_a,
+        ilens,
+        None,
+        None,
+        Some(q_starts_owned.view()),
+        Some(q_ends_owned.view()),
+        Some(v_starts),
+        parallel,
+    );
+
+    let mut out_offsets_vec: Array1<i64> = Array1::zeros(n_work + 1);
+    {
+        let mut acc: i64 = 0;
+        for k in 0..n_work {
+            let query = k / ploidy;
+            let hap = k % ploidy;
+            let ref_len = (regions_arr[[query, 2]] - regions_arr[[query, 1]]) as i64;
+            let diff = diffs[[query, hap]] as i64;
+            acc += (ref_len + diff).max(0);
+            out_offsets_vec[k + 1] = acc;
+        }
+    }
+
+    let total = out_offsets_vec[n_work] as usize;
+    let mut out_data: Array1<u8> = uninit_output(total);
+
+    reconstruct::reconstruct_haplotypes_from_sparse(
+        out_data.view_mut(),
+        out_offsets_vec.view(),
+        regions_arr.view(),
+        shifts_arr.view(),
+        geno_offset_idx.view(),
+        o_starts_a,
+        o_stops_a,
+        geno_v_idxs_view,
+        v_starts,
+        ilens,
+        alt_alleles,
+        alt_offsets,
+        ref_,
+        ref_offsets,
+        pad_char,
+        None, // keep
+        None, // keep_offsets
+        None, // annot_v_idxs
+        None, // annot_ref_pos
+        parallel,
+    );
+
+    (out_data, out_offsets_vec)
+}
+
 /// Generate haplotypes for ONE batch of window rows. `o_starts_b`/`o_stops_b` are the
 /// CSR-row offsets for exactly this batch (length `n_rows * ploidy`, ABSOLUTE indices
 /// into `variant_idxs`); `region_bounds_b` is `(n_rows, 2)`, already expanded per
 /// (region, sample). Output is `n_rows`-bounded — the #284 fix. `geno_v_idxs` is the
 /// shared `variant_idxs` mmap (zero copy). Ragged output only, jitter=0.
+///
+/// Thin FFI wrapper over [`generate_batch_core`] (which the streaming engine also uses).
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
 pub fn svar1_generate_batch<'py>(
@@ -929,37 +1054,19 @@ pub fn svar1_generate_batch<'py>(
     pad_char: u8,
     parallel: bool,
 ) -> PyResult<(Bound<'py, PyArray1<u8>>, Bound<'py, PyArray1<i64>>)> {
-    use crate::genotypes;
-    use crate::reconstruct;
-
     require_contiguous_1d(&ref_, "ref_")?;
     require_contiguous_1d(&o_starts_b, "o_starts_b")?;
     require_contiguous_1d(&o_stops_b, "o_stops_b")?;
 
+    let o_starts_arr = o_starts_b.as_array();
+    let o_stops_arr = o_stops_b.as_array();
+    let o_starts_s: &[i64] = o_starts_arr
+        .as_slice()
+        .expect("contiguity checked by require_contiguous_1d above");
+    let o_stops_s: &[i64] = o_stops_arr
+        .as_slice()
+        .expect("contiguity checked by require_contiguous_1d above");
     let rb = region_bounds_b.as_array();
-    let batch = rb.nrows();
-    let ploidy = store.ploidy();
-    let n_work = batch * ploidy;
-
-    // Per-row region bounds (already (region, sample)-expanded on the Python side).
-    let mut regions_arr = Array2::<i32>::zeros((batch, 3));
-    for bi in 0..batch {
-        regions_arr[[bi, 1]] = rb[[bi, 0]];
-        regions_arr[[bi, 2]] = rb[[bi, 1]];
-    }
-    let shifts_arr = Array2::<i32>::zeros((batch, ploidy)); // jitter=0
-
-    // Local identity map over THIS batch's rows: batch row bi, hap p -> local CSR row
-    // bi*ploidy + p, indexing o_starts_b/o_stops_b (which are already the batch slice).
-    let mut geno_offset_idx = Array2::<i64>::zeros((batch, ploidy));
-    for bi in 0..batch {
-        for p in 0..ploidy {
-            geno_offset_idx[[bi, p]] = (bi * ploidy + p) as i64;
-        }
-    }
-
-    let o_starts_a = o_starts_b.as_array();
-    let o_stops_a = o_stops_b.as_array();
     let v_starts_a = v_starts.as_array();
     let ilens_a = ilens.as_array();
     let alt_alleles_a = alt_alleles.as_array();
@@ -969,52 +1076,12 @@ pub fn svar1_generate_batch<'py>(
 
     let store_ref: &crate::svar1::store::Svar1Store = &store;
 
-    let result = py.detach(move || -> anyhow::Result<(Array1<u8>, Array1<i64>)> {
-        // ZERO COPY: kernel sparse input IS the store's mmap (see geno_v_idxs contract).
-        let geno_v_idxs = store_ref.geno_v_idxs();
-        let geno_v_idxs_view = numpy::ndarray::ArrayView1::from(geno_v_idxs);
-
-        let q_starts_owned: Array1<i32> = regions_arr.column(1).to_owned();
-        let q_ends_owned: Array1<i32> = regions_arr.column(2).to_owned();
-        let diffs = genotypes::get_diffs_sparse(
-            geno_offset_idx.view(),
-            geno_v_idxs_view,
-            o_starts_a,
-            o_stops_a,
-            ilens_a,
-            None,
-            None,
-            Some(q_starts_owned.view()),
-            Some(q_ends_owned.view()),
-            Some(v_starts_a),
-            parallel,
-        );
-
-        let mut out_offsets_vec: Array1<i64> = Array1::zeros(n_work + 1);
-        {
-            let mut acc: i64 = 0;
-            for k in 0..n_work {
-                let query = k / ploidy;
-                let hap = k % ploidy;
-                let ref_len = (regions_arr[[query, 2]] - regions_arr[[query, 1]]) as i64;
-                let diff = diffs[[query, hap]] as i64;
-                acc += (ref_len + diff).max(0);
-                out_offsets_vec[k + 1] = acc;
-            }
-        }
-
-        let total = out_offsets_vec[n_work] as usize;
-        let mut out_data: Array1<u8> = uninit_output(total);
-
-        reconstruct::reconstruct_haplotypes_from_sparse(
-            out_data.view_mut(),
-            out_offsets_vec.view(),
-            regions_arr.view(),
-            shifts_arr.view(),
-            geno_offset_idx.view(),
-            o_starts_a,
-            o_stops_a,
-            geno_v_idxs_view,
+    let (out_data, out_offsets_vec) = py.detach(move || {
+        generate_batch_core(
+            store_ref,
+            o_starts_s,
+            o_stops_s,
+            rb,
             v_starts_a,
             ilens_a,
             alt_alleles_a,
@@ -1022,18 +1089,9 @@ pub fn svar1_generate_batch<'py>(
             ref_a,
             ref_offsets_a,
             pad_char,
-            None, // keep
-            None, // keep_offsets
-            None, // annot_v_idxs
-            None, // annot_ref_pos
             parallel,
-        );
-
-        Ok((out_data, out_offsets_vec))
+        )
     });
-
-    let (out_data, out_offsets_vec) =
-        result.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
     Ok((out_data.into_pyarray(py), out_offsets_vec.into_pyarray(py)))
 }
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -909,6 +909,56 @@ pub fn svar1_read_window<'py>(
     Ok((o_starts.into_pyarray(py), o_stops.into_pyarray(py)))
 }
 
+/// Read-through prefetch: fault the EXACT pages a later `generate_batch` call will
+/// read, warming the shared OS page cache (and triggering kernel readahead of
+/// subsequent pages that overlaps with the caller's own CPU work). `o_starts`/
+/// `o_stops` are ABSOLUTE indices into `vidx` (the store's `variant_idxs` mmap,
+/// zero-copy — see `Svar1Store::geno_v_idxs`'s contract). `black_box` stops the
+/// compiler eliding the fold. Shared by the streaming engine's producer
+/// (`stream_engine.rs`) AND the standalone [`svar1_prefetch_runs`] FFI entry (Design
+/// C's single-thread read-ahead drive, issue #283) — ONE implementation (DRY).
+pub(crate) fn prefetch_runs_core(vidx: &[i32], o_starts: &[i64], o_stops: &[i64]) {
+    for (&lo, &hi) in o_starts.iter().zip(o_stops.iter()) {
+        let (lo, hi) = (lo as usize, hi as usize);
+        let _ = std::hint::black_box(vidx[lo..hi].iter().fold(0i64, |a, &x| a ^ x as i64));
+    }
+}
+
+/// Standalone read-through prefetch FFI (Design C, issue #283): the SAME read-through
+/// the engine's producer does (`prefetch_runs_core`, shared), exposed directly so a
+/// single-thread Python drive can prefetch the NEXT window's runs before generating
+/// the CURRENT one, overlapping kernel readahead with CPU-side generation without a
+/// background thread. `o_starts`/`o_stops` come from `svar1_read_window`. Runs inside
+/// `py.detach`; `store` is `PyRef<'py>`. No return value — this only warms pages.
+#[pyfunction]
+pub fn svar1_prefetch_runs<'py>(
+    py: Python<'py>,
+    store: PyRef<'py, crate::svar1::store::Svar1Store>,
+    o_starts: PyReadonlyArray1<i64>,
+    o_stops: PyReadonlyArray1<i64>,
+) -> PyResult<()> {
+    require_contiguous_1d(&o_starts, "o_starts")?;
+    require_contiguous_1d(&o_stops, "o_stops")?;
+
+    let o_starts_a = o_starts.as_array();
+    let o_stops_a = o_stops.as_array();
+    let o_starts_s: &[i64] = o_starts_a
+        .as_slice()
+        .expect("contiguity checked by require_contiguous_1d above");
+    let o_stops_s: &[i64] = o_stops_a
+        .as_slice()
+        .expect("contiguity checked by require_contiguous_1d above");
+
+    let store_ref: &crate::svar1::store::Svar1Store = &store;
+
+    py.detach(move || {
+        let vidx = store_ref.geno_v_idxs();
+        prefetch_runs_core(vidx, o_starts_s, o_stops_s);
+    });
+
+    Ok(())
+}
+
 /// GIL-free core that generates haplotypes for ONE batch of window rows. Shared by the
 /// [`svar1_generate_batch`] FFI entry AND the streaming engine's consumer
 /// ([`crate::ffi::stream_engine::Svar1StreamEngine`]) so there is ONE implementation

--- a/src/ffi/stream_engine.rs
+++ b/src/ffi/stream_engine.rs
@@ -257,15 +257,12 @@ impl Svar1StreamEngine {
                     slot.job_idx = job_idx;
 
                     // Read-through prefetch: fault the EXACT pages the consumer will read
-                    // into the shared page cache. `black_box` stops the compiler eliding
-                    // the fold. `o_starts`/`o_stops` are absolute indices into the mmap.
+                    // into the shared page cache (shared with the standalone
+                    // `svar1_prefetch_runs` FFI entry — see `prefetch_runs_core`'s
+                    // doc comment, `src/ffi/mod.rs`). `o_starts`/`o_stops` are absolute
+                    // indices into the mmap.
                     let vidx = store.geno_v_idxs();
-                    for (lo, hi) in slot.o_starts.iter().zip(slot.o_stops.iter()) {
-                        let (lo, hi) = (*lo as usize, *hi as usize);
-                        let _ = std::hint::black_box(
-                            vidx[lo..hi].iter().fold(0i64, |a, &x| a ^ x as i64),
-                        );
-                    }
+                    crate::ffi::prefetch_runs_core(vidx, &slot.o_starts, &slot.o_stops);
 
                     if tx_filled.send(slot).is_err() {
                         return Ok(()); // consumer gone

--- a/src/ffi/stream_engine.rs
+++ b/src/ffi/stream_engine.rs
@@ -132,6 +132,26 @@ impl EngineState {
     }
 }
 
+impl Drop for EngineState {
+    /// Deterministic teardown: if the engine is dropped mid-stream (producer still live),
+    /// join the producer instead of leaking a detached thread. Dropping the free `Sender`
+    /// and the filled `Receiver` FIRST closes both channels, so a producer blocked on
+    /// `rx_free.recv()` (no free slot) or `tx_filled.send()` (consumer gone) unblocks and
+    /// returns `Ok(())` — the join then completes promptly (bounded by at most one
+    /// in-flight `read_window`). Cannot double-join: the normal exhaustion / error / panic
+    /// paths already `take()` the handle in `next_batch_core`, leaving `producer == None`
+    /// here. There is no permanent-wedge risk even without this (channel close always
+    /// unblocks the producer); this just makes teardown synchronous so threads can't
+    /// transiently accumulate under create/drop churn.
+    fn drop(&mut self) {
+        self.tx_free = None;
+        self.rx_filled = None;
+        if let Some(h) = self.producer.take() {
+            let _ = h.join();
+        }
+    }
+}
+
 /// Producer/consumer SVAR1 streamer (issue #283). See the module docs for the design.
 #[pyclass]
 pub struct Svar1StreamEngine {
@@ -741,5 +761,268 @@ mod tests {
         let engine = build_engine(&f, Vec::new(), 8);
         assert!(engine.next_batch_core().is_none());
         assert!(engine.next_batch_core().is_none());
+    }
+
+    /// Serializes the two tests that swap the process-global panic hook. See the identical
+    /// guard in `crate::stream`'s tests: `take_hook`/`set_hook` is not atomic, so without
+    /// serialization one test's temporary silent hook can be observed by another as "the
+    /// previous hook" and restored permanently. Diagnostics-only, but no reason to leave it
+    /// racy. A panicking test poisons the mutex; recover via `into_inner()`.
+    static PANIC_HOOK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// I1 (error branch): a producer `read_window` error must surface through the
+    /// consumer's join-then-classify path as `Some(Err(_))` — NOT a clean/empty EOF and
+    /// NOT a hang. Mirrors `run_windows`' `FailingBackend` regression, adapted to the
+    /// engine. Here the contig is registered with `n_local=5` but its `v_starts_c` has
+    /// length 2, so `Svar1Store::read_window` bails (`... has n_local=5 but got v_starts=2`),
+    /// the producer returns `Err`, and the classify `Ok(Err(e))` branch fires.
+    #[test]
+    fn svar1_stream_engine_producer_error_surfaces_not_eof() {
+        let f = fixture();
+        let bad_contig = ContigData {
+            name: "chr1".into(),
+            contig_start: 0,
+            n_local: 5, // deliberately mismatched vs v_starts_c.len() == 2
+            max_v_len: 1,
+            v_starts_c: vec![10, 20],
+            v_ends_c: vec![11, 21],
+            ref_bytes: f.ref_bytes.clone(),
+        };
+        let jobs = vec![WindowJob {
+            contig_idx: 0,
+            regions: vec![(0, 30)],
+            phys_samples: vec![0, 1],
+        }];
+        let store = Svar1Store::open_meta(&f.path, 2, 2).unwrap();
+        let engine = Svar1StreamEngine::build(
+            store,
+            vec![bad_contig],
+            jobs,
+            f.v_starts.clone(),
+            f.ilens.clone(),
+            f.alt_alleles.clone(),
+            f.alt_offsets.clone(),
+            b'N',
+            false,
+            8,
+        );
+
+        match engine.next_batch_core() {
+            Some(Err(e)) => {
+                let msg = format!("{e:?}");
+                assert!(
+                    msg.contains("n_local"),
+                    "expected the read_window error to propagate, got: {msg}"
+                );
+                assert!(
+                    !msg.contains("panicked"),
+                    "an fill() Err must classify as Ok(Err), NOT the panic branch: {msg}"
+                );
+            }
+            other => panic!(
+                "producer error must surface as Some(Err), not {:?}",
+                other.map(|r| r.is_ok())
+            ),
+        }
+        // After the error the engine is `done`: further pulls are clean None, never a hang.
+        assert!(engine.next_batch_core().is_none());
+        assert!(engine.next_batch_core().is_none());
+    }
+
+    /// I1 (panic branch): a producer PANIC must surface through join-then-classify as the
+    /// `Err(_)` ("producer thread panicked") branch — distinct from the `Ok(Err)` error
+    /// case above — and must not hang. Mirrors `run_windows`' `PanickingBackend`. The
+    /// panic is induced with a job whose `contig_idx` is out of range of the engine's
+    /// `contigs` vec, so the producer's `&contigs[job.contig_idx]` is a clean, fully
+    /// in-our-own-code `Vec` bounds-check panic (no dependence on genoray internals / no
+    /// corrupt store) that unwinds the producer thread and is caught by `.join() == Err`.
+    #[test]
+    fn svar1_stream_engine_producer_panic_surfaces_not_hang() {
+        // Serialize the global panic-hook swap; recover from a poisoned lock.
+        let _guard = PANIC_HOOK_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let f = fixture();
+        // Only contig index 0 exists; this job points at 5 -> producer panics on index.
+        let jobs = vec![WindowJob {
+            contig_idx: 5,
+            regions: vec![(0, 30)],
+            phys_samples: vec![0, 1],
+        }];
+        let engine = build_engine(&f, jobs, 8);
+
+        // Silence the deliberate producer-thread panic's backtrace on stderr.
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let outcome = engine.next_batch_core();
+        std::panic::set_hook(prev_hook);
+
+        match outcome {
+            Some(Err(e)) => {
+                let msg = format!("{e:?}");
+                assert!(
+                    msg.contains("panicked"),
+                    "a producer panic must hit the join-classify panic branch, got: {msg}"
+                );
+            }
+            other => panic!(
+                "producer panic must surface as Some(Err(panicked)), not {:?}",
+                other.map(|r| r.is_ok())
+            ),
+        }
+        // `done` after the panic: further pulls are clean None, never a hang or re-join.
+        assert!(engine.next_batch_core().is_none());
+    }
+
+    /// I2: multi-contig per-contig reference. Two contigs with DISTINGUISHABLE references
+    /// (chr1 = all 'G', chr2 = all 'T'); a job on each. The chr2 window's output must be
+    /// reconstructed against chr2's ref slice, NOT chr1's (the bug a single engine-level
+    /// `ref_` would cause). An empty hap on chr2 yields pure chr2 ref bytes, making the ref
+    /// choice directly observable. Asserts the engine's chr2 batch equals a direct generate
+    /// with chr2's ref AND differs from the same generate fed chr1's ref.
+    #[test]
+    fn svar1_stream_engine_uses_per_contig_reference() {
+        // Store: 1 sample x ploidy 2 -> 2 haps. Global var 0 on chr1, global var 1 on chr2.
+        //   hap0 -> variant_idxs[0..1] = [0] (chr1 var);  hap1 -> [1..2] = [1] (chr2 var)
+        let tmp = tempfile::tempdir().unwrap();
+        write_raw::<i32>(tmp.path(), "variant_idxs.npy", &[0, 1]);
+        write_raw::<i64>(tmp.path(), "offsets.npy", &[0, 1, 2]);
+        let path = tmp.path().to_str().unwrap().to_string();
+
+        // Global variant tables: var0 @ chr1 pos10 alt 'A'; var1 @ chr2 pos5 alt 'C'.
+        let v_starts = Array1::from(vec![10i32, 5]);
+        let ilens = Array1::from(vec![0i32, 0]);
+        let alt_alleles = Array1::from(vec![b'A', b'C']);
+        let alt_offsets = Array1::from(vec![0i64, 1, 2]);
+        let chr1_ref = vec![b'G'; 20];
+        let chr2_ref = vec![b'T'; 20];
+
+        let chr1 = ContigData {
+            name: "chr1".into(),
+            contig_start: 0,
+            n_local: 1,
+            max_v_len: 1,
+            v_starts_c: vec![10],
+            v_ends_c: vec![11],
+            ref_bytes: chr1_ref.clone(),
+        };
+        let chr2 = ContigData {
+            name: "chr2".into(),
+            contig_start: 1, // chr2's first global variant id is 1
+            n_local: 1,
+            max_v_len: 1,
+            v_starts_c: vec![5],
+            v_ends_c: vec![6],
+            ref_bytes: chr2_ref.clone(),
+        };
+
+        // Jobs: window on chr1 (region [0,20)), then on chr2 (region [0,10)).
+        let jobs = vec![
+            WindowJob {
+                contig_idx: 0,
+                regions: vec![(0, 20)],
+                phys_samples: vec![0],
+            },
+            WindowJob {
+                contig_idx: 1,
+                regions: vec![(0, 10)],
+                phys_samples: vec![0],
+            },
+        ];
+
+        let store = Svar1Store::open_meta(&path, 1, 2).unwrap();
+        let engine = Svar1StreamEngine::build(
+            store,
+            vec![chr1, chr2],
+            jobs,
+            v_starts.clone(),
+            ilens.clone(),
+            alt_alleles.clone(),
+            alt_offsets.clone(),
+            b'N',
+            false,
+            1000,
+        );
+
+        let mut batches: Vec<(Vec<u8>, Vec<i64>)> = Vec::new();
+        while let Some(r) = engine.next_batch_core() {
+            let (d, o) = r.expect("no producer error");
+            batches.push((d.to_vec(), o.to_vec()));
+        }
+        assert_eq!(batches.len(), 2, "one batch per window");
+
+        // Direct chr2-window generate with the CORRECT (chr2) ref, and with the WRONG
+        // (chr1) ref, on an independent store with both contigs registered.
+        let direct = |ref_bytes: &[u8]| -> (Vec<u8>, Vec<i64>) {
+            let mut s = Svar1Store::open_meta(&path, 1, 2).unwrap();
+            s.set_contig_meta_rs("chr1", 0, 1, 1);
+            s.set_contig_meta_rs("chr2", 1, 1, 1);
+            let w = s.read_window("chr2", &[5], &[6], &[(0, 10)], &[0]).unwrap();
+            // 1 region * 1 sample = 1 row; region bounds [0, 10).
+            let mut rb = Array2::<i32>::zeros((1, 2));
+            rb[[0, 0]] = 0;
+            rb[[0, 1]] = 10;
+            let ref_offsets = Array1::from(vec![0i64, ref_bytes.len() as i64]);
+            let (data, offs) = crate::ffi::generate_batch_core(
+                &s,
+                &w.o_starts,
+                &w.o_stops,
+                rb.view(),
+                v_starts.view(),
+                ilens.view(),
+                alt_alleles.view(),
+                alt_offsets.view(),
+                ndarray::ArrayView1::from(ref_bytes),
+                ref_offsets.view(),
+                b'N',
+                false,
+            );
+            (data.to_vec(), offs.to_vec())
+        };
+
+        let exp_correct = direct(&chr2_ref);
+        let exp_wrong = direct(&chr1_ref);
+        assert_ne!(
+            exp_correct, exp_wrong,
+            "sanity: chr1 vs chr2 ref must produce different output (else the test proves nothing)"
+        );
+        assert_eq!(
+            batches[1], exp_correct,
+            "chr2 window must reconstruct against chr2's ref slice"
+        );
+        assert_ne!(
+            batches[1], exp_wrong,
+            "chr2 window must NOT use chr1's ref (the single-engine-ref bug)"
+        );
+        // The chr2 empty hap (hap0, no chr2 variant) is pure chr2 ref ('T'), never 'G'.
+        assert!(
+            batches[1].0.contains(&b'T') && !batches[1].0.contains(&b'G'),
+            "chr2 output must contain chr2 ref bytes ('T') and none of chr1's ('G')"
+        );
+    }
+
+    /// M1: dropping the engine mid-stream (producer still live/blocked) must not hang and
+    /// must not leak the detached thread — `Drop for EngineState` closes the channels and
+    /// joins. A 4-window plan with `batch_size=1`: after pulling ONE row the producer has
+    /// filled the 2 prefill slots and is blocked on `rx_free.recv()` for a third; dropping
+    /// the engine here closes `free`, unblocking it. If the join wedged, this test (and the
+    /// 20x race loop) would hang.
+    #[test]
+    fn svar1_stream_engine_drop_midstream_joins_cleanly() {
+        let f = fixture();
+        let jobs = (0..4)
+            .map(|_| WindowJob {
+                contig_idx: 0,
+                regions: vec![(0, 30)],
+                phys_samples: vec![0, 1],
+            })
+            .collect();
+        let engine = build_engine(&f, jobs, 1);
+        let first = engine.next_batch_core();
+        assert!(
+            matches!(first, Some(Ok(_))),
+            "first pull must yield a batch"
+        );
+        // `engine` drops here with the producer still live -> Drop must join, not hang.
+        drop(engine);
     }
 }

--- a/src/ffi/stream_engine.rs
+++ b/src/ffi/stream_engine.rs
@@ -1,0 +1,745 @@
+//! `Svar1StreamEngine` — the SVAR1 producer/consumer overlap engine (issue #283).
+//!
+//! **This is gvl's first production threading.** A background *producer* thread reads
+//! window N+1's CSR offsets (`Svar1Store::read_window`) and reads-through the runs it
+//! will hand off (`geno_v_idxs()[o_lo..o_hi]`), warming the shared OS page cache, while
+//! the *consumer* (`next_batch`, called from Python) generates batches from window N.
+//! What is overlapped is I/O latency, not decode — SVAR1's on-disk layout is already the
+//! target representation, so the producer's job is to fault the exact pages ahead of the
+//! consumer (the OS page cache does not prefetch on an application's access pattern; a
+//! thread walking the fixed, `__getitem__`-free traversal does).
+//!
+//! **Why bespoke and not `crate::stream::run_windows`.** `run_windows` uses
+//! `std::thread::scope` + `spawn_scoped`, whose scope must complete within one function
+//! call. The engine's producer must instead outlive many separate `next_batch()` FFI
+//! calls, so it is a *detached* `std::thread::spawn` owning an `Arc<Svar1Store>`, the
+//! jobs, and the channel `Sender`s. The shutdown/panic discipline is copied EXACTLY from
+//! `run_windows` (read its doc comments — they explain WHY each ownership move matters):
+//!
+//!   * two `crossbeam_channel::bounded(2)` channels — `filled` (producer→consumer) and
+//!     `free` (consumer→producer, slot recycling) — with `free` prefilled with 2 default
+//!     slots. Only 2 buffers exist in total, ping-ponging between the channels, so no
+//!     `send` can ever block and memory is capped at `2 * window_offsets` regardless of
+//!     plan length;
+//!   * **shutdown by dropping the producer's `Sender<FilledWindow>`** (the filled tx) when
+//!     the job loop ends — the consumer's `recv()` then observes channel close. The
+//!     consumer holds NO clone of the filled tx, so there is nothing to forget to drop;
+//!   * **join-then-classify**: on channel close the consumer JOINS the producer and only
+//!     then classifies its `anyhow::Result` (`Err(_)` join ⇒ producer panicked; `Ok(Err)`
+//!     ⇒ propagate; `Ok(Ok)` ⇒ clean end). The consumer NEVER early-returns with the
+//!     producer live and unjoined.
+//!
+//! **The engine opens its OWN `Arc<Svar1Store>`** from the store path (it does not
+//! Arc-share the Python-owned `Svar1Store` pyclass instance). Because it mmaps the same
+//! file, the producer's reads and the consumer's reads hit the same OS page-cache pages —
+//! no data duplication. `Svar1Store` is `Send + Sync`, so the `Arc` crosses to the
+//! producer thread and `read_window`/`geno_v_idxs` run GIL-free.
+//!
+//! **Memory:** the engine owns only variant-/contig-scale arrays plus, per contig, its
+//! `v_starts_c`/`v_ends_c` and reference slice. The only sample-scale residency is the
+//! recycled per-window offsets in the ≤2 live `FilledWindow`s — the intended, budgeted
+//! (max_mem-bounded, `window_samples`-scale) allocation, never the full cohort.
+//!
+//! **Note — per-contig reference (deviation from the 8a design note).** The design note
+//! listed a single engine-level `ref_`/`ref_offsets`. That is wrong for a multi-contig
+//! plan: `generate_batch_core` builds per-row `regions` with `contig_idx = 0`, so it
+//! always reconstructs against `ref_offsets[0..2]` — i.e. whatever contig slice it is
+//! handed. The production read path passes `self._ref._contig_slice(contig_idx)` (that
+//! contig's slice, offsets `[0, contig_len]`) per generate call, so byte-parity REQUIRES
+//! the active contig's reference. This engine therefore carries the reference per contig
+//! (`ContigData::ref_bytes`) and hands the current job's contig slice to
+//! `generate_batch_core`. Single-contig behavior is identical; multi-contig is now
+//! correct.
+
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+use crossbeam_channel::{bounded, Receiver, Sender};
+use ndarray::{Array1, Array2};
+use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1};
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+use crate::svar1::store::Svar1Store;
+
+/// Per-contig data the engine needs to serve `read_window` and generation for jobs on
+/// that contig. `contig_start`/`n_local`/`max_v_len` are registered on the engine's own
+/// store via `set_contig_meta_rs` at construction; the rest are held for the loop.
+struct ContigData {
+    name: String,
+    contig_start: u32,
+    n_local: usize,
+    max_v_len: u32,
+    /// This contig's LOCAL 0-based variant starts (ascending) and exclusive ends —
+    /// passed straight to `Svar1Store::read_window`.
+    v_starts_c: Vec<u32>,
+    v_ends_c: Vec<u32>,
+    /// This contig's reference bytes (offsets are implicitly `[0, ref_bytes.len()]`).
+    /// See the module note on per-contig reference.
+    ref_bytes: Vec<u8>,
+}
+
+/// One pre-expanded window of the fixed traversal: `regions` (0-based half-open, on
+/// `contig_idx`) crossed with `phys_samples` (physical/native genotype-column indices).
+/// `phys_samples` is `window_samples`-scale (max_mem-bounded), NOT the full cohort.
+struct WindowJob {
+    contig_idx: usize,
+    regions: Vec<(u32, u32)>,
+    phys_samples: Vec<usize>,
+}
+
+/// One recycled slot: the whole window's CSR offsets plus the `job_idx` that produced it
+/// (so the consumer can recover the window's regions/phys_samples/contig for generation).
+#[derive(Default)]
+struct FilledWindow {
+    o_starts: Vec<i64>,
+    o_stops: Vec<i64>,
+    job_idx: usize,
+}
+
+/// The window the consumer is currently draining, batch by batch.
+struct CurrentWindow {
+    filled: FilledWindow,
+    /// Next window row (region×sample, C-order) to generate from.
+    next_row: usize,
+    /// Total window rows = `regions.len() * phys_samples.len()`.
+    n_batch_rows: usize,
+}
+
+/// Mutable engine state behind the pyclass's `Mutex` (the pyclass methods are `&self`).
+struct EngineState {
+    started: bool,
+    done: bool,
+    /// Recycle drained slots back to the producer. `None` until the producer is spawned.
+    tx_free: Option<Sender<FilledWindow>>,
+    /// Receive prefetched windows from the producer. `None` until spawned.
+    rx_filled: Option<Receiver<FilledWindow>>,
+    /// Producer handle — joined (and classified) exactly once, on channel close.
+    producer: Option<JoinHandle<anyhow::Result<()>>>,
+    current: Option<CurrentWindow>,
+}
+
+impl EngineState {
+    fn new() -> Self {
+        Self {
+            started: false,
+            done: false,
+            tx_free: None,
+            rx_filled: None,
+            producer: None,
+            current: None,
+        }
+    }
+}
+
+/// Producer/consumer SVAR1 streamer (issue #283). See the module docs for the design.
+#[pyclass]
+pub struct Svar1StreamEngine {
+    /// The engine's OWN store (Arc-shared with the producer thread; same mmap file, same
+    /// page cache — NOT the Python-owned pyclass instance).
+    store: Arc<Svar1Store>,
+    contigs: Arc<Vec<ContigData>>,
+    jobs: Arc<Vec<WindowJob>>,
+    /// GLOBAL variant-scale tables (indexed by global variant id from `geno_v_idxs`).
+    v_starts: Array1<i32>,
+    ilens: Array1<i32>,
+    alt_alleles: Array1<u8>,
+    alt_offsets: Array1<i64>,
+    pad_char: u8,
+    parallel: bool,
+    batch_size: usize,
+    state: Mutex<EngineState>,
+}
+
+impl Svar1StreamEngine {
+    /// Shared constructor for `#[new]` and Rust tests. Registers each contig's meta on
+    /// the store, then wraps everything for the producer/consumer loop. `store` is opened
+    /// but not yet contig-registered.
+    #[allow(clippy::too_many_arguments)]
+    fn build(
+        mut store: Svar1Store,
+        contigs: Vec<ContigData>,
+        jobs: Vec<WindowJob>,
+        v_starts: Array1<i32>,
+        ilens: Array1<i32>,
+        alt_alleles: Array1<u8>,
+        alt_offsets: Array1<i64>,
+        pad_char: u8,
+        parallel: bool,
+        batch_size: usize,
+    ) -> Self {
+        for c in &contigs {
+            store.set_contig_meta_rs(&c.name, c.contig_start, c.n_local, c.max_v_len);
+        }
+        Self {
+            store: Arc::new(store),
+            contigs: Arc::new(contigs),
+            jobs: Arc::new(jobs),
+            v_starts,
+            ilens,
+            alt_alleles,
+            alt_offsets,
+            pad_char,
+            parallel,
+            batch_size: batch_size.max(1),
+            state: Mutex::new(EngineState::new()),
+        }
+    }
+
+    /// Spawn the detached producer thread (once). Prefills `free` with 2 default slots,
+    /// then the producer fills window after window, blocked only by the free-slot pool.
+    fn ensure_started(&self, state: &mut EngineState) -> anyhow::Result<()> {
+        if state.started {
+            return Ok(());
+        }
+        state.started = true;
+
+        // 2 slots (ping-pong). Only 2 buffers ever exist, recycled between the two
+        // channels, so no `send` can block; memory is capped regardless of plan length.
+        let n_slots = 2usize;
+        let (tx_filled, rx_filled) = bounded::<FilledWindow>(n_slots);
+        let (tx_free, rx_free) = bounded::<FilledWindow>(n_slots);
+        for _ in 0..n_slots {
+            tx_free
+                .send(FilledWindow::default())
+                .expect("prefill free slots (receiver just created, cannot be closed)");
+        }
+
+        // `tx_filled` and `rx_free` are MOVED into the producer — it is their sole owner.
+        // When the producer returns (all jobs done, a `read_window` error via `?`, or a
+        // `recv`/`send` seeing the consumer gone), `tx_filled` drops and the consumer's
+        // `rx_filled.recv()` observes close as soon as the channel drains. No clone of
+        // `tx_filled` is held anywhere else, so shutdown-by-drop is by construction.
+        let store = Arc::clone(&self.store);
+        let jobs = Arc::clone(&self.jobs);
+        let contigs = Arc::clone(&self.contigs);
+
+        let handle = std::thread::Builder::new()
+            .name("gvl-svar1-stream-producer".into())
+            .spawn(move || -> anyhow::Result<()> {
+                for (job_idx, job) in jobs.iter().enumerate() {
+                    // Recycle a drained slot. Err => consumer is gone (engine dropped);
+                    // stop quietly and let the consumer's own outcome stand.
+                    let Ok(mut slot) = rx_free.recv() else {
+                        return Ok(());
+                    };
+
+                    let c = &contigs[job.contig_idx];
+                    let w = store.read_window(
+                        &c.name,
+                        &c.v_starts_c,
+                        &c.v_ends_c,
+                        &job.regions,
+                        &job.phys_samples,
+                    )?;
+                    slot.o_starts = w.o_starts;
+                    slot.o_stops = w.o_stops;
+                    slot.job_idx = job_idx;
+
+                    // Read-through prefetch: fault the EXACT pages the consumer will read
+                    // into the shared page cache. `black_box` stops the compiler eliding
+                    // the fold. `o_starts`/`o_stops` are absolute indices into the mmap.
+                    let vidx = store.geno_v_idxs();
+                    for (lo, hi) in slot.o_starts.iter().zip(slot.o_stops.iter()) {
+                        let (lo, hi) = (*lo as usize, *hi as usize);
+                        let _ = std::hint::black_box(
+                            vidx[lo..hi].iter().fold(0i64, |a, &x| a ^ x as i64),
+                        );
+                    }
+
+                    if tx_filled.send(slot).is_err() {
+                        return Ok(()); // consumer gone
+                    }
+                }
+                Ok(())
+            })
+            .map_err(|e| anyhow::anyhow!("failed to spawn svar1 streaming producer: {e}"))?;
+
+        state.tx_free = Some(tx_free);
+        state.rx_filled = Some(rx_filled);
+        state.producer = Some(handle);
+        Ok(())
+    }
+
+    /// The consumer, GIL-free. Returns:
+    ///   * `Some(Ok((data, offsets)))` — the next batch;
+    ///   * `Some(Err(_))` — a producer error/panic (join-then-classified);
+    ///   * `None` — the plan is exhausted (clean, no hang).
+    ///
+    /// Drains the current window batch-by-batch; when a window is spent it is recycled to
+    /// the producer and the next prefetched window is `recv`'d. On channel close the
+    /// producer is joined and classified before returning.
+    fn next_batch_core(&self) -> Option<anyhow::Result<(Array1<u8>, Array1<i64>)>> {
+        // Recover from a poisoned lock rather than propagating panic-on-panic.
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        if state.done {
+            return None;
+        }
+        if let Err(e) = self.ensure_started(&mut state) {
+            state.done = true;
+            return Some(Err(e));
+        }
+
+        loop {
+            // 1. If the current window has rows left, generate the next batch.
+            let has_rows = match state.current.as_ref() {
+                Some(cur) => cur.next_row < cur.n_batch_rows,
+                None => false,
+            };
+            if has_rows {
+                return Some(self.generate_from_current(&mut state));
+            }
+
+            // 2. Current window is spent (or absent): recycle it, then fetch the next.
+            if let Some(spent) = state.current.take() {
+                if let Some(tx) = state.tx_free.as_ref() {
+                    // Always recycle (Err only if the producer already exited) so the
+                    // producer can finish rather than block on rx_free.recv().
+                    let _ = tx.send(spent.filled);
+                }
+            }
+
+            let recv = state
+                .rx_filled
+                .as_ref()
+                .expect("rx_filled set by ensure_started")
+                .recv();
+            match recv {
+                Ok(fw) => {
+                    let job = &self.jobs[fw.job_idx];
+                    let n_batch_rows = job.regions.len() * job.phys_samples.len();
+                    state.current = Some(CurrentWindow {
+                        filled: fw,
+                        next_row: 0,
+                        n_batch_rows,
+                    });
+                    // Loop back to generate from the newly received window.
+                }
+                Err(_) => {
+                    // Channel closed => producer finished. JOIN FIRST, classify AFTER —
+                    // never return with the producer live and unjoined.
+                    state.done = true;
+                    if let Some(h) = state.producer.take() {
+                        return match h.join() {
+                            Err(_) => Some(Err(anyhow::anyhow!(
+                                "svar1 streaming producer thread panicked"
+                            ))),
+                            Ok(Err(e)) => Some(Err(e)),
+                            Ok(Ok(())) => None,
+                        };
+                    }
+                    return None;
+                }
+            }
+        }
+    }
+
+    /// Generate the next `batch_size`-bounded slice of the current window's rows. Output
+    /// is `(hi-lo)`-bounded — never whole-window (issue #284). Delegates to the shared
+    /// [`crate::ffi::generate_batch_core`].
+    fn generate_from_current(
+        &self,
+        state: &mut EngineState,
+    ) -> anyhow::Result<(Array1<u8>, Array1<i64>)> {
+        let ploidy = self.store.ploidy();
+
+        // Advance the cursor first (mutable borrow), then reborrow immutably to read.
+        let (row_lo, row_hi, job_idx) = {
+            let cur = state
+                .current
+                .as_mut()
+                .expect("generate_from_current called with a live current window");
+            let row_lo = cur.next_row;
+            let row_hi = (row_lo + self.batch_size).min(cur.n_batch_rows);
+            cur.next_row = row_hi;
+            (row_lo, row_hi, cur.filled.job_idx)
+        };
+        let filled = &state.current.as_ref().unwrap().filled;
+        let job = &self.jobs[job_idx];
+        let c = &self.contigs[job.contig_idx];
+        let n_samples = job.phys_samples.len();
+        let n_rows = row_hi - row_lo;
+
+        // Per (region, sample) row bounds for rows [row_lo, row_hi), C-order
+        // (region, sample): window row bi = ri*n_samples + si -> region regions[bi/n_s].
+        let mut rb = Array2::<i32>::zeros((n_rows, 2));
+        for (i, bi) in (row_lo..row_hi).enumerate() {
+            let ri = bi / n_samples;
+            let (s, e) = job.regions[ri];
+            rb[[i, 0]] = s as i32;
+            rb[[i, 1]] = e as i32;
+        }
+
+        // CSR rows for this batch slice: [row_lo*ploidy, row_hi*ploidy).
+        let o_lo = row_lo * ploidy;
+        let o_hi = row_hi * ploidy;
+        let o_starts_b = &filled.o_starts[o_lo..o_hi];
+        let o_stops_b = &filled.o_stops[o_lo..o_hi];
+
+        // This contig's reference slice (offsets [0, len]); see the module note.
+        let ref_offsets = Array1::from(vec![0i64, c.ref_bytes.len() as i64]);
+        let ref_view = ndarray::ArrayView1::from(c.ref_bytes.as_slice());
+
+        Ok(crate::ffi::generate_batch_core(
+            &self.store,
+            o_starts_b,
+            o_stops_b,
+            rb.view(),
+            self.v_starts.view(),
+            self.ilens.view(),
+            self.alt_alleles.view(),
+            self.alt_offsets.view(),
+            ref_view,
+            ref_offsets.view(),
+            self.pad_char,
+            self.parallel,
+        ))
+    }
+}
+
+#[pymethods]
+impl Svar1StreamEngine {
+    /// Construct the engine: open the store, register per-contig meta, and hold the plan
+    /// (pre-expanded window jobs) plus the global variant tables. All per-contig / per-job
+    /// arrays cross as owned `Vec`s so the producer thread can hold them `'static`.
+    ///
+    /// Per-contig records are parallel arrays indexed by contig: `contig_names[i]`,
+    /// `contig_starts[i]`, `n_locals[i]`, `max_v_lens[i]`, `v_starts_c[i]`, `v_ends_c[i]`,
+    /// `contig_ref_bytes[i]`. Per-job records are parallel arrays indexed by job:
+    /// `job_contig_idx[j]`, `job_region_starts[j]`, `job_region_ends[j]`,
+    /// `job_phys_samples[j]`.
+    #[new]
+    #[pyo3(signature = (
+        store_path, n_samples, ploidy,
+        contig_names, contig_starts, n_locals, max_v_lens, v_starts_c, v_ends_c,
+        contig_ref_bytes,
+        job_contig_idx, job_region_starts, job_region_ends, job_phys_samples,
+        v_starts, ilens, alt_alleles, alt_offsets,
+        pad_char, parallel, batch_size,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        store_path: &str,
+        n_samples: usize,
+        ploidy: usize,
+        contig_names: Vec<String>,
+        contig_starts: Vec<u32>,
+        n_locals: Vec<usize>,
+        max_v_lens: Vec<u32>,
+        v_starts_c: Vec<Vec<u32>>,
+        v_ends_c: Vec<Vec<u32>>,
+        contig_ref_bytes: Vec<Vec<u8>>,
+        job_contig_idx: Vec<usize>,
+        job_region_starts: Vec<Vec<u32>>,
+        job_region_ends: Vec<Vec<u32>>,
+        job_phys_samples: Vec<Vec<usize>>,
+        v_starts: PyReadonlyArray1<i32>,
+        ilens: PyReadonlyArray1<i32>,
+        alt_alleles: PyReadonlyArray1<u8>,
+        alt_offsets: PyReadonlyArray1<i64>,
+        pad_char: u8,
+        parallel: bool,
+        batch_size: usize,
+    ) -> PyResult<Self> {
+        let store = Svar1Store::open_meta(store_path, n_samples, ploidy)?;
+
+        let n_contigs = contig_names.len();
+        if [
+            contig_starts.len(),
+            n_locals.len(),
+            max_v_lens.len(),
+            v_starts_c.len(),
+            v_ends_c.len(),
+            contig_ref_bytes.len(),
+        ]
+        .iter()
+        .any(|&l| l != n_contigs)
+        {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "Svar1StreamEngine: per-contig arrays must all have the same length",
+            ));
+        }
+        let mut contigs = Vec::with_capacity(n_contigs);
+        for i in 0..n_contigs {
+            contigs.push(ContigData {
+                name: contig_names[i].clone(),
+                contig_start: contig_starts[i],
+                n_local: n_locals[i],
+                max_v_len: max_v_lens[i],
+                v_starts_c: v_starts_c[i].clone(),
+                v_ends_c: v_ends_c[i].clone(),
+                ref_bytes: contig_ref_bytes[i].clone(),
+            });
+        }
+
+        let n_jobs = job_contig_idx.len();
+        if [
+            job_region_starts.len(),
+            job_region_ends.len(),
+            job_phys_samples.len(),
+        ]
+        .iter()
+        .any(|&l| l != n_jobs)
+        {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "Svar1StreamEngine: per-job arrays must all have the same length",
+            ));
+        }
+        let mut jobs = Vec::with_capacity(n_jobs);
+        for j in 0..n_jobs {
+            let starts = &job_region_starts[j];
+            let ends = &job_region_ends[j];
+            if starts.len() != ends.len() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "Svar1StreamEngine: job_region_starts and job_region_ends must match",
+                ));
+            }
+            let regions: Vec<(u32, u32)> = starts.iter().zip(ends).map(|(&s, &e)| (s, e)).collect();
+            jobs.push(WindowJob {
+                contig_idx: job_contig_idx[j],
+                regions,
+                phys_samples: job_phys_samples[j].clone(),
+            });
+        }
+
+        Ok(Self::build(
+            store,
+            contigs,
+            jobs,
+            v_starts.as_array().to_owned(),
+            ilens.as_array().to_owned(),
+            alt_alleles.as_array().to_owned(),
+            alt_offsets.as_array().to_owned(),
+            pad_char,
+            parallel,
+            batch_size,
+        ))
+    }
+
+    /// Return the next batch's `(data, offsets)`, or `None` when the plan is exhausted.
+    /// The GIL is released for the whole blocking body (recv/generate/join); it is
+    /// reacquired only to marshal the owned arrays into numpy. A producer error/panic
+    /// surfaces here as a `RuntimeError`, join-then-classified — never a hang.
+    fn next_batch<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Option<(Bound<'py, PyArray1<u8>>, Bound<'py, PyArray1<i64>>)>> {
+        let out = py.detach(|| self.next_batch_core());
+        match out {
+            None => Ok(None),
+            Some(Ok((data, offsets))) => {
+                Ok(Some((data.into_pyarray(py), offsets.into_pyarray(py))))
+            }
+            Some(Err(e)) => Err(PyRuntimeError::new_err(e.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_raw<T: bytemuck::NoUninit>(dir: &std::path::Path, name: &str, data: &[T]) {
+        let mut f = std::fs::File::create(dir.join(name)).unwrap();
+        f.write_all(bytemuck::cast_slice(data)).unwrap();
+    }
+
+    /// The 4-hap fixture shared with `store.rs`: variant_idxs=[0,0,1,1],
+    /// offsets=[0,1,1,3,4], 2 samples x ploidy 2. Per-hap sorted global ids:
+    ///   hap0:[0]  hap1:[]  hap2:[0,1]  hap3:[1]
+    /// Two SNPs: var0 @10 alt 'A', var1 @20 alt 'C'. chr1 reference: 30 bp of 'T'.
+    struct Fixture {
+        _tmp: tempfile::TempDir,
+        path: String,
+        v_starts: Array1<i32>,
+        ilens: Array1<i32>,
+        alt_alleles: Array1<u8>,
+        alt_offsets: Array1<i64>,
+        ref_bytes: Vec<u8>,
+    }
+
+    fn fixture() -> Fixture {
+        let tmp = tempfile::tempdir().unwrap();
+        write_raw::<i32>(tmp.path(), "variant_idxs.npy", &[0, 0, 1, 1]);
+        write_raw::<i64>(tmp.path(), "offsets.npy", &[0, 1, 1, 3, 4]);
+        let path = tmp.path().to_str().unwrap().to_string();
+        Fixture {
+            _tmp: tmp,
+            path,
+            v_starts: Array1::from(vec![10i32, 20]),
+            ilens: Array1::from(vec![0i32, 0]),
+            alt_alleles: Array1::from(vec![b'A', b'C']),
+            alt_offsets: Array1::from(vec![0i64, 1, 2]),
+            ref_bytes: vec![b'T'; 30],
+        }
+    }
+
+    fn chr1_contig(f: &Fixture) -> ContigData {
+        ContigData {
+            name: "chr1".into(),
+            contig_start: 0,
+            n_local: 2,
+            max_v_len: 1,
+            v_starts_c: vec![10, 20],
+            v_ends_c: vec![11, 21],
+            ref_bytes: f.ref_bytes.clone(),
+        }
+    }
+
+    /// Ground truth for one window: a direct `read_window` + a single full-window
+    /// `generate_batch_core`, on an independent store instance.
+    fn expected_window(
+        f: &Fixture,
+        regions: &[(u32, u32)],
+        phys_samples: &[usize],
+    ) -> (Vec<u8>, Vec<i64>) {
+        let mut store = Svar1Store::open_meta(&f.path, 2, 2).unwrap();
+        store.set_contig_meta_rs("chr1", 0, 2, 1);
+        let w = store
+            .read_window("chr1", &[10, 20], &[11, 21], regions, phys_samples)
+            .unwrap();
+
+        let n_regions = regions.len();
+        let n_samples = phys_samples.len();
+        let n_rows = n_regions * n_samples;
+        let mut rb = Array2::<i32>::zeros((n_rows, 2));
+        for bi in 0..n_rows {
+            let ri = bi / n_samples;
+            rb[[bi, 0]] = regions[ri].0 as i32;
+            rb[[bi, 1]] = regions[ri].1 as i32;
+        }
+        let ref_offsets = Array1::from(vec![0i64, f.ref_bytes.len() as i64]);
+        let (data, offs) = crate::ffi::generate_batch_core(
+            &store,
+            &w.o_starts,
+            &w.o_stops,
+            rb.view(),
+            f.v_starts.view(),
+            f.ilens.view(),
+            f.alt_alleles.view(),
+            f.alt_offsets.view(),
+            ndarray::ArrayView1::from(f.ref_bytes.as_slice()),
+            ref_offsets.view(),
+            b'N',
+            false,
+        );
+        (data.to_vec(), offs.to_vec())
+    }
+
+    fn build_engine(f: &Fixture, jobs: Vec<WindowJob>, batch_size: usize) -> Svar1StreamEngine {
+        let store = Svar1Store::open_meta(&f.path, 2, 2).unwrap();
+        Svar1StreamEngine::build(
+            store,
+            vec![chr1_contig(f)],
+            jobs,
+            f.v_starts.clone(),
+            f.ilens.clone(),
+            f.alt_alleles.clone(),
+            f.alt_offsets.clone(),
+            b'N',
+            false,
+            batch_size,
+        )
+    }
+
+    /// The 8a gate: a >=2-window plan flows through the producer/consumer path; every
+    /// batch arrives in plan order and byte-equals a direct `read_window` + generate; the
+    /// plan exhausts and `next_batch` returns `None` cleanly (idempotently, no hang).
+    #[test]
+    fn svar1_stream_engine_yields_windows_in_plan_order() {
+        let f = fixture();
+        // Two windows on chr1: full region, then a narrower region (variant 0 only).
+        let jobs = vec![
+            WindowJob {
+                contig_idx: 0,
+                regions: vec![(0, 30)],
+                phys_samples: vec![0, 1],
+            },
+            WindowJob {
+                contig_idx: 0,
+                regions: vec![(0, 15)],
+                phys_samples: vec![0, 1],
+            },
+        ];
+        // batch_size larger than any window -> one batch per window.
+        let engine = build_engine(&f, jobs, 1000);
+
+        let mut batches: Vec<(Vec<u8>, Vec<i64>)> = Vec::new();
+        while let Some(r) = engine.next_batch_core() {
+            let (d, o) = r.expect("no producer error");
+            batches.push((d.to_vec(), o.to_vec()));
+        }
+        assert_eq!(batches.len(), 2, "one batch per window, in plan order");
+
+        let exp0 = expected_window(&f, &[(0, 30)], &[0, 1]);
+        let exp1 = expected_window(&f, &[(0, 15)], &[0, 1]);
+        assert_eq!(
+            batches[0], exp0,
+            "window 0 data/offsets must match direct read"
+        );
+        assert_eq!(
+            batches[1], exp1,
+            "window 1 data/offsets must match direct read"
+        );
+
+        // Exhaustion is clean and idempotent (must not hang or re-join).
+        assert!(engine.next_batch_core().is_none());
+        assert!(engine.next_batch_core().is_none());
+    }
+
+    /// batch_size=1 splits each window into per-row batches (issue #284 bounding). The
+    /// concatenation of a window's batch data must equal the full-window generate, and the
+    /// batch count must equal the total window-row count. Exercises the multi-batch drain
+    /// + slot-recycle path under threading.
+    #[test]
+    fn svar1_stream_engine_splits_windows_into_bounded_batches() {
+        let f = fixture();
+        let jobs = vec![
+            WindowJob {
+                contig_idx: 0,
+                regions: vec![(0, 30)],
+                phys_samples: vec![0, 1],
+            },
+            WindowJob {
+                contig_idx: 0,
+                regions: vec![(0, 30)],
+                phys_samples: vec![0, 1],
+            },
+        ];
+        let engine = build_engine(&f, jobs, 1);
+
+        let mut all: Vec<(Vec<u8>, Vec<i64>)> = Vec::new();
+        while let Some(r) = engine.next_batch_core() {
+            let (d, o) = r.expect("no producer error");
+            all.push((d.to_vec(), o.to_vec()));
+        }
+        // Each window has 1 region * 2 samples = 2 rows -> 2 batches; 2 windows -> 4.
+        assert_eq!(
+            all.len(),
+            4,
+            "batch_size=1 splits each 2-row window into 2 batches"
+        );
+
+        let exp = expected_window(&f, &[(0, 30)], &[0, 1]);
+        // Window 0's two batches concatenate to the full-window data.
+        let cat0: Vec<u8> = all[0].0.iter().chain(all[1].0.iter()).copied().collect();
+        assert_eq!(
+            cat0, exp.0,
+            "concatenated split batches must equal full-window data"
+        );
+        let cat1: Vec<u8> = all[2].0.iter().chain(all[3].0.iter()).copied().collect();
+        assert_eq!(cat1, exp.0, "second window's split batches must also match");
+    }
+
+    /// An empty plan must not hang: the producer spawns, finds no jobs, drops its filled
+    /// `Sender`; the consumer sees the channel close, joins cleanly, and returns `None`.
+    #[test]
+    fn svar1_stream_engine_empty_plan_is_none() {
+        let f = fixture();
+        let engine = build_engine(&f, Vec::new(), 8);
+        assert!(engine.next_batch_core().is_none());
+        assert!(engine.next_batch_core().is_none());
+    }
+}

--- a/src/ffi/stream_engine.rs
+++ b/src/ffi/stream_engine.rs
@@ -35,10 +35,20 @@
 //! no data duplication. `Svar1Store` is `Send + Sync`, so the `Arc` crosses to the
 //! producer thread and `read_window`/`geno_v_idxs` run GIL-free.
 //!
-//! **Memory:** the engine owns only variant-/contig-scale arrays plus, per contig, its
-//! `v_starts_c`/`v_ends_c` and reference slice. The only sample-scale residency is the
-//! recycled per-window offsets in the ≤2 live `FilledWindow`s — the intended, budgeted
-//! (max_mem-bounded, `window_samples`-scale) allocation, never the full cohort.
+//! **Memory (cohort-independent job residency — issue #284 / final-review Finding 1).**
+//! The engine owns exactly ONE cohort-scale array: `phys_sample_idx` (the public→physical
+//! sample map, `O(n_samples)`, the same single copy PR 1 already keeps). Everything else is
+//! region-/contig-/variant-scale: the `jobs` vec carries per window only its `contig_idx`,
+//! its `regions` (`window_regions`-scale, ≤ `REGION_TARGET` ≈ 64) and a two-`usize` sample
+//! sub-range `(s_lo, s_hi)` — NOT a per-window copy of that window's physical samples. The
+//! producer builds the window's physical sample slice on the fly as a BORROW,
+//! `&phys_sample_idx[s_lo..s_hi]` (`_plan` always yields a contiguous `arange(s_lo, s_hi)`
+//! sample chunk, so the sub-range reconstructs it losslessly with zero new allocation). Thus
+//! total job metadata is `O(n_windows × window_regions)` (region-scale), never
+//! `O(n_windows × window_samples)` ≈ cohort × regions. The only sample-scale residency
+//! during iteration is the recycled per-window offsets in the ≤2 live `FilledWindow`s — the
+//! intended, budgeted (max_mem-bounded, `window_samples`-scale) allocation, never the full
+//! cohort.
 //!
 //! **Note — per-contig reference (deviation from the 8a design note).** The design note
 //! listed a single engine-level `ref_`/`ref_offsets`. That is wrong for a multi-contig
@@ -80,16 +90,21 @@ struct ContigData {
 }
 
 /// One pre-expanded window of the fixed traversal: `regions` (0-based half-open, on
-/// `contig_idx`) crossed with `phys_samples` (physical/native genotype-column indices).
-/// `phys_samples` is `window_samples`-scale (max_mem-bounded), NOT the full cohort.
+/// `contig_idx`) crossed with the contiguous physical-sample sub-range `[s_lo, s_hi)`.
+/// The job carries only the two `usize` bounds, NOT a per-window copy of the physical
+/// samples — the producer borrows `&phys_sample_idx[s_lo..s_hi]` from the engine's single
+/// cohort-scale map when it fills the window (`_plan` always yields a contiguous
+/// `arange(s_lo, s_hi)` sample chunk, so the bounds reconstruct it losslessly). This keeps
+/// job residency region-scale, never `O(n_windows × window_samples)`. See the module docs.
 struct WindowJob {
     contig_idx: usize,
     regions: Vec<(u32, u32)>,
-    phys_samples: Vec<usize>,
+    s_lo: usize,
+    s_hi: usize,
 }
 
 /// One recycled slot: the whole window's CSR offsets plus the `job_idx` that produced it
-/// (so the consumer can recover the window's regions/phys_samples/contig for generation).
+/// (so the consumer can recover the window's regions/sample-range/contig for generation).
 #[derive(Default)]
 struct FilledWindow {
     o_starts: Vec<i64>,
@@ -102,7 +117,7 @@ struct CurrentWindow {
     filled: FilledWindow,
     /// Next window row (region×sample, C-order) to generate from.
     next_row: usize,
-    /// Total window rows = `regions.len() * phys_samples.len()`.
+    /// Total window rows = `regions.len() * (s_hi - s_lo)`.
     n_batch_rows: usize,
 }
 
@@ -160,6 +175,10 @@ pub struct Svar1StreamEngine {
     store: Arc<Svar1Store>,
     contigs: Arc<Vec<ContigData>>,
     jobs: Arc<Vec<WindowJob>>,
+    /// The full public→physical sample map (`O(n_samples)`, ONE copy). Each job's
+    /// `[s_lo, s_hi)` slices into this; the producer borrows `&phys_sample_idx[s_lo..s_hi]`
+    /// per window — no per-window owned copy. Shared with the producer thread.
+    phys_sample_idx: Arc<Vec<usize>>,
     /// GLOBAL variant-scale tables (indexed by global variant id from `geno_v_idxs`).
     v_starts: Array1<i32>,
     ilens: Array1<i32>,
@@ -180,6 +199,7 @@ impl Svar1StreamEngine {
         mut store: Svar1Store,
         contigs: Vec<ContigData>,
         jobs: Vec<WindowJob>,
+        phys_sample_idx: Vec<usize>,
         v_starts: Array1<i32>,
         ilens: Array1<i32>,
         alt_alleles: Array1<u8>,
@@ -195,6 +215,7 @@ impl Svar1StreamEngine {
             store: Arc::new(store),
             contigs: Arc::new(contigs),
             jobs: Arc::new(jobs),
+            phys_sample_idx: Arc::new(phys_sample_idx),
             v_starts,
             ilens,
             alt_alleles,
@@ -233,6 +254,7 @@ impl Svar1StreamEngine {
         let store = Arc::clone(&self.store);
         let jobs = Arc::clone(&self.jobs);
         let contigs = Arc::clone(&self.contigs);
+        let phys_sample_idx = Arc::clone(&self.phys_sample_idx);
 
         let handle = std::thread::Builder::new()
             .name("gvl-svar1-stream-producer".into())
@@ -245,12 +267,15 @@ impl Svar1StreamEngine {
                     };
 
                     let c = &contigs[job.contig_idx];
+                    // Borrow this window's physical samples from the single cohort-scale
+                    // map — no per-window owned copy (see the module memory note).
+                    let phys = &phys_sample_idx[job.s_lo..job.s_hi];
                     let w = store.read_window(
                         &c.name,
                         &c.v_starts_c,
                         &c.v_ends_c,
                         &job.regions,
-                        &job.phys_samples,
+                        phys,
                     )?;
                     slot.o_starts = w.o_starts;
                     slot.o_stops = w.o_stops;
@@ -325,7 +350,7 @@ impl Svar1StreamEngine {
             match recv {
                 Ok(fw) => {
                     let job = &self.jobs[fw.job_idx];
-                    let n_batch_rows = job.regions.len() * job.phys_samples.len();
+                    let n_batch_rows = job.regions.len() * (job.s_hi - job.s_lo);
                     state.current = Some(CurrentWindow {
                         filled: fw,
                         next_row: 0,
@@ -375,7 +400,7 @@ impl Svar1StreamEngine {
         let filled = &state.current.as_ref().unwrap().filled;
         let job = &self.jobs[job_idx];
         let c = &self.contigs[job.contig_idx];
-        let n_samples = job.phys_samples.len();
+        let n_samples = job.s_hi - job.s_lo;
         let n_rows = row_hi - row_lo;
 
         // Per (region, sample) row bounds for rows [row_lo, row_hi), C-order
@@ -423,15 +448,17 @@ impl Svar1StreamEngine {
     ///
     /// Per-contig records are parallel arrays indexed by contig: `contig_names[i]`,
     /// `contig_starts[i]`, `n_locals[i]`, `max_v_lens[i]`, `v_starts_c[i]`, `v_ends_c[i]`,
-    /// `contig_ref_bytes[i]`. Per-job records are parallel arrays indexed by job:
-    /// `job_contig_idx[j]`, `job_region_starts[j]`, `job_region_ends[j]`,
-    /// `job_phys_samples[j]`.
+    /// `contig_ref_bytes[i]`. The full public→physical sample map `phys_sample_idx`
+    /// (length `n_samples`) crosses ONCE. Per-job records are parallel arrays indexed by
+    /// job: `job_contig_idx[j]`, `job_region_starts[j]`, `job_region_ends[j]`,
+    /// `job_s_lo[j]`, `job_s_hi[j]` — each job carries only its contiguous physical-sample
+    /// sub-range `[s_lo, s_hi)` into `phys_sample_idx`, NOT a per-window sample copy.
     #[new]
     #[pyo3(signature = (
         store_path, n_samples, ploidy,
         contig_names, contig_starts, n_locals, max_v_lens, v_starts_c, v_ends_c,
-        contig_ref_bytes,
-        job_contig_idx, job_region_starts, job_region_ends, job_phys_samples,
+        contig_ref_bytes, phys_sample_idx,
+        job_contig_idx, job_region_starts, job_region_ends, job_s_lo, job_s_hi,
         v_starts, ilens, alt_alleles, alt_offsets,
         pad_char, parallel, batch_size,
     ))]
@@ -447,10 +474,12 @@ impl Svar1StreamEngine {
         v_starts_c: Vec<Vec<u32>>,
         v_ends_c: Vec<Vec<u32>>,
         contig_ref_bytes: Vec<Vec<u8>>,
+        phys_sample_idx: Vec<usize>,
         job_contig_idx: Vec<usize>,
         job_region_starts: Vec<Vec<u32>>,
         job_region_ends: Vec<Vec<u32>>,
-        job_phys_samples: Vec<Vec<usize>>,
+        job_s_lo: Vec<usize>,
+        job_s_hi: Vec<usize>,
         v_starts: PyReadonlyArray1<i32>,
         ilens: PyReadonlyArray1<i32>,
         alt_alleles: PyReadonlyArray1<u8>,
@@ -490,11 +519,19 @@ impl Svar1StreamEngine {
             });
         }
 
+        if phys_sample_idx.len() != n_samples {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Svar1StreamEngine: phys_sample_idx has length {} but n_samples={n_samples}",
+                phys_sample_idx.len()
+            )));
+        }
+
         let n_jobs = job_contig_idx.len();
         if [
             job_region_starts.len(),
             job_region_ends.len(),
-            job_phys_samples.len(),
+            job_s_lo.len(),
+            job_s_hi.len(),
         ]
         .iter()
         .any(|&l| l != n_jobs)
@@ -512,11 +549,19 @@ impl Svar1StreamEngine {
                     "Svar1StreamEngine: job_region_starts and job_region_ends must match",
                 ));
             }
+            let (s_lo, s_hi) = (job_s_lo[j], job_s_hi[j]);
+            if s_lo > s_hi || s_hi > n_samples {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Svar1StreamEngine: job sample range [{s_lo}, {s_hi}) is invalid \
+                     for n_samples={n_samples}",
+                )));
+            }
             let regions: Vec<(u32, u32)> = starts.iter().zip(ends).map(|(&s, &e)| (s, e)).collect();
             jobs.push(WindowJob {
                 contig_idx: job_contig_idx[j],
                 regions,
-                phys_samples: job_phys_samples[j].clone(),
+                s_lo,
+                s_hi,
             });
         }
 
@@ -524,6 +569,7 @@ impl Svar1StreamEngine {
             store,
             contigs,
             jobs,
+            phys_sample_idx,
             v_starts.as_array().to_owned(),
             ilens.as_array().to_owned(),
             alt_alleles.as_array().to_owned(),
@@ -647,10 +693,12 @@ mod tests {
 
     fn build_engine(f: &Fixture, jobs: Vec<WindowJob>, batch_size: usize) -> Svar1StreamEngine {
         let store = Svar1Store::open_meta(&f.path, 2, 2).unwrap();
+        // Identity public→physical map for the 2-sample fixture; jobs slice it by range.
         Svar1StreamEngine::build(
             store,
             vec![chr1_contig(f)],
             jobs,
+            vec![0usize, 1],
             f.v_starts.clone(),
             f.ilens.clone(),
             f.alt_alleles.clone(),
@@ -672,12 +720,14 @@ mod tests {
             WindowJob {
                 contig_idx: 0,
                 regions: vec![(0, 30)],
-                phys_samples: vec![0, 1],
+                s_lo: 0,
+                s_hi: 2,
             },
             WindowJob {
                 contig_idx: 0,
                 regions: vec![(0, 15)],
-                phys_samples: vec![0, 1],
+                s_lo: 0,
+                s_hi: 2,
             },
         ];
         // batch_size larger than any window -> one batch per window.
@@ -717,12 +767,14 @@ mod tests {
             WindowJob {
                 contig_idx: 0,
                 regions: vec![(0, 30)],
-                phys_samples: vec![0, 1],
+                s_lo: 0,
+                s_hi: 2,
             },
             WindowJob {
                 contig_idx: 0,
                 regions: vec![(0, 30)],
-                phys_samples: vec![0, 1],
+                s_lo: 0,
+                s_hi: 2,
             },
         ];
         let engine = build_engine(&f, jobs, 1);
@@ -788,13 +840,15 @@ mod tests {
         let jobs = vec![WindowJob {
             contig_idx: 0,
             regions: vec![(0, 30)],
-            phys_samples: vec![0, 1],
+            s_lo: 0,
+            s_hi: 2,
         }];
         let store = Svar1Store::open_meta(&f.path, 2, 2).unwrap();
         let engine = Svar1StreamEngine::build(
             store,
             vec![bad_contig],
             jobs,
+            vec![0usize, 1],
             f.v_starts.clone(),
             f.ilens.clone(),
             f.alt_alleles.clone(),
@@ -843,7 +897,8 @@ mod tests {
         let jobs = vec![WindowJob {
             contig_idx: 5,
             regions: vec![(0, 30)],
-            phys_samples: vec![0, 1],
+            s_lo: 0,
+            s_hi: 2,
         }];
         let engine = build_engine(&f, jobs, 8);
 
@@ -917,12 +972,14 @@ mod tests {
             WindowJob {
                 contig_idx: 0,
                 regions: vec![(0, 20)],
-                phys_samples: vec![0],
+                s_lo: 0,
+                s_hi: 1,
             },
             WindowJob {
                 contig_idx: 1,
                 regions: vec![(0, 10)],
-                phys_samples: vec![0],
+                s_lo: 0,
+                s_hi: 1,
             },
         ];
 
@@ -931,6 +988,7 @@ mod tests {
             store,
             vec![chr1, chr2],
             jobs,
+            vec![0usize], // 1-sample store: identity map
             v_starts.clone(),
             ilens.clone(),
             alt_alleles.clone(),
@@ -1010,7 +1068,8 @@ mod tests {
             .map(|_| WindowJob {
                 contig_idx: 0,
                 regions: vec![(0, 30)],
-                phys_samples: vec![0, 1],
+                s_lo: 0,
+                s_hi: 2,
             })
             .collect();
         let engine = build_engine(&f, jobs, 1);
@@ -1021,5 +1080,56 @@ mod tests {
         );
         // `engine` drops here with the producer still live -> Drop must join, not hang.
         drop(engine);
+    }
+
+    /// Finding 1 guard: a job's `[s_lo, s_hi)` must slice the ENGINE'S single
+    /// `phys_sample_idx` map (borrowed per window), NOT be a per-window copy. With a
+    /// NON-identity map (samples swapped) a full-cohort window must reconstruct the
+    /// PHYSICAL samples `phys_sample_idx[0..2] = [1, 0]` in that order — i.e. it must
+    /// byte-equal a direct `read_window` fed `&[1, 0]` and DIFFER from one fed `&[0, 1]`.
+    /// If the engine ignored the map (or sliced the wrong thing) this would fail.
+    #[test]
+    fn svar1_stream_engine_slices_phys_samples_by_range() {
+        let f = fixture();
+        // The two fixture samples produce distinguishable haps (sample 0: hap0=[0],
+        // hap1=[]; sample 1: hap2=[0,1], hap3=[1]), so a swap changes the output.
+        let jobs = vec![WindowJob {
+            contig_idx: 0,
+            regions: vec![(0, 30)],
+            s_lo: 0,
+            s_hi: 2,
+        }];
+        let store = Svar1Store::open_meta(&f.path, 2, 2).unwrap();
+        let engine = Svar1StreamEngine::build(
+            store,
+            vec![chr1_contig(&f)],
+            jobs,
+            vec![1usize, 0], // swapped map: public 0 -> physical 1, public 1 -> physical 0
+            f.v_starts.clone(),
+            f.ilens.clone(),
+            f.alt_alleles.clone(),
+            f.alt_offsets.clone(),
+            b'N',
+            false,
+            1000,
+        );
+
+        let mut batches: Vec<(Vec<u8>, Vec<i64>)> = Vec::new();
+        while let Some(r) = engine.next_batch_core() {
+            let (d, o) = r.expect("no producer error");
+            batches.push((d.to_vec(), o.to_vec()));
+        }
+        assert_eq!(batches.len(), 1, "one batch for the single full-cohort window");
+
+        let exp_swapped = expected_window(&f, &[(0, 30)], &[1, 0]);
+        let exp_identity = expected_window(&f, &[(0, 30)], &[0, 1]);
+        assert_ne!(
+            exp_swapped, exp_identity,
+            "sanity: swapping physical samples must change the output"
+        );
+        assert_eq!(
+            batches[0], exp_swapped,
+            "window must reconstruct phys_sample_idx[s_lo..s_hi] = [1, 0], not [0, 1]"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ fn genvarloader(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(ffi::reconstruct_haplotypes_fused, m)?)?;
     m.add_function(wrap_pyfunction!(ffi::svar1_read_window, m)?)?;
     m.add_function(wrap_pyfunction!(ffi::svar1_generate_batch, m)?)?;
+    m.add_function(wrap_pyfunction!(ffi::svar1_prefetch_runs, m)?)?;
     m.add_function(wrap_pyfunction!(ffi::svar1_csr_entries_touched, m)?)?;
     m.add_function(wrap_pyfunction!(ffi::reconstruct_haplotypes_from_svar2, m)?)?;
     m.add_function(wrap_pyfunction!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ fn genvarloader(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<tables::RustTable>()?;
     m.add_class::<svar2::store::Svar2Store>()?;
     m.add_class::<svar1::store::Svar1Store>()?;
+    m.add_class::<ffi::stream_engine::Svar1StreamEngine>()?;
     m.add_function(wrap_pyfunction!(ragged::ragged_to_padded, m)?)?;
     m.add_function(wrap_pyfunction!(ffi::intervals_to_tracks, m)?)?;
     m.add_function(wrap_pyfunction!(ffi::get_diffs_sparse, m)?)?;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -35,12 +35,14 @@
 use crossbeam_channel::bounded;
 
 /// One window of the fixed cartesian traversal: regions `[r_lo, r_hi)` on `contig_idx`,
-/// crossed with every sample.
+/// crossed with samples `[s_lo, s_hi)`.
 #[derive(Clone, Debug)]
 pub struct WindowSpec {
     pub contig_idx: usize,
     pub r_lo: usize,
     pub r_hi: usize,
+    pub s_lo: usize,
+    pub s_hi: usize,
 }
 
 /// A source that can fill a window buffer. `Sync` because the producer thread borrows
@@ -190,8 +192,20 @@ mod tests {
 
     fn windows(n: usize) -> Vec<WindowSpec> {
         (0..n)
-            .map(|i| WindowSpec { contig_idx: 0, r_lo: i * 10, r_hi: i * 10 + 10 })
+            .map(|i| WindowSpec {
+                contig_idx: 0,
+                r_lo: i * 10,
+                r_hi: i * 10 + 10,
+                s_lo: 0,
+                s_hi: 1,
+            })
             .collect()
+    }
+
+    #[test]
+    fn window_spec_carries_sample_span() {
+        let w = WindowSpec { contig_idx: 0, r_lo: 0, r_hi: 10, s_lo: 5, s_hi: 12 };
+        assert_eq!(w.s_hi - w.s_lo, 7);
     }
 
     #[test]

--- a/src/svar1/mod.rs
+++ b/src/svar1/mod.rs
@@ -2,12 +2,12 @@ pub mod store;
 
 /// One window's sparse-genotype CSR geometry, produced by `Svar1Store::read_window`.
 ///
-/// **This is the degenerate case of the SVAR1-style window buffer: it holds only
-/// offsets.** SVAR1's on-disk layout is already hap-major sparse CSR of sorted global
-/// variant ids, so there is nothing to decode and no table to materialize —
-/// `geno_v_idxs` is borrowed straight from the `variant_idxs` mmap
-/// (`Svar1Reader::variant_idxs`) and handed to the kernel as-is. VCF/PGEN backends
-/// (#276) DO materialize an owned buffer; do not take this as their template.
+/// **The buffer itself holds only offsets.** SVAR1's on-disk layout is already
+/// hap-major sparse CSR of sorted global variant ids, so there is nothing to decode
+/// and no table to materialize — the variant ids these offsets index into live in the
+/// `variant_idxs` mmap (`Svar1Reader::variant_idxs`), reached via the shared OS page
+/// cache at generate time, and handed to the kernel as-is. VCF/PGEN backends (#276) DO
+/// materialize an owned buffer; do not take this as their template.
 ///
 /// A window is CARTESIAN: `n_regions x n_samples x ploidy`. `o_starts`/`o_stops` are
 /// `n_regions * n_samples * ploidy` long in C-order `(region, sample, ploid)` —
@@ -17,6 +17,21 @@ pub mod store;
 pub struct Svar1Window {
     pub o_starts: Vec<i64>,
     pub o_stops: Vec<i64>,
+}
+
+impl Default for Svar1Window {
+    fn default() -> Self {
+        Svar1Window { o_starts: Vec::new(), o_stops: Vec::new() }
+    }
+}
+
+#[cfg(test)]
+mod window_default_tests {
+    #[test]
+    fn svar1_window_default_is_empty() {
+        let w = super::Svar1Window::default();
+        assert!(w.o_starts.is_empty() && w.o_stops.is_empty());
+    }
 }
 
 #[cfg(test)]

--- a/src/svar1/store.rs
+++ b/src/svar1/store.rs
@@ -4,17 +4,16 @@ use genoray_core::svar1_query::{Svar1Reader, find_ranges, var_ranges};
 use pyo3::exceptions::PyIOError;
 use pyo3::prelude::*;
 
-thread_local! {
-    static CSR_ENTRIES_TOUCHED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-}
+static CSR_ENTRIES_TOUCHED: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
-/// Test/observability hook: total CSR entries spanned by window reads on the current
-/// thread. The #275 throughput gate asserts this scales with the WINDOW, not the
-/// store — the pre-rewrite path inverted the whole contig CSR per batch. Mirrors
-/// genoray's `search::search_tree_build_count`.
+/// Test/observability hook: total CSR entries spanned by window reads, process-wide
+/// (the streaming engine reads windows on a producer thread, not the caller's thread,
+/// so this must accumulate across threads to stay visible). The #275 throughput gate
+/// asserts this scales with the WINDOW, not the store — the pre-rewrite path inverted
+/// the whole contig CSR per batch. Mirrors genoray's `search::search_tree_build_count`.
 #[doc(hidden)]
 pub fn csr_entries_touched() -> usize {
-    CSR_ENTRIES_TOUCHED.with(|c| c.get())
+    CSR_ENTRIES_TOUCHED.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Per-contig scalars. Three numbers — the big `v_starts`/`v_ends` arrays stay on the
@@ -136,7 +135,7 @@ impl Svar1Store {
             .zip(&b.stops)
             .map(|(s, e)| (e - s) as usize)
             .sum();
-        CSR_ENTRIES_TOUCHED.with(|c| c.set(c.get() + spanned));
+        CSR_ENTRIES_TOUCHED.fetch_add(spanned, std::sync::atomic::Ordering::Relaxed);
 
         // `find_ranges` emits C-order (region, sample, ploid), so batch row
         // bi = ri * n_samples + si and CSR row = bi * ploidy + p — an identity map.

--- a/tests/dataset/test_streaming_parity.py
+++ b/tests/dataset/test_streaming_parity.py
@@ -20,11 +20,20 @@ import pytest
 import genvarloader as gvl
 
 
-def test_streaming_matches_written_all_cells(svar1_multicontig_fixture):
+@pytest.mark.parametrize("prefetch_strategy", ["engine", "readahead"])
+def test_streaming_matches_written_all_cells(
+    svar1_multicontig_fixture, prefetch_strategy
+):
+    """Byte-identical parity must hold under BOTH prefetch strategies (issue #283):
+    Design C ("readahead") reuses the exact same `read_window`/`generate_batch` calls
+    Design A ("engine") does, so prefetch is a pure page-warming no-op on output --
+    same assertions, same fixture, only the internal `_prefetch_strategy` toggle
+    differs."""
     f = svar1_multicontig_fixture
     sds = gvl.StreamingDataset(
         f.bed, reference=f.reference_path, variants=f.svar_path
     ).with_seqs("haplotypes")
+    object.__setattr__(sds, "_prefetch_strategy", prefetch_strategy)
     written = gvl.Dataset.open(f.dataset_path, reference=f.reference_path).with_seqs(
         "haplotypes"
     )


### PR DESCRIPTION
Closes #283. Wires the double-buffer engine so window N+1's read overlaps window N's generation. Builds on the read/generate split from #284. Spec: `docs/superpowers/specs/2026-07-17-streaming-svar1-engine-and-memory-design.md`.

> **Stacked on #295 (#284).** Base is the `spec/streaming-svar1-engine-memory` branch so this diff shows only the #283 commits. Merge #295 first, then re-target this to `streaming`.

## What changed
- **`Svar1StreamEngine` (Rust, `src/ffi/stream_engine.rs`)** — gvl's first *production* threading. A background producer thread reads window N+1's offsets and reads-through its runs (warming the shared page cache) while the consumer generates batches from window N. Bespoke detached-thread producer copying `run_windows`' shutdown discipline (2-slot ping-pong `crossbeam_channel`, shutdown-by-`Sender`-drop, join-then-classify-panics, join-on-`Drop`). `generate_batch_core` is factored so the FFI and the engine share one generation impl.
- **Python wiring (`_streaming.py`)** — `_iter_batches` drives the engine (`n_slots=2`); byte-identical parity preserved; the injected callback stays a test seam.
- **Design C + measurement** — a single-thread read-through prefetch (`svar1_prefetch_runs`, behind an internal `_prefetch_strategy` toggle) and a cold-cache A-vs-C harness (`benchmarking/streaming/cold_cache_overlap.py`). **Result: the producer-thread engine (Design A) wins 1.46×** on a cold-cache best-of-3 sweep (engine 0.286s vs readahead 0.417s, non-overlapping ranges) — the single-thread read-through can't hide I/O. **Design A ships as the SVAR1 default.**
- **`#296` fixed** — the `svar1_csr_entries_touched` throughput gate was a `thread_local` blind to the producer thread; made it a process-wide `AtomicUsize`, restoring both #275 gates.

## Memory
Cohort-independent memory (#284's guarantee) is preserved on the engine path: the engine holds `phys_sample_idx` **once** and jobs carry `(s_lo, s_hi)` ranges — the producer borrows `&phys_sample_idx[s_lo..s_hi]` per window, so there is no per-window sample-index copy (residency is O(n_samples) + region-scale, not O(n_windows × n_samples)).

## Verification
- **Byte-identical parity green** under BOTH `engine` and `readahead` strategies (`test_streaming_matches_written_all_cells`, `test_scale_parity_still_byte_identical`).
- Engine concurrency: 8 unit tests (plan-order, bounded-batches, empty-plan, producer-error, producer-panic, per-contig-ref, drop-midstream, phys-sample-slice) + **20× `--release` race runs, no hangs**; adversarial concurrency review passed.
- Full tree 1082 passed; cargo, ruff, pyrefly, `__all__`↔api.md all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)