### PR TITLE
streaming: Wave B spec (#304) + #305 Phase 2 global var_idxs impl (PGEN/SVAR1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "genoray"
 version = "0.1.0"
-source = "git+https://github.com/d-laub/genoray.git?rev=3a44e140aeb5bd48e94d5b3088a889fea30cfc95#3a44e140aeb5bd48e94d5b3088a889fea30cfc95"
+source = "git+https://github.com/d-laub/genoray.git?rev=73d25cbb848168470adef9c4edd571f0a35f4204#73d25cbb848168470adef9c4edd571f0a35f4204"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "svar2-codec"
 version = "0.1.0"
-source = "git+https://github.com/d-laub/genoray.git?rev=3a44e140aeb5bd48e94d5b3088a889fea30cfc95#3a44e140aeb5bd48e94d5b3088a889fea30cfc95"
+source = "git+https://github.com/d-laub/genoray.git?rev=73d25cbb848168470adef9c4edd571f0a35f4204#73d25cbb848168470adef9c4edd571f0a35f4204"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "genoray"
 version = "0.1.0"
-source = "git+https://github.com/d-laub/genoray.git?rev=1d756adc8324198781f75610eb465c8c0ac4772f#1d756adc8324198781f75610eb465c8c0ac4772f"
+source = "git+https://github.com/d-laub/genoray.git?rev=3a44e140aeb5bd48e94d5b3088a889fea30cfc95#3a44e140aeb5bd48e94d5b3088a889fea30cfc95"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "svar2-codec"
 version = "0.1.0"
-source = "git+https://github.com/d-laub/genoray.git?rev=1d756adc8324198781f75610eb465c8c0ac4772f#1d756adc8324198781f75610eb465c8c0ac4772f"
+source = "git+https://github.com/d-laub/genoray.git?rev=3a44e140aeb5bd48e94d5b3088a889fea30cfc95#3a44e140aeb5bd48e94d5b3088a889fea30cfc95"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ seqpro-core = "0.1"
 # genoray crates are pulled straight from GitHub (no crates.io publish). Cargo finds
 # each package by name inside the repo — no in-repo path is given or needed. Bump `rev`
 # to pull newer genoray code; both crates must share the same rev (one clone, one repo).
-svar2-codec = { git = "https://github.com/d-laub/genoray.git", rev = "1d756adc8324198781f75610eb465c8c0ac4772f" }
-genoray_core = { git = "https://github.com/d-laub/genoray.git", rev = "1d756adc8324198781f75610eb465c8c0ac4772f", package = "genoray", default-features = false, features = ["conversion"] }
+svar2-codec = { git = "https://github.com/d-laub/genoray.git", rev = "3a44e140aeb5bd48e94d5b3088a889fea30cfc95" }
+genoray_core = { git = "https://github.com/d-laub/genoray.git", rev = "3a44e140aeb5bd48e94d5b3088a889fea30cfc95", package = "genoray", default-features = false, features = ["conversion"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ seqpro-core = "0.1"
 # genoray crates are pulled straight from GitHub (no crates.io publish). Cargo finds
 # each package by name inside the repo — no in-repo path is given or needed. Bump `rev`
 # to pull newer genoray code; both crates must share the same rev (one clone, one repo).
-svar2-codec = { git = "https://github.com/d-laub/genoray.git", rev = "3a44e140aeb5bd48e94d5b3088a889fea30cfc95" }
-genoray_core = { git = "https://github.com/d-laub/genoray.git", rev = "3a44e140aeb5bd48e94d5b3088a889fea30cfc95", package = "genoray", default-features = false, features = ["conversion"] }
+svar2-codec = { git = "https://github.com/d-laub/genoray.git", rev = "73d25cbb848168470adef9c4edd571f0a35f4204" }
+genoray_core = { git = "https://github.com/d-laub/genoray.git", rev = "73d25cbb848168470adef9c4edd571f0a35f4204", package = "genoray", default-features = false, features = ["conversion"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/docs/roadmaps/streaming-dataset.md
+++ b/docs/roadmaps/streaming-dataset.md
@@ -524,9 +524,21 @@ and `docs/roadmaps/streaming-optimization-baseline.md` (baseline + profile) for 
   folded in — issue [#277](https://github.com/mcvickerlab/GenVarLoader/issues/277), plan
   `docs/superpowers/plans/2026-07-19-streaming-output-mode-breadth-wave-a.md`. `"variants"`/
   `"variant-windows"`/`min_af`/`max_af`/`var_fields` are **Wave B**, tracked separately as
-  issue [#304](https://github.com/mcvickerlab/GenVarLoader/issues/304). Annotated `var_idxs`
-  global-numbering for narrowed/multi-contig VCF/PGEN windows is deferred to issue
-  [#305](https://github.com/mcvickerlab/GenVarLoader/issues/305).
+  issue [#304](https://github.com/mcvickerlab/GenVarLoader/issues/304).
+- ✅ **Per-variant global variant ids (Phase 2: PGEN + SVAR1) — issue
+  [#305](https://github.com/mcvickerlab/GenVarLoader/issues/305).** Spec:
+  `docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md`; plan:
+  `docs/superpowers/plans/2026-07-20-streaming-global-variant-ids.md`. The scalar `var_base`
+  (`var_base + local`) could only express a contiguous offset, which is wrong across a
+  region-overlap gap or an interior-excluded variant. Fixed by carrying a per-variant
+  dataset-global id on `DenseChunk`/`DecodedWindow.global_v_idxs`, gathered onto
+  `annot_v_idxs` by `remap_annot_local_to_global` (genoray bump to
+  `d-laub/genoray` rev `3a44e14`, [genoray PR #134](https://github.com/d-laub/genoray/pull/134),
+  this branch). SVAR1 was already global (no-op); **PGEN now correct** via the `.pvar` row
+  index, including narrowed-window and interior-exclusion gaps (regression-locked). **VCF
+  remains window-local** — genoray's VCF reader hard-codes `global_idx = -1` — real VCF
+  global ids are **Phase 3**, not yet landed. `var_base` itself has been fully retired
+  (Task 2.5 close-out).
 
 ## Sequencing
 

--- a/docs/source/dataset.md
+++ b/docs/source/dataset.md
@@ -257,11 +257,12 @@ or when you'd rather not pay for the write.
 - **`with_seqs("haplotypes" | "annotated")`** — `"annotated"` returns `RaggedAnnotatedHaps`
   (haplotypes plus per-position `var_idxs`/`ref_coords`), byte-identical to
   `Dataset.with_seqs("annotated")` at `jitter=0`. **Limitation (issue
-  [#305](https://github.com/mcvickerlab/GenVarLoader/issues/305)):** SVAR1 `var_idxs` are always
-  dataset-global; for the VCF/PGEN record backends, `var_idxs` are dataset-global only for
-  whole-contig or from-contig-start windows — a narrowed/partial-prefix window (or any window
-  after the first contig in a multi-contig sweep) currently reports window-local `var_idxs`
-  (`var_base=0`) instead of the dataset-global index. Fix deferred.
+  [#305](https://github.com/mcvickerlab/GenVarLoader/issues/305)):** SVAR1 and PGEN `var_idxs`
+  are always dataset-global (including narrowed/partial-prefix windows and windows after the
+  first contig in a multi-contig sweep); for the VCF record backend, `var_idxs` are
+  dataset-global only for whole-contig or from-contig-start windows — a narrowed/partial-prefix
+  VCF window currently reports window-local `var_idxs` instead of the dataset-global index. Fix
+  deferred to Phase 3.
 
 `"variants"`/`"variant-windows"`/`"reference"` output kinds, `min_af`/`max_af`, and `var_fields`
 are **not yet implemented** for `StreamingDataset` — that's Wave B (issue

--- a/docs/superpowers/plans/2026-07-20-streaming-global-variant-ids.md
+++ b/docs/superpowers/plans/2026-07-20-streaming-global-variant-ids.md
@@ -1,0 +1,474 @@
+# Per-Variant Global Variant IDs (record-stream backends) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `StreamingDataset`'s VCF/PGEN record-stream backends emit **dataset-global** variant
+ids per variant (not a scalar `var_base` + window-local index), so `with_seqs("annotated")` and (later)
+`with_seqs("variants")` are byte-identical to the written `Dataset` even when the region-overlap
+filter excludes interior variants behind a spanning deletion.
+
+**Architecture:** genoray's `DenseChunk` gains a per-variant `global_idx` column (mirroring the SVAR2
+`pack_vk_src` call-index). PGEN populates it from the `.pvar` absolute row index it already tracks;
+gvl consumes it into a new `DecodedWindow.global_v_idxs` array and remaps annotation ids by
+per-variant gather instead of adding a scalar `var_base`. VCF — which cannot self-compute the id —
+is a separate, spike-gated phase because its parity hinges on an overlap-semantics question that
+must be empirically resolved first.
+
+**Tech Stack:** Rust (genoray crate `genoray_core`; gvl `src/`), PyO3, Python (`genvarloader`),
+pytest, cargo test, maturin, pixi.
+
+## Global Constraints
+
+- **Byte-identical parity** vs `gvl.write()` + `Dataset[r, s]` under `with_seqs("annotated")` at
+  `jitter=0` — the migration contract. New behavior must not regress existing parity tests.
+- **genoray is a git dependency pinned by `rev`** (Cargo.toml: `git = "https://github.com/d-laub/genoray.git", rev = "…"`). A genoray change ships by merging to genoray `main`, then bumping both `svar2-codec` and `genoray_core` `rev` to the same commit (CLAUDE.md → Development Notes).
+- **Rebuild Rust before pytest**: after editing anything under `src/` (or bumping the genoray rev),
+  run `pixi run -e dev maturin develop --release` or pytest imports the **stale** compiled
+  extension. `cargo test` compiles from source and is unaffected.
+- **Rust tests need `LD_LIBRARY_PATH`** to `.pixi/envs/dev/lib` to load libpython (see the
+  `cargo-test` pixi task; do not invoke `cargo test` bare).
+- **Full tree before pushing** shared-code/symbol changes: `pixi run -e dev pytest tests -q` (scoped
+  runs skip `tests/unit/`).
+- **1:1 record↔atom contract**: gvl forces bcftools atomization (`bcftools norm -f ref -a -m -any`)
+  before `gvl.write`, and `_reject_unsupported_variants` rejects multi-allelic/symbolic at write
+  (`_write.py:655`). The canonical global id is therefore the file-order record rank per contig
+  (`with_row_index` over the `.gvi`/`.pvar`, `_var_ranges.py:132`). Do NOT design for multi-atom
+  records; assert the invariant instead.
+- **Target branch:** `streaming`. genoray change is a cross-repo PR to `d-laub/genoray` `main`.
+
+## Phasing & parallelism
+
+- **Phase 1 (genoray PR)** and **Phase 2 (gvl consume, PGEN+SVAR1)** are sequential: Phase 2 needs
+  the genoray rev merged + bumped. Within Phase 1, Tasks 1.1/1.2 are sequential (1.2 uses 1.1's
+  field). Within Phase 2, Task 2.4's two fixtures are parallelizable.
+- **Phase 3 (VCF)** is gated on Task 3.1 (a verification spike) and may land as a **separate gvl PR**
+  after Phase 2 — do not block PGEN/SVAR1 correctness on it.
+- Per repo convention: dispatch independent implementation tasks via
+  `superpowers:dispatching-parallel-agents` + `superpowers:subagent-driven-development`, using
+  **Sonnet or weaker** for implementation.
+
+---
+
+## PHASE 1 — genoray: `DenseChunk.global_idx` carrier + PGEN population
+
+> Cross-repo PR against `d-laub/genoray` `main`. All paths in this phase are in the genoray repo.
+> Use the pinned-rev checkout as the working reference:
+> `~/.cargo/git/checkouts/genoray-26e7da4241f8ed6f/1d756ad/` — but implement against a fresh clone of
+> genoray `main` (bump target). Confirm every file:line against the actual `main` source; the line
+> numbers below are from rev `1d756ad` and may drift.
+
+### Task 1.1: Add the `global_idx` per-variant column to `DenseChunk` and thread it through assembly
+
+**Files:**
+- Modify: `src/types.rs` (`DenseChunk` struct, ~`:137-179`)
+- Modify: `src/record_source.rs` (`RawRecord` struct, ~`:13-33`)
+- Modify: `src/chunk_assembler.rs` (`PendingAtom` ~`:15-37`; `AtomMeta` ~`:183-195`;
+  `decompose_raw_record` ~`:349-358`; `flush_window` ~`:256-264`; metadata loop ~`:644-715`)
+- Test: `src/chunk_assembler.rs` `#[cfg(test)] mod tests` (extend
+  `decompose_raw_record_threads_each_atoms_own_alt_index_to_dense_format` ~`:841-886`)
+
+**Interfaces:**
+- Produces: `DenseChunk.global_idx: Vec<i32>` — one entry per surviving variant, parallel to
+  `pos`/`ilens`/`alt_offsets`, holding that variant's dataset-global id. `RawRecord.global_idx: i32`
+  — the source-supplied global id for a record (default/sentinel `-1` when the source does not set
+  it, so existing non-record-stream callers compile).
+
+- [ ] **Step 1: Write the failing test** — extend the existing atomization test to assert each atom
+  carries the record's `global_idx`. In `src/chunk_assembler.rs` tests, add:
+
+```rust
+#[test]
+fn decompose_threads_record_global_idx_onto_each_atom() {
+    // A single biallelic SNP record tagged with global id 7 must yield one
+    // PendingAtom whose global_idx == 7 (the 1:1 record<->atom contract).
+    let mut pending: Vec<PendingAtom> = Vec::new();
+    let rec = RawRecord {
+        // ...mirror the existing decompose test's RawRecord construction...
+        global_idx: 7,
+        ..raw_record_snp_fixture()   // reuse the existing fixture helper
+    };
+    let dropped = decompose_raw_record(
+        rec.pos, &rec.ref_allele, &rec.alts, &mut pending, /*skip_out_of_scope*/ false,
+    ).unwrap();
+    assert_eq!(dropped, 0);
+    assert_eq!(pending.len(), 1, "biallelic SNP must atomize 1:1");
+    assert_eq!(pending[0].global_idx, 7);
+}
+```
+
+Note: match the existing test's exact `decompose_raw_record` signature and fixture helper (read
+`:841-886` first; if the helper doesn't exist, inline a minimal `RawRecord` as that test does).
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd <genoray> && LD_LIBRARY_PATH=… cargo test -p genoray decompose_threads_record_global_idx -- --nocapture`
+Expected: FAIL — `global_idx` is not a field of `RawRecord`/`PendingAtom` (compile error).
+
+- [ ] **Step 3: Add the fields and plumbing (minimal)**
+
+- `src/types.rs`: add `pub global_idx: Vec<i32>,` to `DenseChunk` (place it next to `pos`).
+- `src/record_source.rs`: add `pub global_idx: i32,` to `RawRecord`; set it to `-1` at every
+  existing construction site (grep `RawRecord {` across the crate) except the record-stream sources
+  (Task 1.2 sets those).
+- `src/chunk_assembler.rs`:
+  - `PendingAtom`: add `pub global_idx: i32,`.
+  - `decompose_raw_record`: it currently takes `(pos, ref_allele, alts, pending, skip_out_of_scope)`.
+    Thread the record's `global_idx` in (add a param, OR pass the whole `RawRecord`) and set
+    `global_idx: rec.global_idx` in the `pending.push(PendingAtom { … })` at `:349-358`. Add
+    `debug_assert!(atoms.len() == 1 || skip_out_of_scope, "1:1 record↔atom contract");` after
+    atomization to make a violated invariant loud.
+  - `AtomMeta`: add `global_idx: i32`; copy it from the pending atom in `flush_window` (`:256-264`).
+  - Metadata loop (`:644-675`): declare `let mut global_idx: Vec<i32> = Vec::with_capacity(v);` and
+    add `global_idx.push(a.global_idx);` next to `pos.push(a.pos);`.
+  - `DenseChunk { … }` construction (`:704-715`): add `global_idx,`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p genoray decompose_threads_record_global_idx`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full genoray suite (nothing regressed)**
+
+Run: `LD_LIBRARY_PATH=… cargo test -p genoray`
+Expected: PASS (the new field defaults to `-1`; existing assertions on `DenseChunk` fields are
+unaffected — they don't check `global_idx`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types.rs src/record_source.rs src/chunk_assembler.rs
+git commit -m "feat(chunk): carry per-variant global_idx through DenseChunk assembly"
+```
+
+### Task 1.2: PGEN record source populates `global_idx` from the `.pvar` absolute row index
+
+**Files:**
+- Modify: `src/pvar.rs` (`PvarReader`, expose `vidx` ~`:33`, `:191`)
+- Modify: `src/pgen_reader.rs` (`PgenRecordSource::next_record` ~`:94-207`, esp. after
+  `next_variant()` at ~`:154`)
+- Test: `src/pgen_reader.rs` tests (mirror `src/pvar.rs:282` `var_start_skips_leading_variants`)
+
+**Interfaces:**
+- Consumes: `RawRecord.global_idx` (Task 1.1).
+- Produces: PGEN survivors carry `global_idx == .pvar row index == var_start + offset`, correct
+  across region-overlap gaps (the row counter advances for skipped candidates too).
+
+- [ ] **Step 1: Write the failing test** — a narrowed PGEN scan where the extent filter skips a
+  leading candidate must still tag survivors with their true (gapped) `.pvar` row indices.
+
+```rust
+#[test]
+fn pgen_source_tags_survivors_with_true_pvar_row_index() {
+    // Fixture .pvar/.pgen with variants at rows 0..=4 on one contig. Query a
+    // region that (via extent-overlap) keeps rows {2,3,4} and drops {0,1}.
+    // Assert next_record() yields RawRecords with global_idx 2,3,4 in order.
+    let mut src = pgen_source_fixture(/*var_start*/ 0, /*var_end*/ 5, /*region*/ (region_lo, region_hi));
+    let mut ids = Vec::new();
+    while let Some(rec) = src.next_record().unwrap() { ids.push(rec.global_idx); }
+    assert_eq!(ids, vec![2, 3, 4]);
+}
+```
+
+Use the existing PGEN test fixtures/helpers in `src/pgen_reader.rs` tests; if none expose a narrowed
+region, construct one mirroring `pvar.rs`'s fixture builder.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p genoray pgen_source_tags_survivors_with_true_pvar_row_index`
+Expected: FAIL — `global_idx` is `-1` (default from Task 1.1), not the row index.
+
+- [ ] **Step 3: Implement** — expose and read the `.pvar` absolute row index.
+
+- `src/pvar.rs`: add `pub fn current_vidx(&self) -> usize { self.vidx }` (`vidx` is the pre-increment
+  absolute row index initialized by `var_start` skipping at `:118-126` and incremented per
+  `next_variant` at `:191`).
+- `src/pgen_reader.rs` `next_record`: capture `let gidx = self.pvar.current_vidx();` immediately
+  after the `next_variant()` call (`:154`), **before** the region-overlap exclusion block
+  (`:164-207`), and set `rec.global_idx = gidx as i32` on the emitted `RawRecord`. Because the
+  exclusion happens after `next_variant`, `vidx` has already advanced for dropped candidates — each
+  survivor keeps its own true row index.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p genoray pgen_source_tags_survivors_with_true_pvar_row_index`
+Expected: PASS.
+
+- [ ] **Step 5: Full genoray suite + commit**
+
+Run: `LD_LIBRARY_PATH=… cargo test -p genoray` → PASS.
+
+```bash
+git add src/pvar.rs src/pgen_reader.rs
+git commit -m "feat(pgen): tag record-stream survivors with true .pvar global row index"
+```
+
+- [ ] **Step 6: Open the genoray PR, merge to `main`, note the merge commit SHA** (needed for the
+  Phase 2 rev bump). PR title: `feat: per-variant global_idx on DenseChunk (PGEN populated)`.
+
+---
+
+## PHASE 2 — gvl: consume `global_idx`, retire scalar `var_base` (PGEN + SVAR1)
+
+> All paths in this phase are in the gvl repo/worktree.
+
+### Task 2.1: Bump the genoray rev
+
+**Files:** Modify `Cargo.toml` (both `svar2-codec` and `genoray_core` `rev`).
+
+- [ ] **Step 1:** Set both `rev` values to the Phase 1 merge SHA (they must share one rev).
+- [ ] **Step 2:** Rebuild: `pixi run -e dev maturin develop --release`. Expected: builds clean;
+  `DenseChunk` now exposes `global_idx`.
+- [ ] **Step 3:** Commit: `git add Cargo.toml Cargo.lock && git commit -m "build(deps): bump genoray rev for DenseChunk.global_idx"`
+
+### Task 2.2: `DecodedWindow.global_v_idxs` + `fill_decoded_window` copies it
+
+**Files:**
+- Modify: `src/record_stream/transpose.rs` (`DecodedWindow` `:29-46`; `fill_decoded_window` `:51-116`)
+- Test: `src/record_stream/transpose.rs` tests (extend `transpose_emits_variant_indices_hap_major`)
+
+**Interfaces:**
+- Produces: `DecodedWindow.global_v_idxs: Vec<i32>` — length `n_var` (one per window-local variant
+  column), `global_v_idxs[local] == dataset-global id`. Filled from `chunk.global_idx`.
+
+- [ ] **Step 1: Write the failing test** — extend the transpose fixture to carry `global_idx` and
+  assert it copies through. Add `global_idx: vec![5, 8]` to the `dense_fixture()` `DenseChunk` (2
+  variants) and assert:
+
+```rust
+assert_eq!(slot.global_v_idxs, vec![5, 8]);
+```
+
+(Also add `global_idx: Vec::new()` / `global_idx: vec![…]` to every `DenseChunk { … }` literal in the
+transpose tests and in `vcf.rs`/`pgen.rs` empty-window construction so the crate compiles.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `LD_LIBRARY_PATH=$PWD/.pixi/envs/dev/lib cargo test -p genvarloader transpose_emits_variant_indices_hap_major`
+Expected: FAIL — `global_v_idxs` is not a field.
+
+- [ ] **Step 3: Implement**
+
+- `DecodedWindow`: add `pub global_v_idxs: Vec<i32>,`. **Remove `pub var_base: i64,`** (retired) —
+  or, to stage safely, keep it unused for this task and delete in Task 2.5. Recommended: remove now
+  and fix the fallout in 2.3/2.4 within this phase.
+- `fill_decoded_window`: add `slot.global_v_idxs.clear(); slot.global_v_idxs.extend_from_slice(&chunk.global_idx);`
+  next to the `v_starts` copy. Update the empty-`DenseChunk` literals (vcf.rs/pgen.rs) to include
+  `global_idx: Vec::new()`.
+
+- [ ] **Step 4: Run the test to verify it passes** → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/record_stream/transpose.rs src/record_stream/vcf.rs src/record_stream/pgen.rs
+git commit -m "feat(streaming): carry per-variant global_v_idxs on DecodedWindow"
+```
+
+### Task 2.3: `generate_batch_core` remaps annotation ids by per-variant gather (not `var_base` add)
+
+**Files:**
+- Modify: `src/ffi/mod.rs` (`generate_batch_core` signature + the `var_base` add-back block
+  `:1113-1121`; the two fused wrappers that pass `var_base`)
+- Modify: `src/record_stream/engine.rs` (`RecordBackend::generate` `:199-217` — pass
+  `slot.global_v_idxs` instead of `slot.var_base`)
+- Modify: `src/ffi/stream_engine.rs` (SVAR1 `generate` — passes `var_base=0` at `:220`; SVAR1's
+  `geno_v_idxs` are already global, so pass `None`)
+- Test: an `src/ffi` or `src/record_stream/engine.rs` Rust test asserting the gather remap
+
+**Interfaces:**
+- Consumes: `DecodedWindow.global_v_idxs` (2.2).
+- `generate_batch_core(…, global_v_idxs: Option<ndarray::ArrayView1<i32>>, parallel)` — replaces the
+  `var_base: i64` parameter. When `Some`, after reconstruction each non-negative `annot_v_idxs`
+  entry (a window-LOCAL column index) is remapped: `annot_v[i] = global_v_idxs[annot_v[i]]`. When
+  `None` (SVAR1, whose `geno_v_idxs` are already global), `annot_v` is left as-is.
+
+- [ ] **Step 1: Write the failing test** — a record-path `generate` over a window whose
+  `global_v_idxs = [0, 2]` (an interior variant excluded upstream) must emit annotation ids `{0, 2}`,
+  not `{0, 1}`. Build a `RecordBackend` (or call `generate_batch_core` directly) with a 2-variant
+  window where both haps carry both variants, `global_v_idxs = [0, 2]`, and assert the returned
+  `annot_v_idxs` contains `2` (never `1`).
+
+```rust
+#[test]
+fn generate_remaps_local_annot_ids_to_global_via_gather() {
+    // window: 2 local variants, global_v_idxs = [0, 2]; a hap carrying both
+    // must annotate with global ids 0 and 2 (the gapped set), never 1.
+    let (data, annot_v, _pos, _off) = generate_batch_core(
+        /* … 2-variant fixture … */,
+        Some(ndarray::ArrayView1::from(&[0i32, 2])), // global_v_idxs
+        /*parallel*/ false,
+    );
+    let ids: Vec<i32> = annot_v.unwrap().iter().copied().filter(|&x| x >= 0).collect();
+    assert!(ids.contains(&2) && !ids.contains(&1), "got {ids:?}");
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `LD_LIBRARY_PATH=$PWD/.pixi/envs/dev/lib cargo test -p genvarloader generate_remaps_local_annot_ids_to_global`
+Expected: FAIL — signature still takes `var_base: i64` (compile error), or ids are `{0,1}`.
+
+- [ ] **Step 3: Implement**
+
+- `generate_batch_core`: change the `var_base: i64` param to `global_v_idxs: Option<ArrayView1<i32>>`.
+  Replace the `:1113-1121` block with:
+
+```rust
+if let Some(gv) = global_v_idxs {
+    if let Some(av) = annot_v.as_mut() {
+        for x in av.iter_mut() {
+            if *x >= 0 {
+                *x = gv[*x as usize]; // window-local col -> dataset-global id
+            }
+        }
+    }
+}
+```
+
+- `RecordBackend::generate` (`engine.rs:215`): pass
+  `Some(ndarray::ArrayView1::from(slot.global_v_idxs.as_slice()))`.
+- SVAR1 `generate` (`stream_engine.rs:220`) and the two fused plain wrappers (`ffi/mod.rs:668,843`,
+  `:1194-1195`): pass `None` (SVAR1 `geno_v_idxs` are already global; the fused plain path never
+  emits annotation).
+
+- [ ] **Step 4: Run the test to verify it passes** → PASS.
+
+- [ ] **Step 5: Rebuild + run the existing annotated parity test (must still pass for SVAR1/whole-contig)**
+
+Run: `pixi run -e dev maturin develop --release && pixi run -e dev pytest tests/dataset/test_streaming_annotated_parity.py::test_annotated_matches_written -q`
+Expected: PASS for all three backends (whole-contig fixtures were already correct; the remap is a
+no-op there since `global_v_idxs == 0..n`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ffi/mod.rs src/record_stream/engine.rs src/ffi/stream_engine.rs
+git commit -m "feat(streaming): remap annot var_idxs via per-variant global gather; retire var_base"
+```
+
+### Task 2.4: PGEN parity — flip the xfail + add an interior-exclusion fixture
+
+**Files:**
+- Modify: `tests/dataset/test_streaming_annotated_parity.py`
+  (`test_annotated_pgen_narrowed_window_var_idxs_gap` `:125-175` — remove the `xfail` marker)
+- Create: an interior-exclusion PGEN fixture + test in the same file
+- Test data: reuse `pgen_snp_ins_del_multi` (conftest) and/or add a spanning-deletion fixture in
+  `tests/dataset/conftest.py`
+
+**Interfaces:**
+- Consumes: the corrected global-id path (2.1–2.3).
+
+- [ ] **Step 1: Un-xfail the existing narrowed-window gap test.** Delete the `@pytest.mark.xfail(…)`
+  decorator on `test_annotated_pgen_narrowed_window_var_idxs_gap` (`:125-131`) and update its
+  docstring to state it is now a passing regression lock (the narrowed region `[71,200)` first-kept
+  variant is global id 2; the streamed `var_idxs` must be `[2,3,4]`).
+
+- [ ] **Step 2: Run it to verify it now PASSES**
+
+Run: `pixi run -e dev pytest tests/dataset/test_streaming_annotated_parity.py::test_annotated_pgen_narrowed_window_var_idxs_gap -q`
+Expected: PASS (previously `xfail`). If it still fails, the global-id plumbing is wrong — debug 2.2/2.3.
+
+- [ ] **Step 3: Write a failing interior-exclusion test.** Add a fixture (in `conftest.py`) whose
+  variants include a spanning deletion that, for a chosen region, is kept while an interior variant
+  behind it is dropped — so the written oracle's `var_idxs` are a **gapped** set (e.g. `{0, 2}`).
+  Add `test_annotated_pgen_interior_exclusion_var_idxs_gapped` asserting streamed `var_idxs` equal
+  the written `var_idxs` (which will contain the gap):
+
+```python
+def test_annotated_pgen_interior_exclusion_var_idxs_gapped(pgen_spanning_del, tmp_path):
+    ds, sds = _interior_exclusion_case(pgen_spanning_del, tmp_path)  # region keeps DEL, drops interior SNP
+    saw_gap = False
+    for data, r_idx, s_idx in sds.to_iter(batch_size=4):
+        for row in range(len(r_idx)):
+            exp = ds[int(r_idx[row]), int(s_idx[row])]
+            for h in range(sds.ploidy):
+                got = np.asarray(data.var_idxs[row][h]); want = np.asarray(exp.var_idxs[h])
+                np.testing.assert_array_equal(got, want)
+                v = want[want >= 0]
+                if v.size >= 2 and np.any(np.diff(v) > 1):
+                    saw_gap = True
+    assert saw_gap, "fixture must exercise a non-contiguous (gapped) global var_idxs set"
+```
+
+Fixture note: a spanning deletion `REF=ACGTACGT` at pos P (extent P..P+8) plus an interior SNP at
+P+3, with a query region `[P+5, P+9)` — the DEL's extent reaches the region (kept), the interior SNP
+does not (dropped). Confirm the written `Dataset` produces a gapped `var_idxs` for this cell first
+(that's the oracle); the `saw_gap` assert guards against a fixture that doesn't actually gap.
+
+- [ ] **Step 4: Run it to verify it passes** → PASS. If the streamed set is contiguous while the
+  oracle is gapped, 2.2/2.3 are wrong.
+
+- [ ] **Step 5: Full annotated parity suite + commit**
+
+Run: `pixi run -e dev pytest tests/dataset/test_streaming_annotated_parity.py -q` → PASS.
+
+```bash
+git add tests/dataset/test_streaming_annotated_parity.py tests/dataset/conftest.py
+git commit -m "test(streaming): PGEN annotated var_idxs global + interior-exclusion gap (#305)"
+```
+
+### Task 2.5: Retire `var_base` residue + close-out
+
+**Files:** `src/record_stream/vcf.rs` (`slot.var_base = 0` + its doc comment `:153-170`),
+`src/record_stream/pgen.rs` (`slot.var_base = 0` + doc `:595-614`), `src/record_stream/transpose.rs`
+(if `var_base` not already removed in 2.2), any remaining `var_base` references.
+
+- [ ] **Step 1:** grep `var_base` across `src/` and `python/`; remove the now-dead scalar and its doc
+  comments. VCF's `fill` sets `global_v_idxs` per Task 3 (until then it decodes with genoray's
+  default `-1` — see Phase 3; PGEN's `fill` needs no per-variant work since genoray populates it).
+- [ ] **Step 2:** Rebuild + full tree: `pixi run -e dev maturin develop --release && pixi run -e dev pytest tests -q`. Expected: PASS.
+- [ ] **Step 3:** Commit: `git commit -am "refactor(streaming): remove retired scalar var_base"`
+- [ ] **Step 4:** Update `#311` (mark the annotated interior-exclusion bug fixed by this PR) and
+  `docs/roadmaps/streaming-dataset.md` (Plan 5 status). PGEN + SVAR1 annotated global ids are now
+  correct; VCF remains behind Phase 3.
+
+---
+
+## PHASE 3 — VCF global ids (spike-gated; may be a separate gvl PR)
+
+> **Do not start Phase 3 concretely until Task 3.1 resolves the overlap-semantics question.** The
+> VCF global-id VALUE must come from gvl's `.gvi` oracle (`vcf._var_idxs`), threaded so it aligns
+> positionally with the Rust survivors. That alignment is only valid if the Rust `extent_overlaps`
+> kept-set equals the Python `var_indices` kept-set — which is UNVERIFIED and shows a credible
+> mismatch at deletion anchor bases (Rust anchor-trimmed `[pos+1, …)` vs Python `[POS-1, …)`).
+
+### Task 3.1 (SPIKE): empirically compare Rust `extent_overlaps` vs Python `var_indices` kept-sets
+
+**Deliverable:** a differential test over deletion-boundary fixtures that either (a) proves the two
+kept-sets are identical across SNP/INS/DEL/spanning-DEL at every region-boundary offset, or (b)
+characterizes the exact divergence.
+
+- [ ] **Step 1:** Build a small VCF fixture with a deletion `ACGT>A` and neighbors; for a sweep of
+  query regions around the deletion's anchor/extent boundaries, compute:
+  - Python: `vcf._var_idxs(contig, [start], [end])` (the write-path oracle, `_var_ranges.py`).
+  - Rust: the survivors the `VcfWindowFiller` decodes for the same region (`debug_decode_window`).
+- [ ] **Step 2:** Assert set-equality per region. Record every divergence (expected at the anchor
+  base per the `_var_end_expr` vs `extent_overlaps` analysis).
+- [ ] **Step 3: Decision fork based on the result:**
+  - **If identical:** proceed to Task 3.2 (thread `vcf._var_idxs` ids through, aligned positionally).
+  - **If they diverge:** the fix is to make the two overlap rules agree first — either align the
+    streaming `OverlapMode` to `_var_end_expr` (a genoray/gvl overlap-mode choice) or fix
+    `var_indices`/`_var_end_expr` to anchor-trim (a written-path change, coordinate with #202 since
+    it also concerns variant-region overlap). This is a design decision to surface, not code to
+    guess. **Stop and report the divergence + recommended reconciliation before writing 3.2.**
+
+### Task 3.2 (conditional): supply VCF global ids from `vcf._var_idxs`, carried on `global_idx`
+
+> Concrete steps depend on 3.1's outcome; sketch only. Precompute, per window/job at
+> `VcfWindowFiller` construction (the traversal plan is known), the per-region global-id array via
+> `vcf._var_idxs(contig, regions)`; thread it to the Rust `VcfRecordSource` as a caller-supplied
+> id stream consumed in emission order (so alignment is by construction), populating `RawRecord.global_idx`.
+> Then `fill_decoded_window` carries it to `global_v_idxs` exactly as PGEN does. Add VCF interior-
+> exclusion + multi-contig annotated parity fixtures mirroring Task 2.4. Retire VCF's `-1` default.
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** #305 (global ids) — Phases 1–3; latent Wave A annotated bug (#311) — fixed by
+  Phase 2 for PGEN/SVAR1, Phase 3 for VCF. `var_base` retirement — Task 2.5.
+- **Confidence:** Phases 1–2 (genoray carrier + PGEN + gvl consume) are high-confidence and concrete.
+  Phase 3 (VCF) is deliberately spike-gated — the overlap-semantics mismatch is real and unverified,
+  and writing its code before Task 3.1 would be guessing.
+- **Follow-on plans (separate docs):** PR-B0 (#202 clip), PR-B1 (variants output), PR-B2/B3/B4 per
+  the spec's PR stack — each gets its own plan once this foundation lands.

--- a/docs/superpowers/plans/2026-07-20-streaming-global-variant-ids.md
+++ b/docs/superpowers/plans/2026-07-20-streaming-global-variant-ids.md
@@ -358,17 +358,18 @@ git commit -m "feat(streaming): remap annot var_idxs via per-variant global gath
 **Interfaces:**
 - Consumes: the corrected global-id path (2.1–2.3).
 
-- [ ] **Step 1: Un-xfail the existing narrowed-window gap test.** Delete the `@pytest.mark.xfail(…)`
+- [x] **Step 1: Un-xfail the existing narrowed-window gap test.** Delete the `@pytest.mark.xfail(…)`
   decorator on `test_annotated_pgen_narrowed_window_var_idxs_gap` (`:125-131`) and update its
   docstring to state it is now a passing regression lock (the narrowed region `[71,200)` first-kept
   variant is global id 2; the streamed `var_idxs` must be `[2,3,4]`).
 
-- [ ] **Step 2: Run it to verify it now PASSES**
+- [x] **Step 2: Run it to verify it now PASSES**
 
 Run: `pixi run -e dev pytest tests/dataset/test_streaming_annotated_parity.py::test_annotated_pgen_narrowed_window_var_idxs_gap -q`
 Expected: PASS (previously `xfail`). If it still fails, the global-id plumbing is wrong — debug 2.2/2.3.
+Actual: PASS.
 
-- [ ] **Step 3: Write a failing interior-exclusion test.** Add a fixture (in `conftest.py`) whose
+- [x] **Step 3: Write a failing interior-exclusion test.** Add a fixture (in `conftest.py`) whose
   variants include a spanning deletion that, for a chosen region, is kept while an interior variant
   behind it is dropped — so the written oracle's `var_idxs` are a **gapped** set (e.g. `{0, 2}`).
   Add `test_annotated_pgen_interior_exclusion_var_idxs_gapped` asserting streamed `var_idxs` equal
@@ -395,10 +396,26 @@ P+3, with a query region `[P+5, P+9)` — the DEL's extent reaches the region (k
 does not (dropped). Confirm the written `Dataset` produces a gapped `var_idxs` for this cell first
 (that's the oracle); the `saw_gap` assert guards against a fixture that doesn't actually gap.
 
-- [ ] **Step 4: Run it to verify it passes** → PASS. If the streamed set is contiguous while the
-  oracle is gapped, 2.2/2.3 are wrong.
+**Verified-first finding (deviation from the geometry sketched above):** a window starting *after*
+the DEL's own POS (e.g. `[P+4, P+10)` over a `REF=ACGTAC`/`ALT=A` DEL at P, mirroring this plan's
+`[P+5,P+9)` sketch) does **not** gap — empirically, the written oracle simply omits the DEL's
+`var_idx` entirely for that cell (`kept={2}`, not `{0,2}`), because the annotated array only stamps
+a variant id at the position where its ALT bytes are actually emitted (the DEL's POS), and that
+position lies *before* such a window. Streamed matched written exactly in this case too — so it's
+not a write-vs-stream divergence, just a non-gapping geometry. The gap the plan wants only appears
+when the window **includes the DEL's own POS** (so its surviving ALT byte is in-window) while an
+interior SNP's reference position — inside the DEL's deleted span — is never emitted regardless of
+that SNP's own genotype (confirmed by setting the interior SNP's GT to ALT on the *same* haplotype
+as the DEL: the gap is unchanged, `[0,-1,-1,2,-1]`, proving genuine interior consumption rather than
+a "genotype absent" artifact). Implemented as `pgen_interior_exclusion` in `conftest.py`: DEL at
+0-based pos 20 (`REF=ACGTAC`/`ALT=A`, extent `[20,26)`), interior SNP at pos 22 (`G>T`), trailing SNP
+at pos 28 (`A>G`), query region `[20,30)` → written oracle (and streamed) `var_idxs` for hap0
+`[0,-1,-1,2,-1]`, kept `{0,2}`.
 
-- [ ] **Step 5: Full annotated parity suite + commit**
+- [x] **Step 4: Run it to verify it passes** → PASS. Streamed matches the written oracle's gapped
+  set (`{0,2}`) exactly; `saw_gap` guard confirmed non-trivial.
+
+- [x] **Step 5: Full annotated parity suite + commit**
 
 Run: `pixi run -e dev pytest tests/dataset/test_streaming_annotated_parity.py -q` → PASS.
 

--- a/docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md
+++ b/docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md
@@ -73,7 +73,8 @@ backend.
   (`vcf.rs`) and `PgenWindowFiller` (`pgen.rs`); the producer/consumer engine recycles the
   `DecodedWindow` slot between windows (every filler MUST set `var_base` on every call).
 - `generate_batch_core` (`src/ffi/mod.rs:994`) adds `var_base` to every non-negative
-  `annot_v_idxs` entry after reconstruction (the annotated path).
+  `annot_v_idxs` entry after reconstruction (the annotated path). **PR-A retires this scalar
+  `var_base` in favor of a per-variant `global_v_idxs` array — see the PR-A correctness note.**
 
 The written variants oracle (branch `main`):
 
@@ -87,43 +88,62 @@ The written variants oracle (branch `main`):
 
 ## Design
 
-### PR-A (#305) — correct dataset-global variant ids for the record backends
+### PR-A (#305) — per-variant dataset-global variant ids for the record backends
 
-**Problem.** `RecordBackend::generate` emits global ids as `var_base + local`. Both
-`VcfWindowFiller::fill` and `PgenWindowFiller::fill` currently hard-code `slot.var_base = 0`
-(`vcf.rs:170`, `pgen.rs:614`). #305's body is **stale**: it describes PGEN as already correct from
-`var_start`, but Wave A commit `0b98174b` *reverted* PGEN to `0` ("was buggy PGEN var_start"),
-so #305 covers **both** backends.
+> **Design corrected during plan-writing** (2026-07-20). The original approach — a scalar
+> `var_base` added to window-local ids (`var_base + local`) — is **fundamentally insufficient**,
+> and #305's body (a `var_start`-based base) is doubly wrong. A cross-repo genoray change replaces
+> it. See the correctness note below.
 
-**Why `var_start` alone is wrong.** `var_start` (PGEN) / the window's first candidate (VCF) is a
-**padded, over-inclusive** search lower bound. The `PgenRecordSource`/`VcfRecordSource` then run a
-precise anchor-trimmed `extent_overlaps` filter that can drop a **leading prefix** of padded-in
-candidates whose trimmed extent doesn't reach `win_start`. When it drops `skip_count` of them, the
-window's local column 0 is global id `var_start + skip_count`, not `var_start`.
+**The real defect: the kept set is non-contiguous.** `OverlapMode::Variant` filters on variant
+**extent** (POS + ref_consumed), applied per record in genoray's `vcf_reader.rs:535-554`
+(`extent_overlaps`). A window can therefore **exclude an interior variant behind a spanning
+deletion** — e.g. regions `[(110,115)]`, variants DEL@100 (extent→120, kept), SNP@105 (extent 106,
+**dropped**), SNP@112 (extent 113, kept): the survivors are global ids `{0, 2}`, not `{0, 1}`.
+Same-POS mixed-extent ties (cf. the SVAR1 max-ends tie bug) are a second source of interior
+exclusion. genoray's own SVAR2 query path proves this: `spine.rs` test
+`test_gather_keys_excludes_interior_non_overlap_behind_spanning_deletion` asserts exactly
+`[kr(100,0), kr(112,2)]`.
 
-**Why `var_base + local` is still valid.** The dropped candidates are always a *contiguous leading
-prefix* of the candidate range: candidates are position-sorted, and the window is a suffix-overlap,
-so anything not overlapping `[win_start, …)` sorts before it (even a long spanning DEL is anchored
-at a POS before the window). No interior candidate is dropped, so the kept set is a **contiguous
-global range** starting at `var_start + skip_count`, and a single additive base recovers every id.
+The record-stream `DenseChunk` (`genoray types.rs:137-179`) then **renumbers survivors to dense
+local indices `0..n` and carries no per-variant global id** — the gap is destroyed inside genoray.
+A scalar `var_base` can only reconstruct a **contiguous** range `{base, base+1, …}`, which
+mismatches the written oracle's gapped `{base, base+2, …}` (the write path stores true global ids
+with gaps: `_var_ranges.py` `with_row_index` over the atomized per-contig table + the same
+extent-overlap join). **No value of `var_base` fixes this** — the fix must carry per-variant global
+ids. (SVAR1 and the SVAR2 query path already do, via `pack_vk_src`; only the VCF/PGEN record-stream
+path is affected.)
 
-**Fix.**
+**This is a latent bug in already-merged Wave A.** `with_seqs("annotated")` on VCF/PGEN emits
+`annot_v_idxs` via `var_base + local` (`generate_batch_core`, `ffi/mod.rs:994`), so it is silently
+**wrong for any window containing a spanning deletion or same-POS tie** — even single-contig at
+window 0, not just the multi-contig/narrowed case the code comment ("KNOWN GAP", `vcf.rs:153-170`)
+acknowledges. PR-A fixes annotated too.
 
-- The record source reports `skip_count` (the number of leading candidates its precise filter
-  dropped) — a gvl-internal addition to `Pgen/VcfRecordSource`, **no genoray change**.
-- `PgenWindowFiller::fill`: `slot.var_base = var_start + skip_count` (`var_start` is already global
-  via the `.pvar` prescan's `contig_ranges`/`contig_pos`, `pgen.rs:407-410`).
-- `VcfWindowFiller`: it has no per-contig index today. Add a **per-contig cumulative
-  variant-count table** built once at `VcfWindowFiller::new` (a lightweight header/index pass,
-  mirroring PGEN's `.pvar` prescan and how `sample_indices` is already resolved once at
-  construction rather than per-window). This yields `contig_global_lo`; then
-  `slot.var_base = contig_global_lo + within_contig_offset + skip_count`.
+**Fix (decision: genoray emits global ids).** Mirror the SVAR2 `pack_vk_src` pattern:
 
-**Tests.** A multi-contig VCF **annotated-output** parity fixture (mirrors
-`svar1_multicontig_fixture`, which already proves SVAR1's `var_base = 0` global-ids path is correct
-for multi-contig) plus the analogous PGEN case. This unblocks correct multi-contig / narrowed
-`annot_v_idxs` for the **annotated** output already shipped in Wave A, and provides the global-id
-foundation the variants surface (PR-B1) needs. Closes #305.
+- **genoray PR** — add a per-variant global-id column to `DenseChunk` (e.g. `global_idx: Vec<i32>`,
+  one per surviving variant, in chunk order), populated by the record source through
+  atomization/exclusion so each survivor carries its **true dataset-global** id:
+  - **PGEN** is index-addressed (`PgenRecordSource` scans a global `[var_start, var_end)` range),
+    so a survivor's id is `var_start + scan_offset` — cheap and tie-safe, no position matching.
+  - **VCF** is tabix position-addressed; the source needs a **per-contig variant base** (the
+    cumulative atom count before the fetch region). genoray adds a per-contig variant index built
+    once at source construction (it has no cheap `contig_ranges`-equivalent today) so the running
+    within-contig atom index + that base gives the global id.
+  - Merge to genoray `main`; bump gvl's git `rev` (genoray is a first-party dep reached by rev
+    bump — CLAUDE.md → Development Notes; the roadmap's other genoray prerequisites set precedent).
+- **gvl PR-A** — bump the rev; add `global_v_idxs: Vec<i32>` to `DecodedWindow`; populate it in
+  `fill_decoded_window` from `chunk.global_idx`; **retire the scalar `var_base`** — `generate`
+  emits `annot_v_idxs` (and, in PR-B1, variants `v_idxs`) directly from `global_v_idxs[local]`,
+  not `var_base + local`. The `generate_batch_core` `var_base` add-back is removed/zeroed.
+
+**Tests.** Parity fixtures that specifically exercise **interior exclusion** (a spanning deletion
+that drops an interior variant; a same-POS SNP+DEL mixed-extent tie) plus **multi-contig** and
+**narrowed/partial-prefix** windows, on **both VCF and PGEN**, asserting `annot_v_idxs` are the
+exact gapped global ids the written `Dataset` produces. Mirrors `svar1_multicontig_fixture` and adds
+the interior-exclusion case (which SVAR1 already handles correctly and the record path currently
+does not). Closes #305; provides the global-id foundation PR-B1 needs.
 
 ### PR-B0 (#202) — clip variants to the region window (both paths)
 
@@ -148,12 +168,13 @@ alone, so it can be cherry-picked to `main` earlier if desired.
 
 The default `var_fields = ["alt", "ilen", "start"]` needs **no REF and no AF** — all three come
 from channels `DecodedWindow` already carries (`v_starts`/`ilens`/`alt`/`alt_offsets`) plus the
-per-hap CSR and `var_base` (PR-A). So the first variants PR ships without touching the decode.
+per-hap CSR and the per-variant `global_v_idxs` (PR-A). So the first variants PR ships without
+touching the decode.
 
 - **New consumer path** in `RecordBackend` (and the SVAR1 backend): for the `[row_lo, row_hi)`
   slice, gather each `(region, sample, ploid)`'s window-local `v_idxs` from the per-hap CSR
   (`geno_offsets`/`geno_v_idxs`), **clip to the region window** (PR-B0 semantics), map local→global
-  via `var_base`, and feed the **existing** `assemble_variant_buffers_u8/i32` kernel plus the
+  via `global_v_idxs[local]` (PR-A), and feed the **existing** `assemble_variant_buffers_u8/i32` kernel plus the
   `gather_*`/`fill_empty_*` helpers. This is the DRY win: the written and streaming variants paths
   share one Rust assembly kernel; the only difference is where the per-hap variant lists come from
   (streaming's window-local CSR vs the written per-cell sparse set).
@@ -212,6 +233,11 @@ per-hap CSR and `var_base` (PR-A). So the first variants PR ships without touchi
   CSR + static table already match the kernel's inputs.
 - **REF via reference-slice**, not a genoray `DenseChunk` change — avoids a cross-repo dependency;
   parity is the gate.
+- **Global ids → genoray emits them** (chosen, corrected 2026-07-20). Interior exclusion makes the
+  kept set non-contiguous, so the scalar `var_base` is unfixable; genoray's `DenseChunk` gains a
+  per-variant global-id column (SVAR2 `pack_vk_src` pattern), consumed via `DecodedWindow.global_v_idxs`.
+  This is a cross-repo genoray PR + rev bump — the one place Wave B deliberately touches genoray
+  (REF stays in-repo via reference-slice). It also fixes the latent Wave A annotated bug.
 - **Branch (resolved)**: Wave A is merged into `streaming` (PR #308), so **every Wave B PR —
   including PR-A and the PR-B0 #202 fix — targets `streaming` directly.** No stacking on the (now
   deleted) `spec/277-output-mode-wave-a` branch, and no `main`-vs-`streaming` split for #202.
@@ -221,15 +247,21 @@ per-hap CSR and `var_base` (PR-A). So the first variants PR ships without touchi
 - **Parity oracle**: byte-identical vs `gvl.write()` + `Dataset[r, s]` under the matching
   `with_seqs(...)` / `min_af` / `max_af` / `var_fields`, on the **corrected** (#202-clipped) written
   path. One parity fixture per knob, on **SVAR1 + VCF + PGEN**.
-- **Multi-contig / narrowed windows** (the #305 gap): a multi-contig VCF (and PGEN) fixture where
-  the window does not start at global variant 0, asserting global `v_idxs` / `annot_v_idxs` are
-  exact. Mirrors `svar1_multicontig_fixture`.
+- **Interior exclusion (the #305 crux)**: a window with a spanning deletion that drops an interior
+  variant, and a same-POS SNP+DEL mixed-extent tie, on **both VCF and PGEN**, asserting
+  `annot_v_idxs` (and PR-B1 `v_idxs`) are the exact **gapped** global ids the written `Dataset`
+  produces — the case a scalar `var_base` cannot express.
+- **Multi-contig / narrowed windows**: a fixture where the window does not start at global variant 0,
+  asserting global ids are exact. Mirrors `svar1_multicontig_fixture`.
 - **AF-missing guard**: setting `min_af`/`max_af` without a cached `AF` column raises the same error
   as the written path.
 - **Empty groups**: `(region, sample, ploid)` cells with no in-window variant produce the written
   path's dummy fills (`DummyVariant`, `_flat_variants.py:37`).
-- **Rust unit tests**: `var_base = var_start + skip_count` under a synthetic leading-skip window;
-  the per-contig VCF count table; the variants consumer's local→global mapping and region clip.
+- **genoray-side tests**: the `DenseChunk.global_idx` column is correct under interior exclusion for
+  both the index-addressed (PGEN) and position-addressed (VCF) record sources (genoray PR's own
+  suite, mirroring the existing `spine.rs` interior-exclusion test).
+- **gvl Rust unit tests**: `fill_decoded_window` copies `global_idx → global_v_idxs`; `generate`
+  emits `global_v_idxs[local]` (not `var_base + local`); the variants consumer's region clip.
 - **Rebuild note** (CLAUDE.md): `maturin develop --release` before pytest after any `src/` change;
   run the full tree before pushing symbol/shared-code changes.
 
@@ -237,7 +269,8 @@ per-hap CSR and `var_base` (PR-A). So the first variants PR ships without touchi
 
 | PR | Scope | Depends on | Parallel? |
 |----|-------|-----------|-----------|
-| **PR-A** | #305 `var_base` (VCF+PGEN) + `skip_count` + VCF per-contig table + multi-contig fixtures | Wave A (merged, #308) | — foundation |
+| **genoray PR** | `DenseChunk.global_idx` per-variant global-id column (PGEN index-addressed; VCF per-contig base) + interior-exclusion tests | — | ⛔ cross-repo prerequisite for PR-A |
+| **PR-A** | #305: bump rev; `DecodedWindow.global_v_idxs`; retire scalar `var_base`; re-point annotated; interior-exclusion + multi-contig parity fixtures (fixes latent Wave A annotated bug) | genoray PR, Wave A (merged, #308) | — foundation |
 | **PR-B0** | #202 written-path region clip (targets `streaming`) | — | ✅ independent of PR-A |
 | **PR-B1** | streaming `with_seqs("variants")`, default fields, region-clipped, reuse assemble kernel | PR-A, PR-B0 | serial base for B2–B4 |
 | **PR-B2** | `min_af`/`max_af` (AF channel) | PR-B1 | ✅ vs B3 |
@@ -253,11 +286,13 @@ as each PR lands.
 
 - **REF reference-slice divergence** — mitigated by parity; genoray REF exposure is the fallback
   (PR-B4).
-- **`skip_count` reporting** — requires a small `Pgen/VcfRecordSource` API addition; if the source
-  can't cheaply report it, the filler can recompute the leading-skip from the window's precise
-  overlap predicate. Either way gvl-internal.
-- **VCF per-contig count pass cost** — one construction-time pass over the index/header; acceptable
-  (same amortization class as the `.pvar` prescan). Watch that it doesn't re-scan per window.
+- **Cross-repo genoray change** — PR-A is gated on a genoray PR (`DenseChunk.global_idx`) merging to
+  genoray `main` + a gvl rev bump. Sequence it like the roadmap's other genoray prerequisites; do
+  the genoray PR first. The VCF per-contig base inside genoray is the non-trivial part (position-
+  addressed, no existing `contig_ranges`); PGEN is cheap (index-addressed).
+- **Latent Wave A annotated bug** — merged `with_seqs("annotated")` is wrong under interior
+  exclusion today. PR-A fixes it, but until it lands the merged annotated output is unsafe for any
+  VCF/PGEN cohort with spanning deletions; call this out on the board and in #305.
 - **FORMAT dense-vs-carrier encodings** (#231) — the consumer must handle both `format_staged` and
   `format_by_carrier`; covered by per-source parity fixtures.
 - **SVAR2** — not in this wave; it inherits the generic consumer when #298 merges, but its store

--- a/docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md
+++ b/docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md
@@ -7,9 +7,10 @@
 [#305](https://github.com/mcvickerlab/GenVarLoader/issues/305) — record-backend `var_base` for narrowed/multi-contig windows
 **Folds in:** [#202](https://github.com/mcvickerlab/GenVarLoader/issues/202) — `with_seqs("variants")` not clipped to the region window ·
 [#231](https://github.com/mcvickerlab/GenVarLoader/issues/231) — custom per-call FORMAT/INFO `var_fields`
-**Follows:** Wave A [#277](https://github.com/mcvickerlab/GenVarLoader/issues/277)
-(branch `spec/277-output-mode-wave-a`) — `with_len` + jitter + `with_seqs("annotated")`
-**Target branch:** `streaming` (stacked on `spec/277-output-mode-wave-a`)
+**Follows:** Wave A [#277](https://github.com/mcvickerlab/GenVarLoader/issues/277) — `with_len` +
+jitter + `with_seqs("annotated")` — **merged into `streaming`** via PR
+[#308](https://github.com/mcvickerlab/GenVarLoader/pull/308) (2026-07-20)
+**Target branch:** `streaming` (Wave A already merged; every Wave B PR targets `streaming` directly)
 **Backends:** SVAR1 + VCF + PGEN (the backends merged into `streaming`). SVAR2 ([#298](https://github.com/mcvickerlab/GenVarLoader/issues/298)) inherits the generic code when it merges.
 
 ## Summary
@@ -137,12 +138,11 @@ contig). The haplotype/annotated path does clip correctly (`regions=req.regions,
 (PR-B1) applies the identical clip natively (its haplotype path already clips per-row via the `rb`
 region bounds in `generate_batch_core`). Closes #202.
 
-**Branch/ordering.** The written-path fix is an independent pre-existing bug; it targets `main` and
-benefits all users immediately. `streaming` merges `main` (the roadmap already prescribes periodic
-`main → streaming` merges) **before** PR-B1's variants-parity test runs, so parity is asserted
-against the corrected oracle. If cross-branch timing proves awkward at plan-time, the fallback is to
-land the written-path clip directly on `streaming` with the rest of Wave B; either way both paths
-clip.
+**Branch/ordering.** The written-path fix targets **`streaming`** with the rest of Wave B (decided:
+keep all Wave B on one branch to avoid cross-branch merge-timing coupling with the parity tests).
+It lands before PR-B1 so PR-B1's variants-parity is asserted against the corrected oracle. The fix
+flows to `main` at the streaming milestone merge, closing #202 for all users then; it also stands
+alone, so it can be cherry-picked to `main` earlier if desired.
 
 ### PR-B1 — streaming variants output (`RaggedVariants`), default fields, region-clipped
 
@@ -212,8 +212,9 @@ per-hap CSR and `var_base` (PR-A). So the first variants PR ships without touchi
   CSR + static table already match the kernel's inputs.
 - **REF via reference-slice**, not a genoray `DenseChunk` change — avoids a cross-repo dependency;
   parity is the gate.
-- **Open at plan-time**: whether PR-A stacks directly on `spec/277-output-mode-wave-a` or waits for
-  Wave A to merge to `streaming` first. Not blocking the spec.
+- **Branch (resolved)**: Wave A is merged into `streaming` (PR #308), so **every Wave B PR —
+  including PR-A and the PR-B0 #202 fix — targets `streaming` directly.** No stacking on the (now
+  deleted) `spec/277-output-mode-wave-a` branch, and no `main`-vs-`streaming` split for #202.
 
 ## Testing / parity plan
 
@@ -236,8 +237,8 @@ per-hap CSR and `var_base` (PR-A). So the first variants PR ships without touchi
 
 | PR | Scope | Depends on | Parallel? |
 |----|-------|-----------|-----------|
-| **PR-A** | #305 `var_base` (VCF+PGEN) + `skip_count` + VCF per-contig table + multi-contig fixtures | Wave A | — foundation |
-| **PR-B0** | #202 written-path region clip (target `main`) | — | ✅ independent of PR-A |
+| **PR-A** | #305 `var_base` (VCF+PGEN) + `skip_count` + VCF per-contig table + multi-contig fixtures | Wave A (merged, #308) | — foundation |
+| **PR-B0** | #202 written-path region clip (targets `streaming`) | — | ✅ independent of PR-A |
 | **PR-B1** | streaming `with_seqs("variants")`, default fields, region-clipped, reuse assemble kernel | PR-A, PR-B0 | serial base for B2–B4 |
 | **PR-B2** | `min_af`/`max_af` (AF channel) | PR-B1 | ✅ vs B3 |
 | **PR-B3** | `var_fields` dosage + custom FORMAT/INFO (#231) | PR-B1 | ✅ vs B2 |

--- a/docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md
+++ b/docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md
@@ -1,0 +1,277 @@
+# Design: `StreamingDataset` — variants-output surface (Wave B) + global variant ids
+
+**Date:** 2026-07-20
+**Status:** design (pending spec review)
+**Roadmap:** `docs/roadmaps/streaming-dataset.md` (Plan 5)
+**Issues:** [#304](https://github.com/mcvickerlab/GenVarLoader/issues/304) — Wave B (variants-output surface) ·
+[#305](https://github.com/mcvickerlab/GenVarLoader/issues/305) — record-backend `var_base` for narrowed/multi-contig windows
+**Folds in:** [#202](https://github.com/mcvickerlab/GenVarLoader/issues/202) — `with_seqs("variants")` not clipped to the region window ·
+[#231](https://github.com/mcvickerlab/GenVarLoader/issues/231) — custom per-call FORMAT/INFO `var_fields`
+**Follows:** Wave A [#277](https://github.com/mcvickerlab/GenVarLoader/issues/277)
+(branch `spec/277-output-mode-wave-a`) — `with_len` + jitter + `with_seqs("annotated")`
+**Target branch:** `streaming` (stacked on `spec/277-output-mode-wave-a`)
+**Backends:** SVAR1 + VCF + PGEN (the backends merged into `streaming`). SVAR2 ([#298](https://github.com/mcvickerlab/GenVarLoader/issues/298)) inherits the generic code when it merges.
+
+## Summary
+
+Bring the write-free `StreamingDataset` up to the written `Dataset`'s **variant-level** output
+surface — the "expensive half" of output-mode breadth that Wave A deliberately deferred. Unlike
+Wave A (which reused the existing window buffer and the fused reconstruct kernels), Wave B needs
+**new per-variant channels decoded into the window buffer** and a **new consumer path** that
+bypasses reconstruction entirely.
+
+What ships:
+
+- **`sds.with_seqs("variants")`** → `RaggedVariants` batches, byte-identical to `gvl.write()` +
+  `Dataset[r, s]` under the matching config.
+- **`sds.with_seqs("variant-windows")`** → `_FlatVariantWindows` (flanked tokenized ref/alt
+  windows).
+- **`min_af` / `max_af`** filtering (variants output only — matches the written path, which raises
+  `NotImplementedError` for haplotype/annotated AF filtering, `_haps.py:692-695`).
+- **`var_fields`** — custom per-call FORMAT/INFO columns (default `["alt", "ilen", "start"]`,
+  issue #231).
+
+Two decisions taken during design (see [Decisions](#decisions)):
+
+1. **#202 (region clipping): fix both paths.** Streaming clips variants to the region window from
+   the start; the written path is corrected to match (its current `regions=None` gather returns an
+   unclipped set). Parity is asserted against the **corrected** oracle.
+2. **Scope: full Wave B, delivered as a stack of small PRs** (below), docs/skill/api folded into
+   each PR that adds a knob.
+
+### Why this is the expensive half
+
+The written variants path (`get_variants_flat`, `python/genvarloader/_dataset/_flat_variants.py:775`)
+does **not** use a reconstruct kernel. It gathers per-`(region, sample, ploid)` sparse variant
+indices, applies AF filtering, and assembles ragged buffers via `assemble_variant_buffers_u8/i32`
+(`src/ffi/mod.rs:463-576`) plus `gather_*`/`compact_keep_*`/`fill_empty_*` helpers
+(`src/variants/mod.rs`). It consumes per-variant data the streaming window buffer
+(`src/record_stream/transpose.rs::DecodedWindow`) does **not** carry today:
+
+- **REF allele bytes** — for `RaggedVariants.ref`/`.end` and `variant-windows(ref="allele")`.
+- **the `AF` INFO field** — for `min_af`/`max_af`.
+- **dosages / per-call FORMAT fields** — for `var_fields` (#231).
+- **dataset-global variant ids** — streaming's `geno_v_idxs` are window-**local** column indices;
+  the written `v_idxs` are global. This is exactly the gap #305 closes.
+
+`fill_decoded_window` throws all of this away today; Wave B extracts what each knob needs, per
+backend.
+
+## Background: what already exists (Wave A base)
+
+`StreamingDataset` (`python/genvarloader/_dataset/_streaming.py`) is a frozen-dataclass lazy view,
+**iteration-only** (`to_iter`; `__getitem__` returns `None`). It **always requires a reference**
+(`_streaming.py:179-181`), so every backend already holds the full reference contig bytes
+(`ContigRef.ref_bytes`, `src/record_stream/engine.rs:69`). Wave A established:
+
+- `with_seqs(kind)` dispatch (`_streaming.py:712`) — currently `"haplotypes"`/`"annotated"` only;
+  `"variants"`/`"variant-windows"` raise `NotImplementedError` pointing at this issue.
+- The `DecodedWindow` static table (`v_starts`/`ilens`/`alt_alleles`/`alt_offsets`) + per-hap CSR
+  (`geno_offsets`/`geno_v_idxs`) + **`var_base`** (`src/record_stream/transpose.rs:29-46`).
+- The `WindowFiller` trait (`fill(job, contig, slot)`, `engine.rs:44`) with `VcfWindowFiller`
+  (`vcf.rs`) and `PgenWindowFiller` (`pgen.rs`); the producer/consumer engine recycles the
+  `DecodedWindow` slot between windows (every filler MUST set `var_base` on every call).
+- `generate_batch_core` (`src/ffi/mod.rs:994`) adds `var_base` to every non-negative
+  `annot_v_idxs` entry after reconstruction (the annotated path).
+
+The written variants oracle (branch `main`):
+
+- `RaggedVariants` (`_dataset/_rag_variants.py:201`) — shape `(batch, ploidy, ~variants)`;
+  requires `alt` + `start` + **one of** `{ref, ilen}`; `ilen`/`end` derivable from allele lengths;
+  extra numeric FORMAT/INFO fields ride along.
+- REF bytes / AF / dosage / custom FORMAT are all read from **on-disk tables** in the written
+  dataset dir (`variants.arrow`, `dosages.npy`, `var_field_data`), loaded into memory at open —
+  **not** re-read from source. Streaming has no dataset dir, so it must produce these from the
+  **live** source (genoray `DenseChunk` for VCF/PGEN; the SVAR store).
+
+## Design
+
+### PR-A (#305) — correct dataset-global variant ids for the record backends
+
+**Problem.** `RecordBackend::generate` emits global ids as `var_base + local`. Both
+`VcfWindowFiller::fill` and `PgenWindowFiller::fill` currently hard-code `slot.var_base = 0`
+(`vcf.rs:170`, `pgen.rs:614`). #305's body is **stale**: it describes PGEN as already correct from
+`var_start`, but Wave A commit `0b98174b` *reverted* PGEN to `0` ("was buggy PGEN var_start"),
+so #305 covers **both** backends.
+
+**Why `var_start` alone is wrong.** `var_start` (PGEN) / the window's first candidate (VCF) is a
+**padded, over-inclusive** search lower bound. The `PgenRecordSource`/`VcfRecordSource` then run a
+precise anchor-trimmed `extent_overlaps` filter that can drop a **leading prefix** of padded-in
+candidates whose trimmed extent doesn't reach `win_start`. When it drops `skip_count` of them, the
+window's local column 0 is global id `var_start + skip_count`, not `var_start`.
+
+**Why `var_base + local` is still valid.** The dropped candidates are always a *contiguous leading
+prefix* of the candidate range: candidates are position-sorted, and the window is a suffix-overlap,
+so anything not overlapping `[win_start, …)` sorts before it (even a long spanning DEL is anchored
+at a POS before the window). No interior candidate is dropped, so the kept set is a **contiguous
+global range** starting at `var_start + skip_count`, and a single additive base recovers every id.
+
+**Fix.**
+
+- The record source reports `skip_count` (the number of leading candidates its precise filter
+  dropped) — a gvl-internal addition to `Pgen/VcfRecordSource`, **no genoray change**.
+- `PgenWindowFiller::fill`: `slot.var_base = var_start + skip_count` (`var_start` is already global
+  via the `.pvar` prescan's `contig_ranges`/`contig_pos`, `pgen.rs:407-410`).
+- `VcfWindowFiller`: it has no per-contig index today. Add a **per-contig cumulative
+  variant-count table** built once at `VcfWindowFiller::new` (a lightweight header/index pass,
+  mirroring PGEN's `.pvar` prescan and how `sample_indices` is already resolved once at
+  construction rather than per-window). This yields `contig_global_lo`; then
+  `slot.var_base = contig_global_lo + within_contig_offset + skip_count`.
+
+**Tests.** A multi-contig VCF **annotated-output** parity fixture (mirrors
+`svar1_multicontig_fixture`, which already proves SVAR1's `var_base = 0` global-ids path is correct
+for multi-contig) plus the analogous PGEN case. This unblocks correct multi-contig / narrowed
+`annot_v_idxs` for the **annotated** output already shipped in Wave A, and provides the global-id
+foundation the variants surface (PR-B1) needs. Closes #305.
+
+### PR-B0 (#202) — clip variants to the region window (both paths)
+
+On the written path, `get_variants_flat` gathers `v_idxs` straight from the per-cell sparse
+genotype set and uses `regions` only for flank/window token assembly — never to filter by region
+extent (the `regions=None` call site the issue names). So `RaggedVariants` can include variants
+outside the queried window (boundary-overlapping indels; for PGEN, variants elsewhere on the
+contig). The haplotype/annotated path does clip correctly (`regions=req.regions, keep=req.keep`).
+
+**Fix.** Thread a region-extent-overlap filter into the variants `v_idxs` gather so
+`with_seqs("variants")` is windowed the same way haplotype output is. Streaming's variants consumer
+(PR-B1) applies the identical clip natively (its haplotype path already clips per-row via the `rb`
+region bounds in `generate_batch_core`). Closes #202.
+
+**Branch/ordering.** The written-path fix is an independent pre-existing bug; it targets `main` and
+benefits all users immediately. `streaming` merges `main` (the roadmap already prescribes periodic
+`main → streaming` merges) **before** PR-B1's variants-parity test runs, so parity is asserted
+against the corrected oracle. If cross-branch timing proves awkward at plan-time, the fallback is to
+land the written-path clip directly on `streaming` with the rest of Wave B; either way both paths
+clip.
+
+### PR-B1 — streaming variants output (`RaggedVariants`), default fields, region-clipped
+
+The default `var_fields = ["alt", "ilen", "start"]` needs **no REF and no AF** — all three come
+from channels `DecodedWindow` already carries (`v_starts`/`ilens`/`alt`/`alt_offsets`) plus the
+per-hap CSR and `var_base` (PR-A). So the first variants PR ships without touching the decode.
+
+- **New consumer path** in `RecordBackend` (and the SVAR1 backend): for the `[row_lo, row_hi)`
+  slice, gather each `(region, sample, ploid)`'s window-local `v_idxs` from the per-hap CSR
+  (`geno_offsets`/`geno_v_idxs`), **clip to the region window** (PR-B0 semantics), map local→global
+  via `var_base`, and feed the **existing** `assemble_variant_buffers_u8/i32` kernel plus the
+  `gather_*`/`fill_empty_*` helpers. This is the DRY win: the written and streaming variants paths
+  share one Rust assembly kernel; the only difference is where the per-hap variant lists come from
+  (streaming's window-local CSR vs the written per-cell sparse set).
+- **Python**: `StreamingDataset.with_seqs("variants")` maps `_seq_kind → RaggedVariants`; `to_iter`
+  pulls a variants batch (a new engine `next_batch_variants`) and yields `RaggedVariants`.
+- **Parity**: byte-identical vs the corrected written `Dataset.with_seqs("variants")` on SVAR1 +
+  VCF + PGEN.
+
+### PR-B2 — `min_af` / `max_af`
+
+- **VCF/PGEN**: request the `AF` INFO column from genoray (`DenseChunk.info_staged`,
+  `StagedColumn::Float`) by adding an `AF` `FieldSpec` to the chunk reader the filler constructs.
+- **SVAR1**: read AF from its store.
+- Add an `afs` channel to `DecodedWindow`; the variants consumer builds
+  `keep = (af >= min_af) & (af <= max_af)` and compacts before assembly — mirroring
+  `get_variants_flat`'s AF filter (`_flat_variants.py:810-833`).
+- **Guard parity**: the written path raises if `min_af`/`max_af` is set without a cached `AF`
+  column (`_haps.py:319-325`); streaming reproduces the same error surface.
+
+### PR-B3 — `var_fields` (dosage + custom FORMAT/INFO, #231)
+
+- **dosage / FORMAT**: request the columns from genoray. `DenseChunk` exposes two encodings —
+  dense `format_staged` (multi-sample VCF, PGEN) or carrier-sparse `format_by_carrier` (the k-way
+  merge over single-sample VCFs); the consumer handles both.
+- **numeric INFO** columns (beyond AF): `info_staged`.
+- **SVAR**: read from store (`_svar_format_fields`).
+- Per-sample gather into ride-along ragged fields, compacted by the same `keep` mask, mirroring
+  `get_variants_flat:822-883`. `available_var_fields` on the streaming side is computed from what
+  the live source exposes (analogous to `Haps.__post_init__:310-317`).
+
+### PR-B4 — REF bytes + `variant-windows` (`_FlatVariantWindows`)
+
+- **REF bytes** (VCF/PGEN): genoray's `DenseChunk` does not expose REF (`// pub refe` commented
+  out in `types.rs`). Since `StreamingDataset` always has a reference, slice
+  `ref_bytes = reference[start : start + ref_len]` with `ref_len = alt_len − ilen` (`alt_len` from
+  `alt_offsets`) — exact for the normalized, left-aligned biallelic variants gvl requires. **No
+  genoray change.** SVAR reads REF from its store. This enables the explicit `ref` var_field.
+  - *Risk / validated by parity*: this assumes VCF `REF` == reference at `[POS, POS+len(REF))`,
+    which holds for variants normalized against the dataset's reference. The parity test is the
+    gate; if an edge case diverges, the fallback is to expose REF from genoray's `DenseChunk`.
+- **variant-windows** (`_FlatVariantWindows`, `_flat_variants.py:267`): tokenized flanked ref/alt
+  windows. The token LUT is built in Python `with_seqs` exactly as the written path does
+  (`_impl.py:742-757`, `VarWindowOpt` with `ref`/`alt ∈ {"window","allele"}`, `flank_length`,
+  `token_alphabet`, `unknown_token`). `ref="window"` flanks the reference genome (streaming has
+  it); `ref="allele"` uses REF bytes (above). Reuse the written window-assembly kernels.
+
+## Decisions
+
+- **#202 → fix both paths** (chosen). Streaming clips natively; the written path is corrected so
+  parity is against a correct oracle rather than a preserved bug. Consistent with the migration
+  convention (a buggy oracle is fixed in its own PR, not reproduced) and keeps `with_seqs("variants")`
+  meaningfully windowed for all users.
+- **Scope → full Wave B, staged PRs** (chosen). One design, delivered as PR-A → PR-B0 → PR-B1 →
+  PR-B2 → PR-B3 → PR-B4, so each lands small and independently parity-tested.
+- **Reuse `assemble_variant_buffers_*`** rather than a streaming-specific kernel — the streaming
+  CSR + static table already match the kernel's inputs.
+- **REF via reference-slice**, not a genoray `DenseChunk` change — avoids a cross-repo dependency;
+  parity is the gate.
+- **Open at plan-time**: whether PR-A stacks directly on `spec/277-output-mode-wave-a` or waits for
+  Wave A to merge to `streaming` first. Not blocking the spec.
+
+## Testing / parity plan
+
+- **Parity oracle**: byte-identical vs `gvl.write()` + `Dataset[r, s]` under the matching
+  `with_seqs(...)` / `min_af` / `max_af` / `var_fields`, on the **corrected** (#202-clipped) written
+  path. One parity fixture per knob, on **SVAR1 + VCF + PGEN**.
+- **Multi-contig / narrowed windows** (the #305 gap): a multi-contig VCF (and PGEN) fixture where
+  the window does not start at global variant 0, asserting global `v_idxs` / `annot_v_idxs` are
+  exact. Mirrors `svar1_multicontig_fixture`.
+- **AF-missing guard**: setting `min_af`/`max_af` without a cached `AF` column raises the same error
+  as the written path.
+- **Empty groups**: `(region, sample, ploid)` cells with no in-window variant produce the written
+  path's dummy fills (`DummyVariant`, `_flat_variants.py:37`).
+- **Rust unit tests**: `var_base = var_start + skip_count` under a synthetic leading-skip window;
+  the per-contig VCF count table; the variants consumer's local→global mapping and region clip.
+- **Rebuild note** (CLAUDE.md): `maturin develop --release` before pytest after any `src/` change;
+  run the full tree before pushing symbol/shared-code changes.
+
+## Decomposition (PR stack)
+
+| PR | Scope | Depends on | Parallel? |
+|----|-------|-----------|-----------|
+| **PR-A** | #305 `var_base` (VCF+PGEN) + `skip_count` + VCF per-contig table + multi-contig fixtures | Wave A | — foundation |
+| **PR-B0** | #202 written-path region clip (target `main`) | — | ✅ independent of PR-A |
+| **PR-B1** | streaming `with_seqs("variants")`, default fields, region-clipped, reuse assemble kernel | PR-A, PR-B0 | serial base for B2–B4 |
+| **PR-B2** | `min_af`/`max_af` (AF channel) | PR-B1 | ✅ vs B3 |
+| **PR-B3** | `var_fields` dosage + custom FORMAT/INFO (#231) | PR-B1 | ✅ vs B2 |
+| **PR-B4** | REF bytes (reference-slice) + `variant-windows` | PR-B1 (+B3 for `ref` field) | last |
+
+Docs / `skills/genvarloader/SKILL.md` / `docs/source/*.md` / `api.md` updates fold into each PR
+that adds a public knob (CLAUDE.md public-API + docs-audit gates). Update
+`docs/roadmaps/streaming-dataset.md` (Plan 5) status markers and the StreamingDataset project board
+as each PR lands.
+
+## Risks
+
+- **REF reference-slice divergence** — mitigated by parity; genoray REF exposure is the fallback
+  (PR-B4).
+- **`skip_count` reporting** — requires a small `Pgen/VcfRecordSource` API addition; if the source
+  can't cheaply report it, the filler can recompute the leading-skip from the window's precise
+  overlap predicate. Either way gvl-internal.
+- **VCF per-contig count pass cost** — one construction-time pass over the index/header; acceptable
+  (same amortization class as the `.pvar` prescan). Watch that it doesn't re-scan per window.
+- **FORMAT dense-vs-carrier encodings** (#231) — the consumer must handle both `format_staged` and
+  `format_by_carrier`; covered by per-source parity fixtures.
+- **SVAR2** — not in this wave; it inherits the generic consumer when #298 merges, but its store
+  read of REF/AF/FORMAT must be wired then.
+
+## References
+
+- Streaming roadmap: `docs/roadmaps/streaming-dataset.md` (Plan 5).
+- Wave A spec: `docs/superpowers/specs/2026-07-19-streaming-output-mode-breadth-wave-a-design.md`.
+- Written variants path: `python/genvarloader/_dataset/_flat_variants.py` (`get_variants_flat:775`),
+  `_dataset/_rag_variants.py` (`RaggedVariants:201`), `_dataset/_haps.py`
+  (`get_variants_flat` dispatch `:588-606`; AF `NotImplementedError` `:692-695`; provenance
+  `_Variants.from_table:104-165`), `_dataset/_impl.py` (`with_seqs:642`, `var_fields:338-381`).
+- Streaming engine: `src/record_stream/{engine.rs,transpose.rs,vcf.rs,pgen.rs}`,
+  `src/ffi/{mod.rs,stream_engine.rs}`, `python/genvarloader/_dataset/_streaming.py`.
+- Assembly kernels: `src/ffi/mod.rs:463-576` (`assemble_variant_buffers_*`), `src/variants/mod.rs`.
+- genoray `DenseChunk` (pinned rev `1d756ad`): `info_staged`/`format_staged`/`format_by_carrier`,
+  REF commented out.

--- a/python/genvarloader/_dataset/_streaming.py
+++ b/python/genvarloader/_dataset/_streaming.py
@@ -1042,8 +1042,9 @@ class _Svar1Backend:
         Wave A `with_len`); forwarded straight to the engine constructor's trailing
         `output_length` parameter. `annotated` (issue #277 Wave A Task 4) selects
         whether the engine computes `annot_v_idxs`/`annot_ref_pos` -- SVAR1's
-        `geno_v_idxs` is already dataset-global, so the Rust side needs no `var_base`
-        (see `stream_engine.rs`'s `Svar1Backend.annotated` doc comment).
+        `geno_v_idxs` is already dataset-global, so the Rust side passes `None` for
+        the per-variant global-id gather (see `stream_engine.rs`'s
+        `Svar1Backend.annotated` doc comment).
 
         Cohort-independent job residency (issue #284 / final-review Finding 1): the
         full public->physical sample map `self._phys_sample_idx` crosses ONCE (length
@@ -1295,11 +1296,12 @@ class _VcfBackend:
         length >= 1 (issue #277 Wave A `with_len`), forwarded straight to the
         engine constructor's trailing `output_length` parameter. `annotated`
         (issue #277 Wave A Task 4) selects whether the engine computes
-        `annot_v_idxs`/`annot_ref_pos`; `VcfWindowFiller` maps window-local
-        variant ids to dataset-global ones via `var_base = 0` -- CORRECT for
-        every current single-contig/whole-contig fixture but a KNOWN GAP for a
-        window that doesn't start at global variant 0 (see `vcf.rs`'s
-        `WindowFiller::fill` doc comment and GitHub issue #305).
+        `annot_v_idxs`/`annot_ref_pos`, remapped window-local -> dataset-global
+        per-variant via `slot.global_v_idxs` (genoray `DenseChunk.global_idx`,
+        gathered by `generate_batch_core`). VCF's genoray ids are hard-coded
+        `-1` until Phase 3, so the gather is a no-op and emitted ids stay
+        window-local -- the known VCF gap (see `vcf.rs`'s `WindowFiller::fill`
+        doc comment and GitHub issue #305).
         """
         from ..genvarloader import RecordStreamEngine
 
@@ -1430,19 +1432,15 @@ class _PgenBackend:
         `vcf_path` naming (here it's the resolved `.pgen` path). `output_length`
         is `-1` for ragged or a fixed length >= 1 (issue #277 Wave A `with_len`).
         `annotated` (issue #277 Wave A Task 4) selects whether the engine
-        computes `annot_v_idxs`/`annot_ref_pos`; `PgenWindowFiller` uses the
-        SAME `var_base = 0` default as `_VcfBackend` (see its doc comment
-        above) -- an earlier version of this filler set `var_base` from the
-        pre-scanned `.pvar` per-contig position table's `var_start`, but that
-        value is the PADDED search lower bound, not necessarily the global id
-        of the first variant the window actually keeps (genoray's precise
-        extent-overlap filter can skip leading padded-in candidates), so it
-        silently undercounted `annot_v_idxs` for narrowed windows. `var_base
-        = 0` is exact for every window that starts at a contig's first KEPT
-        variant (whole-contig / from-contig-start regions -- every current
-        fixture) but a KNOWN GAP for a narrowed/partial-prefix or multi-contig
-        window, same limitation as VCF (see `pgen.rs`'s `PgenWindowFiller::fill`
-        doc comment and GitHub issue #305, which now covers PGEN as well as VCF).
+        computes `annot_v_idxs`/`annot_ref_pos`, remapped window-local ->
+        dataset-global per-variant via `slot.global_v_idxs`. Unlike VCF, PGEN's
+        genoray ids are sourced from the `.pvar` row index for each kept
+        variant -- always known/correct, including across the region-overlap
+        gap that made the earlier scalar `var_base` (derived from the padded
+        `var_start` search bound, not the first KEPT variant) silently
+        undercount `annot_v_idxs` for narrowed windows. PGEN no longer shares
+        VCF's Phase-3 gap (see `pgen.rs`'s `PgenWindowFiller::fill` doc comment
+        and GitHub issue #305).
         """
         from ..genvarloader import RecordStreamEngine
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -984,12 +984,20 @@ pub fn svar1_prefetch_runs<'py>(
 /// `annotated` selects whether the two annotation outputs (`annot_v_idxs`/
 /// `annot_ref_pos`, issue #277 Wave A Task 4) are computed at all — when `false` the
 /// kernel is called with `None, None` for them (zero extra allocation/work), matching
-/// pre-Task-4 behavior exactly. When `true`, `var_base` is added to every non-negative
-/// entry of the emitted `annot_v_idxs` AFTER reconstruction — the kernel itself always
-/// writes window-LOCAL variant column ids (`geno_v_idxs`' own indexing space); callers
-/// whose `geno_v_idxs` is window-local (VCF/PGEN record-stream windows) pass their
-/// window's global variant-id base here so the emitted ids are dataset-GLOBAL. SVAR1's
-/// `geno_v_idxs` is already dataset-global, so it passes `var_base = 0` (a no-op add).
+/// pre-Task-4 behavior exactly. When `true`, the emitted `annot_v_idxs` are remapped
+/// from window-LOCAL variant column ids (`geno_v_idxs`' own indexing space) to
+/// dataset-GLOBAL ids AFTER reconstruction, by a per-variant GATHER through
+/// `global_v_idxs` (see [`remap_annot_local_to_global`]): `annot_v[i]` becomes
+/// `global_v_idxs[annot_v[i]]`, preserving the `-1` no-variant sentinel — and, per
+/// variant, skipping the gather (leaving the local id as-is) if THAT variant's own
+/// global id is not yet known (`global_v_idxs[local] == -1`; today only VCF, whose
+/// genoray-level global id support is separate follow-on work, issue #305 Phase 3).
+/// A scalar offset is NOT sufficient here — the region-overlap filter can drop
+/// interior variants, so a window's kept variants are not necessarily a contiguous
+/// run of global ids. Callers whose `geno_v_idxs` is window-local (VCF/PGEN
+/// record-stream windows) pass `Some(global_v_idxs)` (the window's local-column ->
+/// global-id map). SVAR1's `geno_v_idxs` is already dataset-global, so it passes
+/// `None` (no remap needed).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn generate_batch_core(
     geno_v_idxs: &[i32],
@@ -1007,7 +1015,7 @@ pub(crate) fn generate_batch_core(
     output_length: i64, // -1 = ragged (per-hap actual length), >=0 = fixed
     shifts: Option<ndarray::ArrayView2<i32>>, // None => zeros (deterministic / jitter=0)
     annotated: bool, // issue #277 Wave A Task 4: emit annot_v_idxs/annot_ref_pos
-    var_base: i64,   // added to non-negative annot_v_idxs entries when annotated
+    global_v_idxs: Option<ndarray::ArrayView1<i32>>, // Some => remap window-local annot ids to global
     parallel: bool,
 ) -> (Array1<u8>, Option<Array1<i32>>, Option<Array1<i32>>, Array1<i64>) {
     use crate::genotypes;
@@ -1110,17 +1118,46 @@ pub(crate) fn generate_batch_core(
         parallel,
     );
 
-    if var_base != 0 {
+    // Remap window-LOCAL annotation column ids to dataset-GLOBAL ids by gather.
+    // `-1` (no-variant sentinel) is preserved. SVAR1 passes None (its ids are already global).
+    if let Some(gv) = global_v_idxs {
         if let Some(av) = annot_v.as_mut() {
-            for x in av.iter_mut() {
-                if *x >= 0 {
-                    *x += var_base as i32;
-                }
-            }
+            remap_annot_local_to_global(av, gv);
         }
     }
 
     (out_data, annot_v, annot_pos, out_offsets_vec)
+}
+
+/// Remap window-LOCAL annotation column ids (indices into a window's own
+/// `geno_v_idxs`/`global_v_idxs`) to dataset-GLOBAL variant ids, in place, by a
+/// per-element gather through `global_v_idxs` (window-local column -> dataset-global
+/// id, issue #305). The `-1` no-variant sentinel in `annot_v` is left untouched. This
+/// is NOT a scalar offset: the region-overlap filter can exclude interior variants
+/// from a window, so kept global ids are not necessarily contiguous.
+///
+/// `global_v_idxs[local] == -1` means THAT variant's dataset-global id is not (yet)
+/// known — today this is VCF's genoray-level default (`RawRecord::global_idx` is
+/// hard-coded `-1`; real VCF global ids are Phase 3 / issue #305 follow-on work, not
+/// yet landed), never PGEN's (its `.pvar`-row-derived ids are always `>= 0`) or
+/// SVAR1's (which never calls this — its `geno_v_idxs` are already global, so callers
+/// pass `None`). Remapping through a `-1` entry would silently turn a real annotated
+/// variant into the no-variant sentinel, which is a worse regression than leaving the
+/// window-local id as a best-effort passthrough (byte-identical to the pre-gather
+/// `var_base=0` no-op for VCF's currently-tested whole-contig fixtures) — so an
+/// unknown global id is skipped, not gathered.
+pub(crate) fn remap_annot_local_to_global(
+    annot_v: &mut ndarray::Array1<i32>,
+    global_v_idxs: ndarray::ArrayView1<i32>,
+) {
+    for x in annot_v.iter_mut() {
+        if *x >= 0 {
+            let g = global_v_idxs[*x as usize]; // window-local col -> dataset-global id
+            if g >= 0 {
+                *x = g;
+            } // else: global id not yet known for this variant (VCF Phase 3 gap) — leave local id as-is
+        }
+    }
 }
 
 /// Generate haplotypes for ONE batch of window rows. `o_starts_b`/`o_stops_b` are the
@@ -1192,7 +1229,7 @@ pub fn svar1_generate_batch<'py>(
             output_length,
             None, // shifts -- SVAR1's standalone wrapper does not support jitter/shifts
             false, // annotated -- the readahead-only wrapper does not support annotated output
-            0,     // var_base -- unused when annotated=false
+            None,  // global_v_idxs -- SVAR1 geno_v_idxs already dataset-global
             parallel,
         )
     });
@@ -3091,6 +3128,18 @@ mod tests {
         assert_eq!(&bytes, b"CGT");
         assert_eq!(vidx, vec![7, 6, 5]);
         assert_eq!(rpos, vec![102, 101, 100]);
+    }
+
+    // ── remap_annot_local_to_global — window-local annot ids -> dataset-global (#304/#305) ──
+
+    #[test]
+    fn remap_annot_local_to_global_gathers_and_preserves_sentinel() {
+        // window-local annot ids [0, 1, -1, 0] with global map [0, 2]
+        // must become [0, 2, -1, 0] (never 1 — the interior-excluded id).
+        let mut annot = ndarray::Array1::from(vec![0i32, 1, -1, 0]);
+        let gmap = ndarray::Array1::from(vec![0i32, 2]);
+        crate::ffi::remap_annot_local_to_global(&mut annot, gmap.view());
+        assert_eq!(annot.to_vec(), vec![0, 2, -1, 0]);
     }
 
     // ── guard tests — check_disjoint_bounds_within (Finding 1, PR #273 review) ──

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1144,8 +1144,8 @@ pub(crate) fn generate_batch_core(
 /// pass `None`). Remapping through a `-1` entry would silently turn a real annotated
 /// variant into the no-variant sentinel, which is a worse regression than leaving the
 /// window-local id as a best-effort passthrough (byte-identical to the pre-gather
-/// `var_base=0` no-op for VCF's currently-tested whole-contig fixtures) — so an
-/// unknown global id is skipped, not gathered.
+/// scalar-offset no-op, the retired `var_base=0`, for VCF's currently-tested
+/// whole-contig fixtures) — so an unknown global id is skipped, not gathered.
 pub(crate) fn remap_annot_local_to_global(
     annot_v: &mut ndarray::Array1<i32>,
     global_v_idxs: ndarray::ArrayView1<i32>,
@@ -3140,6 +3140,16 @@ mod tests {
         let gmap = ndarray::Array1::from(vec![0i32, 2]);
         crate::ffi::remap_annot_local_to_global(&mut annot, gmap.view());
         assert_eq!(annot.to_vec(), vec![0, 2, -1, 0]);
+    }
+
+    #[test]
+    fn remap_annot_local_to_global_leaves_local_when_global_unknown() {
+        // global map all -1 (VCF's genoray default until Phase 3): every real
+        // local annot id must be LEFT AS-IS (not corrupted to -1), sentinel preserved.
+        let mut annot = ndarray::Array1::from(vec![0i32, 1, -1]);
+        let gmap = ndarray::Array1::from(vec![-1i32, -1]);
+        crate::ffi::remap_annot_local_to_global(&mut annot, gmap.view());
+        assert_eq!(annot.to_vec(), vec![0, 1, -1]);
     }
 
     // ── guard tests — check_disjoint_bounds_within (Finding 1, PR #273 review) ──

--- a/src/ffi/stream_engine.rs
+++ b/src/ffi/stream_engine.rs
@@ -125,8 +125,8 @@ struct Svar1Backend {
     output_length: i64,
     /// Issue #277 Wave A Task 4: when `true`, `generate` requests the two annotation
     /// outputs (`annot_v_idxs`/`annot_ref_pos`) from `generate_batch_core`, with
-    /// `var_base = 0` — SVAR1's `store.geno_v_idxs()` is already dataset-GLOBAL
-    /// (see the module doc's "GLOBAL variant-scale tables" note), so no offset is
+    /// `global_v_idxs = None` — SVAR1's `store.geno_v_idxs()` is already dataset-GLOBAL
+    /// (see the module doc's "GLOBAL variant-scale tables" note), so no remap is
     /// needed, even across contigs. `false` (default) preserves pre-Task-4 behavior
     /// exactly (no extra allocation/work).
     annotated: bool,
@@ -217,7 +217,7 @@ impl EngineBackend for Svar1Backend {
             self.output_length,
             None, // shifts -- not yet wired for the engine path (jitter is Task 4+)
             self.annotated,
-            0, // var_base -- SVAR1's geno_v_idxs is already dataset-global (no offset)
+            None, // global_v_idxs -- SVAR1's geno_v_idxs is already dataset-global
             self.parallel,
         ))
     }
@@ -572,7 +572,7 @@ mod tests {
             -1, // ragged
             None,
             false, // annotated
-            0,     // var_base
+            None,  // global_v_idxs
             false,
         );
         (data.to_vec(), offs.to_vec())
@@ -926,7 +926,7 @@ mod tests {
                 -1, // ragged
                 None,
                 false, // annotated
-                0,     // var_base
+                None,  // global_v_idxs
                 false,
             );
             (data.to_vec(), offs.to_vec())

--- a/src/record_stream/engine.rs
+++ b/src/record_stream/engine.rs
@@ -91,8 +91,9 @@ struct RecordBackend {
     output_length: i64,
     /// Issue #277 Wave A Task 4: when `true`, `generate` requests the two annotation
     /// outputs (`annot_v_idxs`/`annot_ref_pos`) from `generate_batch_core`, mapped to
-    /// dataset-GLOBAL ids via the filled slot's `var_base`. `false` (default)
-    /// preserves pre-Task-4 behavior exactly (no extra allocation/work).
+    /// dataset-GLOBAL ids via a per-variant gather through the filled slot's
+    /// `global_v_idxs` (issue #305; see `remap_annot_local_to_global`). `false`
+    /// (default) preserves pre-Task-4 behavior exactly (no extra allocation/work).
     annotated: bool,
 }
 
@@ -212,7 +213,7 @@ impl EngineBackend for RecordBackend {
             self.output_length,
             None, // shifts -- not yet wired for the engine path (jitter is Task 4+)
             self.annotated,
-            slot.var_base,
+            Some(ndarray::ArrayView1::from(slot.global_v_idxs.as_slice())),
             self.parallel,
         ))
     }
@@ -665,7 +666,7 @@ mod tests {
             -1, // ragged
             None,
             false, // annotated
-            0,     // var_base
+            None,  // global_v_idxs
             false,
         );
         (data.to_vec(), offs.to_vec())
@@ -840,7 +841,7 @@ mod tests {
             -1, // ragged
             None,
             false, // annotated
-            0,     // var_base
+            None,  // global_v_idxs
             false,
         );
         let expected = (exp_data.to_vec(), exp_offs.to_vec());

--- a/src/record_stream/pgen.rs
+++ b/src/record_stream/pgen.rs
@@ -624,6 +624,7 @@ impl WindowFiller for PgenWindowFiller {
             job.regions.clone(),
             self.overlap,
             sample_perm,
+            /* dosage_readers */ Vec::new(),
         )?;
         let mut asm = ChunkAssembler::new(
             Box::new(source),
@@ -654,6 +655,7 @@ impl WindowFiller for PgenWindowFiller {
                 let empty = DenseChunk {
                     chunk_id: 0,
                     pos: Vec::new(),
+                    global_idx: Vec::new(),
                     ilens: Vec::new(),
                     alt: Vec::new(),
                     alt_offsets: vec![0],

--- a/src/record_stream/pgen.rs
+++ b/src/record_stream/pgen.rs
@@ -592,26 +592,17 @@ impl WindowFiller for PgenWindowFiller {
         };
         debug_assert!(var_start >= contig_lo && var_end <= contig_hi);
         VARIANTS_DECODED.fetch_add(var_end.saturating_sub(var_start), Ordering::Relaxed);
-        // `slot.var_base` is intentionally left at its default 0, NOT set to
-        // `var_start` (issue #277 Wave A Task 4, annotated output — this was a
-        // confirmed bug in an earlier version of this fill). `var_start` above is
-        // the PADDED, over-inclusive search lower bound (`partition_point` minus
-        // the contig's max ref_len pad), not the global id of the first variant
-        // this window actually KEEPS: `PgenRecordSource` (constructed below) runs
-        // a precise anchor-trimmed `extent_overlaps` filter that can skip leading
-        // padded-in candidates whose trimmed extent doesn't reach `win_start`. When
-        // it does, the `DecodedWindow`'s local column 0 corresponds to global id
-        // `var_start + skip_count`, not `var_start` — so `var_base + local` in
-        // `generate_batch_core` would silently UNDERCOUNT every emitted global
-        // `var_idx` by `skip_count`. Hard-coding `var_base = 0` matches
-        // `VcfWindowFiller`'s same-value default (see `vcf.rs`'s `var_base` doc
-        // comment) and is exact for every window that starts at the contig's
-        // first KEPT variant (whole-contig / from-contig-start regions — every
-        // current fixture) but a KNOWN GAP for a narrowed/partial-prefix or
-        // multi-contig window, same as VCF. Tracked in GitHub issue #305 (now
-        // scoped to cover PGEN too, not just VCF). Must still be set on every call
-        // — see the `DecodedWindow::var_base` doc comment on why (recycled slot).
-        slot.var_base = 0;
+        // Global ids are now per-variant, not a scalar base: `PgenRecordSource`
+        // (constructed below) yields a `DenseChunk` whose `global_idx` is sourced
+        // from genoray's `.pvar`-row index for each kept variant, and
+        // `fill_decoded_window` copies it verbatim into `slot.global_v_idxs`. That
+        // survives exactly the gap the old `var_start`-derived scalar could not:
+        // `PgenRecordSource`'s anchor-trimmed `extent_overlaps` filter can skip
+        // leading padded-in candidates, so kept global ids are not necessarily
+        // contiguous from `var_start` — a scalar offset would have silently
+        // undercounted `annot_v_idxs` for narrowed/multi-contig windows. Per-variant
+        // ids are correct across that gap; PGEN no longer shares VCF's Phase-3
+        // limitation (see `src/ffi/mod.rs`'s `remap_annot_local_to_global` doc).
 
         let reader = Python::attach(|py| self.reader.clone_ref(py));
         let source = PgenRecordSource::new(

--- a/src/record_stream/transpose.rs
+++ b/src/record_stream/transpose.rs
@@ -34,19 +34,13 @@ pub struct DecodedWindow {
     pub alt_offsets: Vec<i64>,
     pub geno_v_idxs: Vec<i32>,
     pub geno_offsets: Vec<i64>,
-    /// Dataset-GLOBAL variant index of this window's local column 0 — i.e. the value
-    /// to add to a window-local `geno_v_idxs` entry to recover its global id (issue
-    /// #277 Wave A Task 4, annotated output). `fill_decoded_window` never sets this
-    /// (it only fills the static/CSR tables); each `WindowFiller::fill` MUST set it
-    /// explicitly every call (this struct's slot is RECYCLED between windows by the
-    /// producer/consumer engine, not re-`Default`-ed, so a filler that forgets would
-    /// leak the previous window's stale value). See `pgen.rs`'s and `vcf.rs`'s
-    /// `WindowFiller::fill` for the two current settings.
-    pub var_base: i64,
     /// Per-variant dataset-global id, parallel to `v_starts` (i.e. `global_v_idxs[i]`
     /// is the global id of the variant at window-local column `i`). Copied verbatim
-    /// from `chunk.global_idx` by `fill_decoded_window`; consumed by a later task
-    /// (issue #305) to remap annotation ids. Not yet read by any consumer.
+    /// from `chunk.global_idx` by `fill_decoded_window` (every call, including the
+    /// empty-window path, so this recycled slot never leaks a stale value). Consumed
+    /// by `generate_batch_core` (via `RecordBackend::generate`), which gathers each
+    /// window-local annotation id through this array to its dataset-global id — see
+    /// [`crate::ffi::remap_annot_local_to_global`].
     pub global_v_idxs: Vec<i32>,
 }
 

--- a/src/record_stream/transpose.rs
+++ b/src/record_stream/transpose.rs
@@ -43,6 +43,11 @@ pub struct DecodedWindow {
     /// leak the previous window's stale value). See `pgen.rs`'s and `vcf.rs`'s
     /// `WindowFiller::fill` for the two current settings.
     pub var_base: i64,
+    /// Per-variant dataset-global id, parallel to `v_starts` (i.e. `global_v_idxs[i]`
+    /// is the global id of the variant at window-local column `i`). Copied verbatim
+    /// from `chunk.global_idx` by `fill_decoded_window`; consumed by a later task
+    /// (issue #305) to remap annotation ids. Not yet read by any consumer.
+    pub global_v_idxs: Vec<i32>,
 }
 
 /// Fill `slot` (reusing its allocations) from a window's `DenseChunk`. The static table
@@ -65,6 +70,8 @@ pub fn fill_decoded_window(
     slot.alt_offsets.clear();
     slot.alt_offsets
         .extend(chunk.alt_offsets.iter().map(|&o| o as i64));
+    slot.global_v_idxs.clear();
+    slot.global_v_idxs.extend_from_slice(&chunk.global_idx);
 
     // Word-level two-pass counting-sort transpose. Instead of calling get_bit once per
     // (v,s,p) cell (V*S*P reads), walk the packed `words` in flat v-major order — this is
@@ -140,6 +147,7 @@ mod tests {
         DenseChunk {
             chunk_id: 0,
             pos: vec![10, 20],
+            global_idx: vec![5, 8],
             ilens: vec![0, 0],
             alt: vec![b'A', b'C'],
             alt_offsets: vec![0, 1, 2],
@@ -167,6 +175,7 @@ mod tests {
         // CSR over 4 haps: hap0=[0], hap1=[], hap2=[0,1], hap3=[1]
         assert_eq!(slot.geno_offsets, vec![0, 1, 1, 3, 4]);
         assert_eq!(slot.geno_v_idxs, vec![0, 0, 1, 1]);
+        assert_eq!(slot.global_v_idxs, vec![5, 8]);
     }
 
     #[test]
@@ -178,6 +187,7 @@ mod tests {
         let chunk = DenseChunk {
             chunk_id: 0,
             pos: vec![],
+            global_idx: Vec::new(),
             ilens: vec![],
             alt: vec![],
             alt_offsets: vec![0],
@@ -208,6 +218,7 @@ mod tests {
         let chunk = DenseChunk {
             chunk_id: 0,
             pos: vec![42],
+            global_idx: vec![17],
             ilens: vec![0],
             alt: vec![b'T'],
             alt_offsets: vec![0, 1],
@@ -275,6 +286,7 @@ mod tests {
         let chunk = DenseChunk {
             chunk_id: 0,
             pos: (0..n_var as u32).collect(),
+            global_idx: (0..n_var as i32).collect(),
             ilens: vec![0; n_var],
             alt: vec![b'A'; n_var],
             alt_offsets: (0..=n_var as u32).collect(),

--- a/src/record_stream/vcf.rs
+++ b/src/record_stream/vcf.rs
@@ -215,6 +215,7 @@ impl WindowFiller for VcfWindowFiller {
                 let empty = DenseChunk {
                     chunk_id: 0,
                     pos: Vec::new(),
+                    global_idx: Vec::new(),
                     ilens: Vec::new(),
                     alt: Vec::new(),
                     alt_offsets: vec![0],

--- a/src/record_stream/vcf.rs
+++ b/src/record_stream/vcf.rs
@@ -150,24 +150,12 @@ impl WindowFiller for VcfWindowFiller {
         let sample_indices = self.sample_indices[job.s_lo..job.s_hi].to_vec();
         let n_local_samples = sample_indices.len();
 
-        // `var_base` (issue #277 Wave A Task 4, annotated output): the dataset-GLOBAL
-        // variant-id base for this window's local column 0. Unlike `PgenWindowFiller`
-        // (which pre-scans the `.pvar` into a per-contig position table and can derive
-        // this cheaply, see `pgen.rs`), `VcfWindowFiller` has no per-contig variant
-        // count/position index — genoray's `VcfRecordSource` does not expose one
-        // (checked: no cheap `contig_ranges`-equivalent). Hard-coding `var_base = 0`
-        // is CORRECT for every Wave A / current fixture (all single-contig, each
-        // window's region starts at that contig's first variant — i.e. global variant
-        // 0), but is a KNOWN GAP for a window that does not start at global variant 0
-        // (multi-contig cohorts, or a region not covering a contig's first variant):
-        // the emitted `annot_v_idxs` would be window-local, not global, in that case.
-        // Tracked as a follow-up (`streaming: VCF annotated var_idxs need a
-        // per-contig variant-count table`, GitHub issue TBD) rather than silently
-        // shipping wrong ids for an untested config; every TESTED VCF annotated
-        // config (Task 4 + Task 5 same-POS fixtures) is single-contig/whole-contig,
-        // so `var_base = 0` is exact there. Must be set on every call — see the
-        // `DecodedWindow::var_base` doc comment on why (recycled slot).
-        slot.var_base = 0;
+        // Window-local -> dataset-global annotation-id remap is now per-variant via
+        // `slot.global_v_idxs`, filled below by `fill_decoded_window` from genoray's
+        // `DenseChunk.global_idx` (not a scalar base added to a local index). VCF's
+        // genoray ids are hard-coded `-1` until Phase 3 (issue #305 follow-on), so
+        // `remap_annot_local_to_global` skips them and emits window-local ids — the
+        // known VCF gap; see that function's doc comment in `src/ffi/mod.rs`.
 
         let source = VcfRecordSource::with_sample_indices(
             &self.vcf_path,

--- a/tests/dataset/conftest.py
+++ b/tests/dataset/conftest.py
@@ -731,6 +731,103 @@ def pgen_snp_ins_del_multi(tmp_path_factory) -> PgenSnpInsDelMultiFixture:
     )
 
 
+# Interior-exclusion fixture (#305 Part B, `test_streaming_annotated_parity.py`):
+# a spanning DEL that CONSUMES an interior SNP's reference position (the
+# interior SNP's site lies inside the DEL's deleted span, so no byte is ever
+# emitted there regardless of the interior SNP's own genotype), plus a
+# TRAILING SNP beyond the DEL's extent. This produces a HOLE in the middle of
+# the global variant-id set (unlike the `pgen_snp_ins_del_multi` narrowed-
+# window test's leading-only gap): verified empirically (see task report) --
+# even with the interior SNP genotype carried (ALT) on the SAME haplotype as
+# the DEL, both the written oracle and the streamed PGEN backend emit
+# `var_idxs` `[0, -1, -1, 2, -1]` for that haplotype (kept global ids {0, 2},
+# non-contiguous) -- confirming this is genuine interior exclusion, not a
+# trivial "genotype absent" artifact.
+#
+# Reference: "ACGT" repeated 15x = 60bp, so ref[i] cycles A,C,G,T by i % 4.
+# chr1: DEL POS=21 (0-based 20), REF=ref[20:26]="ACGTAC", ALT="A" (extent
+# 0-based [20, 26)); interior SNP POS=23 (0-based 22, REF='G', ALT='T',
+# extent [22, 23) -- inside the DEL's deleted span); trailing SNP POS=29
+# (0-based 28, REF='A', ALT='G', extent [28, 29) -- beyond the DEL's extent).
+# Query region [20, 30) (starts at the DEL's own position, so the DEL's
+# surviving ALT base is itself in-window): kept global ids {0, 2}.
+_INTERIOR_EXCLUSION_REF = "ACGT" * 15
+assert len(_INTERIOR_EXCLUSION_REF) == 60
+_INTERIOR_EXCLUSION_VCF = """\
+##fileformat=VCFv4.2
+##contig=<ID=chr1,length=60>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts0
+chr1\t21\t.\tACGTAC\tA\t.\t.\t.\tGT\t1|0
+chr1\t23\t.\tG\tT\t.\t.\t.\tGT\t1|0
+chr1\t29\t.\tA\tG\t.\t.\t.\tGT\t1|0
+"""
+
+
+@dataclass(slots=True)
+class PgenInteriorExclusionFixture:
+    """PGEN-source counterpart of the hand-authored `_INTERIOR_EXCLUSION_VCF`
+    (see the module-level comment above it for the variant table and why the
+    narrowed `regions` window produces a non-contiguous kept-variant set).
+    Converts the inline VCF via `plink2 --make-pgen` at fixture time, same
+    convention as `pgen_multi_contig` converting `vcf_multi_contig`.
+    """
+
+    pgen: Path
+    fasta: Path
+    contig: str
+    n_samples: int
+    ploidy: int
+    sample_names: list[str]
+    regions: pl.DataFrame
+
+
+@pytest.fixture(scope="module")
+def pgen_interior_exclusion(tmp_path_factory) -> PgenInteriorExclusionFixture:
+    d = tmp_path_factory.mktemp("pgen_interior_exclusion_src")
+    fasta = d / "ref.fa"
+    fasta.write_text(f">chr1\n{_INTERIOR_EXCLUSION_REF}\n")
+    subprocess.run(["samtools", "faidx", str(fasta)], check=True)
+
+    vcf_txt = d / "in.vcf"
+    vcf_txt.write_text(_INTERIOR_EXCLUSION_VCF)
+    vcf_gz = d / "in.vcf.gz"
+    with vcf_gz.open("wb") as fh:
+        subprocess.run(["bgzip", "-c", str(vcf_txt)], stdout=fh, check=True)
+    subprocess.run(["tabix", "-p", "vcf", str(vcf_gz)], check=True)
+
+    out_prefix = d / "ie"
+    subprocess.run(
+        [
+            "plink2",
+            "--vcf",
+            str(vcf_gz),
+            "--make-pgen",
+            "--allow-extra-chr",
+            "--output-chr",
+            "chrM",
+            "--out",
+            str(out_prefix),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    # Narrowed query window [20, 30) -- see the module-level comment above
+    # `_INTERIOR_EXCLUSION_VCF` for the overlap arithmetic.
+    regions = pl.DataFrame({"chrom": ["chr1"], "chromStart": [20], "chromEnd": [30]})
+
+    return PgenInteriorExclusionFixture(
+        pgen=out_prefix.with_suffix(".pgen"),
+        fasta=fasta,
+        contig="chr1",
+        n_samples=1,
+        ploidy=2,
+        sample_names=["s0"],
+        regions=regions,
+    )
+
+
 @dataclass(slots=True)
 class VcfSamePosNonlexFixture:
     """Task 5 (issue #300): a GENUINE (not coincidental) file-order same-POS

--- a/tests/dataset/test_streaming_annotated_parity.py
+++ b/tests/dataset/test_streaming_annotated_parity.py
@@ -85,7 +85,8 @@ def _narrowed_pgen_case(pgen_snp_ins_del_multi, tmp_path):
     below: writes the oracle dataset and constructs a matching
     `StreamingDataset`, both restricted to region `[71, 200)`. See
     `test_annotated_pgen_narrowed_window_var_idxs_gap`'s docstring for why
-    this region exposes the `var_base` gap (issue #305).
+    this region exercises the non-contiguous global `var_idxs` set that the
+    per-variant global-id gather now handles correctly (issue #305).
     """
     f = pgen_snp_ins_del_multi
     out = tmp_path / "ds"
@@ -101,11 +102,11 @@ def _narrowed_pgen_case(pgen_snp_ins_del_multi, tmp_path):
 def test_annotated_pgen_narrowed_window_haps_match(pgen_snp_ins_del_multi, tmp_path):
     """Sanity check (NOT xfail): haplotype reconstruction and ref_coords for
     a narrowed (non-whole-contig) PGEN window still match the written oracle
-    exactly. Only the *global numbering* of `var_idxs` is affected by the
-    `var_base` gap (see `test_annotated_pgen_narrowed_window_var_idxs_gap`)
+    exactly. Only the *global numbering* of `var_idxs` was ever affected by
+    the #305 gap (see `test_annotated_pgen_narrowed_window_var_idxs_gap`)
     -- the underlying decode (which variants are applied, and where) is
-    correct regardless of `var_base`, since `var_base` is only added as a
-    final offset onto already-correctly-decoded local ids.
+    correct regardless of id numbering, since the global id is only applied
+    as a final per-variant gather onto already-correctly-decoded local ids.
     """
     ds, sds = _narrowed_pgen_case(pgen_snp_ins_del_multi, tmp_path)
 

--- a/tests/dataset/test_streaming_annotated_parity.py
+++ b/tests/dataset/test_streaming_annotated_parity.py
@@ -122,13 +122,6 @@ def test_annotated_pgen_narrowed_window_haps_match(pgen_snp_ins_del_multi, tmp_p
     assert n_cells > 0, "narrowed-window fixture yielded no cells"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "#305: record-backend var_base for narrowed/partial-prefix windows "
-        "deferred; PGEN currently emits local (var_base=0) var_idxs"
-    ),
-)
 def test_annotated_pgen_narrowed_window_var_idxs_gap(pgen_snp_ins_del_multi, tmp_path):
     """Regression lock for the CONFIRMED bug found in review of Task 4: a
     NARROWED (not whole-contig) window on `pgen_snp_ins_del_multi` used to
@@ -145,14 +138,16 @@ def test_annotated_pgen_narrowed_window_var_idxs_gap(pgen_snp_ins_del_multi, tmp
     INS's extent, so the padded search (padded by the contig's max ref_len,
     4, for the DEL) lands on local index 1 (pos69) as `var_start`, but the
     precise filter skips that candidate -- the window's first KEPT variant is
-    pos109 (global id 2). The written oracle reports `var_idxs` `[2, 3, 4]`;
-    the streaming PGEN backend (var_base=0, issue #277 Wave A / #305 gap)
-    reports local ids `[0, 1, 2]` instead.
+    pos109 (global id 2). The written oracle reports `var_idxs` `[2, 3, 4]`.
 
-    This test is expected to XFAIL until #305 gives PGEN a correct per-contig
-    global var_base (the first KEPT variant's global id, not the padded
-    search lower bound). If it unexpectedly XPASSES, the gap has been fixed
-    and this test (and its `xfail` marker) should be removed/updated.
+    This is now a PASSING REGRESSION LOCK: #305 gives PGEN correct per-variant
+    global ids via genoray's `.pvar` row index (the source of truth for each
+    variant's dataset-global id) plus gvl's per-variant gather onto that id
+    (retiring the scalar `var_base`, which could only ever encode a single
+    offset and thus couldn't represent a skipped leading candidate). The
+    narrowed region `[71, 200)` drops leading candidates 0 and 1, so the
+    first KEPT variant is global id 2, and the streamed `var_idxs` must equal
+    the written oracle's `[2, 3, 4]`.
     """
     ds, sds = _narrowed_pgen_case(pgen_snp_ins_del_multi, tmp_path)
 
@@ -173,3 +168,65 @@ def test_annotated_pgen_narrowed_window_var_idxs_gap(pgen_snp_ins_del_multi, tmp
                 )
             n_cells += 1
     assert n_cells > 0, "narrowed-window fixture yielded no cells"
+
+
+def test_annotated_pgen_interior_exclusion_var_idxs_gapped(
+    pgen_interior_exclusion, tmp_path
+):
+    """Regression lock for a HOLE in the middle of the global variant-id set
+    (issue #305), complementing `test_annotated_pgen_narrowed_window_var_idxs_gap`
+    above: that test's `[2, 3, 4]` is a leading-gap-only (still contiguous)
+    set; this test exercises a genuinely NON-CONTIGUOUS kept set with a gap
+    in the interior.
+
+    `pgen_interior_exclusion` (see its docstring/comment in ``conftest.py``)
+    is a spanning DEL (global id 0) whose deleted span [20, 26) consumes an
+    interior SNP's reference position (global id 1, at 0-based pos 22) --
+    genotyped 1|0 (carried on hap0) to confirm empirically that the exclusion
+    is genuine interior consumption, not merely "genotype absent": no byte is
+    ever emitted at a deleted reference position regardless of what any
+    variant record at that position's genotype says. A trailing SNP (global
+    id 2, at 0-based pos 28) sits beyond the DEL's extent. Over the query
+    region [20, 30), hap0 of sample s0 carries the DEL and the trailing SNP
+    but never the interior SNP -- confirmed by inspecting the WRITTEN oracle
+    directly: `var_idxs` is `[0, -1, -1, 2, -1]`, i.e. kept global ids
+    `{0, 2}` with `np.diff([0, 2]) == [2] > 1`, a genuine gap. The streaming
+    PGEN backend must reproduce this exact non-contiguous set, not just a
+    uniformly-shifted contiguous one -- this is the case a scalar `var_base`
+    offset cannot represent, since offsetting local index `i` by a constant
+    can never skip a candidate that falls strictly between two kept ones.
+    """
+    f = pgen_interior_exclusion
+    out = tmp_path / "ds"
+    gvl.write(out, f.regions, variants=str(f.pgen), overwrite=True)
+    written = gvl.Dataset.open(out, reference=f.fasta)
+    ds = written.with_seqs("annotated")
+    sds = gvl.StreamingDataset(
+        f.regions, reference=f.fasta, variants=str(f.pgen)
+    ).with_seqs("annotated")
+
+    n_cells = 0
+    saw_gap = False
+    for data, r_idx, s_idx in sds.to_iter(batch_size=4):
+        for row in range(len(r_idx)):
+            exp = ds[int(r_idx[row]), int(s_idx[row])]  # RaggedAnnotatedHaps
+            for h in range(sds.ploidy):
+                got_vidx = np.asarray(data.var_idxs[row][h])
+                exp_vidx = np.asarray(exp.var_idxs[h])
+                np.testing.assert_array_equal(
+                    got_vidx,
+                    exp_vidx,
+                    err_msg=(
+                        f"row={row} hap={h}: streamed var_idxs must be "
+                        "dataset-GLOBAL, matching the written oracle exactly"
+                    ),
+                )
+                kept = exp_vidx[exp_vidx >= 0]
+                if kept.size >= 2 and np.any(np.diff(kept) > 1):
+                    saw_gap = True
+            n_cells += 1
+    assert n_cells > 0, "interior-exclusion fixture yielded no cells"
+    assert saw_gap, (
+        "fixture did not produce a non-contiguous kept var_idxs set for any "
+        "hap; the test can't guard the interior-exclusion gap without one"
+    )

--- a/tests/dataset/test_streaming_annotated_parity.py
+++ b/tests/dataset/test_streaming_annotated_parity.py
@@ -1,11 +1,13 @@
 """Task 4 (issue #277, Wave A): annotated output (``AnnotatedHaps``) must be
 byte-identical to the written oracle for all three streaming backends
 (SVAR1, VCF, PGEN) at jitter=0, including the emitted ``var_idxs`` -- which
-must be dataset-GLOBAL variant ids (see the streaming engines' ``var_base``
-plumbing: SVAR1 for free, PGEN via the ``.pvar`` per-contig pre-scan, VCF via
-``var_base=0`` -- exact for these single-contig/whole-contig fixtures, see
-``_VcfBackend.build_engine``'s doc comment and GitHub issue #305 for the
-documented multi-contig gap).
+must be dataset-GLOBAL variant ids (see the streaming engines' per-variant
+global-id gather: genoray's ``DenseChunk.global_idx`` is copied verbatim into
+``DecodedWindow.global_v_idxs`` by ``fill_decoded_window``, then gathered by
+``generate_batch_core`` -- SVAR1 for free (already global), PGEN via the
+``.pvar`` row index (correct, issue #305 Phase 2), VCF still window-local
+until Phase 3 -- see ``_VcfBackend.build_engine``'s doc comment and GitHub
+issue #305 for the documented gap).
 
 ``streaming_case`` (``tests/dataset/conftest.py``) supplies
 ``(regions, reference, variants, written)``; ``written`` is a plain


### PR DESCRIPTION
Design spec for StreamingDataset **Wave B** — the variant-level output surface — plus the **#305** record-backend global-variant-id fix. Product of `/superpowers:brainstorming` over #304 + #305.

**Spec:** `docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md`
**Plan (#305 Phase 2):** `docs/superpowers/plans/2026-07-20-streaming-global-variant-ids.md`

---

## ✅ Phase 2 implementation LANDED on this branch (#305, PGEN + SVAR1)

> Note: this branch now carries **both** the Wave B spec docs **and** the completed #305 Phase 2
> implementation. If you'd prefer the #305 code as its own PR-A off `streaming`, say so — the impl
> commits (`3fbb8c64..HEAD`) can be split out; I did not force-push or restructure without your call.

Record-stream backends now emit **dataset-global** `var_idxs` under `with_seqs("annotated")`,
byte-identical to the written `Dataset` even when the region-overlap filter drops interior/leading
variants. The scalar `var_base` + window-local index is replaced by a **per-variant gather**:
`DenseChunk.global_idx` (genoray) → `DecodedWindow.global_v_idxs` → `generate_batch_core`
(`annot_v[i] = global_v_idxs[annot_v[i]]`). SVAR1 passes `None` (already global).

**Note the design correction vs the merged spec:** the spec above says "`var_base + local` is valid
because the anchor-trim filter only drops a contiguous leading prefix." That assumption is FALSE for
interior exclusion (a variant behind a spanning deletion) — hence the move to a genuine per-variant
gather. The interior-exclusion regression test (`{0,2}`) locks this.

**VCF unchanged:** genoray hard-codes VCF `global_idx = -1` (real VCF ids are Phase 3), so the gather
skips `-1` and emits window-local ids — byte-identical to the old no-op for whole-contig fixtures.

### ✅ Merge dependency resolved
Depended on **genoray PR d-laub/genoray#134** (`DenseChunk.global_idx`, PGEN-populated). #134 is
**merged** into genoray `main` at `73d25cbb848168470adef9c4edd571f0a35f4204`, and both `svar2-codec`
and `genoray_core` are re-pinned from the branch-tip SHA `3a44e14` to that merge commit (commit
`1a5baf1b`). The prior pin is a parent of the merge, so no code changed — verified: `cargo test
--lib` 184 passed, annotated-parity pytest 6 passed.

### Tests
Rust unit tests for the gather + the load-bearing `-1` guard; PGEN annotated parity un-xfailed
(`[2,3,4]`) + interior-exclusion `{0,2}` fixture (vs written oracle, `saw_gap`-guarded).
`cargo test --lib` → 184 passed; full `pytest tests` → 1145 passed, 53 skipped, 4 xfailed.
Fixes the latent Wave A annotated interior-exclusion bug (#311) for PGEN/SVAR1.

---

## Wave B spec scope (design only; implemented by later PRs)

### Base
Wave A (#277) is **merged into `streaming`** via #308, so every Wave B PR targets `streaming` directly.

### Scope
- `with_seqs("variants")` (`RaggedVariants`) + `with_seqs("variant-windows")` (`_FlatVariantWindows`)
- `min_af`/`max_af`, `var_fields` (custom FORMAT/INFO, #231)
- #305: correct dataset-global variant ids ✅ (this PR, via per-variant gather — supersedes the
  spec's `var_base = var_start + skip_count` approach)
- #202: clip variants to the region window on **both** paths (decision: fix both)

### PR stack (all target `streaming`)
PR-A (#305) ✅ → PR-B0 (#202) → PR-B1 (variants, default fields) → PR-B2 (`min_af`/`max_af`) →
PR-B3 (`var_fields`) → PR-B4 (REF + variant-windows). Docs/skill/api folded into each.

### Follow-ups
- Phase 3 (VCF global ids) — spike-gated on the write-vs-stream overlap-semantics question (see
  Task 3.1 finding); separate PR.
- Multi-contig **annotated** regression test for PGEN (defense-in-depth; gather is contig-agnostic).

Relates to #304, #305; folds in #202, #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

