### PR TITLE
streaming: fail-fast VCF + with_seqs("annotated"); defer VCF global variant ids

### DIFF
--- a/docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md
+++ b/docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md
@@ -55,6 +55,19 @@ indices, applies AF filtering, and assembles ragged buffers via `assemble_varian
 - **dataset-global variant ids** — streaming's `geno_v_idxs` are window-**local** column indices;
   the written `v_idxs` are global. This is exactly the gap #305 closes.
 
+> **Correction (2026-07-21).** The "dataset-global variant ids" bullet does **not** apply to the
+> variants *output*. `RaggedVariants`, `_FlatVariants`, and `_FlatVariantWindows`
+> (`_rag_variants.py`, `_flat_variants.py`) expose field **values** — `alt`/`ref`/`start`/`ilen`/
+> `dosage`/`var_fields` — and **no** `v_idxs` field. The written path's `v_idxs = genos.data` is an
+> internal *gather index* into the on-disk variant table (`self.variants.info["AF"][v_idxs]`,
+> `_gather_alleles(v_idxs, ...)`); streaming reads the same fields straight off each record and never
+> gathers from a table, so variants/variant-windows are **self-contained from the records** and need
+> no global id. Within-window ordering and AF filtering fall out of reading position-sorted records
+> and each record's `INFO/AF`. Only `with_seqs("annotated")` (`AnnotatedHaps.var_idxs`, a per-position
+> provenance field) genuinely needs the dataset-global id. Wave B PR-B1 should therefore drop the
+> variants-output dependency on `global_v_idxs`; the real per-backend work is the REF/AF/dosage/FORMAT
+> extraction below. See #305 / #311 and the VCF-annotated fail-fast in `_streaming.py`.
+
 `fill_decoded_window` throws all of this away today; Wave B extracts what each knob needs, per
 backend.
 
@@ -119,6 +132,19 @@ path is affected.)
 **wrong for any window containing a spanning deletion or same-POS tie** — even single-contig at
 window 0, not just the multi-contig/narrowed case the code comment ("KNOWN GAP", `vcf.rs:153-170`)
 acknowledges. PR-A fixes annotated too.
+
+> **Status update (2026-07-21).** The **PGEN half shipped** — genoray #134 added
+> `DenseChunk.global_idx` (PGEN populated via the `.pvar` row index) and gvl PR-A consumes it
+> (`fill_decoded_window` → `DecodedWindow.global_v_idxs` → per-variant gather; `var_base` retired).
+> The **VCF half is deferred**: the per-contig variant index below needs a one-time full-source
+> record scan (VCF has no `.pvar`-equivalent), and — per the 2026-07-21 correction above — it is
+> needed **only** for `with_seqs("annotated")`, **not** for variants/variant-windows output. Rather
+> than pay the scan for a single output mode with no current use case, VCF + `annotated` is now a
+> **fail-fast `NotImplementedError`** in `_streaming.py` (closes the #311 silent-wrongness); variants
+> output proceeds for VCF with **no genoray change**. Revisit the scan only when a concrete
+> VCF-annotated streaming use case appears — the cross-contig base is then free from the CSI/TBI
+> metadata pseudo-bins (`hts_idx_get_stat`; cf. standardmodelbio/seqlab#199), leaving only the
+> within-contig offset to derive.
 
 **Fix (decision: genoray emits global ids).** Mirror the SVAR2 `pack_vk_src` pattern:
 

--- a/docs/superpowers/specs/2026-07-21-vcf-annotated-failfast-design.md
+++ b/docs/superpowers/specs/2026-07-21-vcf-annotated-failfast-design.md
@@ -1,0 +1,68 @@
+# Design: fail-fast VCF + `annotated`; defer VCF global variant ids
+
+**Date:** 2026-07-21
+**Branch:** `streaming-vcf-annotated-failfast` → merges into `streaming`
+**Relates to:** #305 (record-backend global variant ids), #311 (annotated `var_idxs` wrong under
+interior exclusion), #304 (Wave B variants output). genoray #134 (PGEN global ids, merged).
+
+## Problem
+
+`with_seqs("annotated")` emits per-position **dataset-global** variant ids
+(`AnnotatedHaps.var_idxs`). SVAR1 carries these for free; PGEN derives them from the `.pvar` absolute
+row index (genoray #134). A **VCF** source has no cheap per-record global id — genoray leaves
+`RawRecord.global_idx = -1` (`vcf_reader.rs`), so gvl's local→global gather is skipped and the emitted
+ids are **silently wrong** for any window that is multi-contig, mid-contig (narrowed), or drops an
+interior variant behind a spanning deletion (#311) — i.e. essentially every real training window. The
+merged Wave A parity test passed only because its fixtures are single-contig / whole-contig / no
+interior exclusion.
+
+Making VCF global ids correct requires a **one-time full-source record scan** (VCF has no
+`.pvar`-equivalent), because narrowed windows demand the exact within-contig record rank. That is an
+expensive price for one output mode.
+
+## Key finding: variants output does **not** need the global id
+
+`RaggedVariants`, `_FlatVariants`, and `_FlatVariantWindows` expose field **values** —
+`alt`/`ref`/`start`/`ilen`/`dosage`/`var_fields` — and **no** `v_idxs` field. The written path's
+`v_idxs = genos.data` is an internal **gather index** into the on-disk variant table
+(`self.variants.info["AF"][v_idxs]`, `_gather_alleles(v_idxs, …)`). Streaming reads those fields
+straight off each record (genoray's `ChunkAssembler` already decodes them into `DenseChunk`) and never
+gathers from a table, so **variants / variant-windows are self-contained from the records**. Ordering
+and AF filtering fall out of reading position-sorted records and each record's `INFO/AF`.
+
+So the global id is needed **only** for `annotated` — a per-nucleotide provenance field with no
+substitute. Dropping annotated for VCF removes the *entire* reason to build the VCF scan.
+
+## Decision
+
+Do **not** build the genoray VCF global-id machinery now. Instead:
+
+**(a) Fail-fast guard (this PR).** In `StreamingDataset._materialize` (`_streaming.py`), where the
+SVAR2 output-mode guard already lives, raise `NotImplementedError` for
+`isinstance(self._backend, _VcfBackend) and _annotated`. The guard fires before `build_engine`, so no
+Rust/FFI is involved. This converts the #311 silent-wrongness into an honest error pointing users to a
+PGEN/SVAR source. `with_seqs("annotated")` docstring updated to state the limitation.
+
+- Tests: drop `"vcf"` from `test_streaming_annotated_parity.py::BACKENDS` (SVAR1 + PGEN still prove the
+  local→global gather); add `test_vcf_annotated_fails_fast` asserting the guard raises at
+  materialization.
+- The Rust `-1`/`remap_annot_local_to_global` fallback stays in place (still correct for the
+  now-unreachable VCF path; shared with PGEN/SVAR1).
+
+**(b) Record the finding.** Correct the Wave B spec
+(`docs/superpowers/specs/2026-07-20-streaming-variants-output-wave-b-design.md`) with dated notes:
+variants output is self-contained from records for VCF (no `global_v_idxs` dependency); the genoray
+VCF scan is deferred and needed only for annotated. Annotate #305 / #311 with the same, cross-linking
+seqlab#199 (CSI/TBI metadata pseudo-bins) as the eventual cheap cross-contig base.
+
+## Scope / non-goals
+
+- **No genoray change.** VCF `RawRecord.global_idx` stays `-1`.
+- **No change to SVAR1/PGEN annotated**, plain VCF haplotypes, `with_len`, or jitter.
+- Revisit the VCF scan only when a concrete VCF-annotated streaming use case appears.
+
+## Verification
+
+- `test_vcf_annotated_fails_fast` — VCF + annotated raises `NotImplementedError`.
+- `test_streaming_annotated_parity.py` SVAR1 + PGEN cases still pass (behavior unchanged).
+- `ruff check` / `ruff format` clean on touched files.

--- a/python/genvarloader/_dataset/_streaming.py
+++ b/python/genvarloader/_dataset/_streaming.py
@@ -472,6 +472,27 @@ class StreamingDataset:
                     "SVAR1/VCF/PGEN engines (issue #277). Use ragged haplotype output "
                     "with jitter=0 for .svar2 sources."
                 )
+            # `with_seqs("annotated")` emits per-position dataset-GLOBAL variant ids
+            # (`AnnotatedHaps.var_idxs`). SVAR1 carries these for free and PGEN derives
+            # them from the `.pvar` absolute row index, but a VCF source has no cheap
+            # per-record global id: genoray leaves `RawRecord.global_idx = -1` for VCF
+            # (`vcf_reader.rs`), so the local->global gather is skipped and the emitted
+            # ids are silently WRONG for any window that is multi-contig, mid-contig
+            # (narrowed), or drops an interior variant behind a spanning deletion --
+            # i.e. essentially every real training window (issues #305, #311). Rather
+            # than return silently-wrong ids, fail fast: annotated output requires a
+            # PGEN or SVAR source. Populating VCF global ids needs a one-time full-source
+            # record scan and is deferred until there is a concrete use case (#305).
+            if isinstance(self._backend, _VcfBackend) and _annotated:
+                raise NotImplementedError(
+                    'with_seqs("annotated") is not supported for the VCF backend: '
+                    "AnnotatedHaps.var_idxs are dataset-global variant ids, which a VCF "
+                    "source cannot produce without an expensive full-file scan (genoray "
+                    "leaves them unset, so they would be silently wrong for multi-contig, "
+                    "narrowed, or interior-exclusion windows; issues #305, #311). Use a "
+                    "PGEN (.pgen) or SVAR (.svar/.svar2) source for annotated output, or "
+                    'plain with_seqs("haplotypes") for the VCF backend.'
+                )
             if self._prefetch_strategy == "engine":
                 # "engine" drives the record-style backends (SVAR1, VCF, PGEN), which
                 # share the same `build_engine(jobs, batch_size, out_len, annotated)`
@@ -900,7 +921,14 @@ class StreamingDataset:
         """Select the sequence output kind. ``"haplotypes"`` (default) or
         ``"annotated"`` (:class:`AnnotatedHaps` -- haplotypes plus per-position
         variant indices and reference coordinates). ``"variants"`` /
-        ``"variant-windows"`` / ``"reference"`` are Wave B / later plans."""
+        ``"variant-windows"`` / ``"reference"`` are Wave B / later plans.
+
+        ``"annotated"`` is **not supported for the VCF backend** (its
+        ``var_idxs`` are dataset-global variant ids a VCF source cannot produce
+        cheaply; issues #305, #311) -- materializing such a dataset raises
+        :class:`NotImplementedError`. Use a PGEN or SVAR source for annotated
+        output.
+        """
         kind_map = {"haplotypes": RaggedSeqs, "annotated": RaggedAnnotatedHaps}
         if kind not in kind_map:
             raise NotImplementedError(

--- a/tests/dataset/test_streaming_annotated_parity.py
+++ b/tests/dataset/test_streaming_annotated_parity.py
@@ -31,7 +31,12 @@ import pytest
 
 import genvarloader as gvl
 
-BACKENDS = ["svar1", "vcf", "pgen"]
+# VCF is intentionally excluded: `with_seqs("annotated")` is a fail-fast
+# NotImplementedError for the VCF backend (its `var_idxs` are dataset-global ids
+# a VCF source cannot produce cheaply; issues #305, #311). See
+# `test_vcf_annotated_fails_fast` for the guard's coverage. SVAR1 (ids for free)
+# and PGEN (ids from the `.pvar` row index) exercise the local->global gather.
+BACKENDS = ["svar1", "pgen"]
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -73,6 +78,21 @@ def test_annotated_matches_written(streaming_case, backend):
         f"backend={backend}: fixture produced no variant-carrying haplotype; "
         "the var_idxs comparison proves nothing without one"
     )
+
+
+def test_vcf_annotated_fails_fast(streaming_case):
+    """`with_seqs("annotated")` on a VCF-backed `StreamingDataset` must raise
+    `NotImplementedError` at materialization rather than emit silently-wrong
+    dataset-global `var_idxs` (issues #305, #311). VCF sources have no cheap
+    per-record global id; annotated output requires a PGEN or SVAR source.
+    """
+    regions, reference, variants, _written = streaming_case("vcf")
+    sds = gvl.StreamingDataset(
+        regions, reference=reference, variants=variants
+    ).with_seqs("annotated")
+    with pytest.raises(NotImplementedError, match="annotated.*VCF backend"):
+        # Materialization (and thus the guard) fires when iteration begins.
+        next(iter(sds.to_iter(batch_size=4)))
 
 
 _NARROWED_PGEN_REGIONS = pl.DataFrame(

--- a/tests/dataset/test_streaming_composition.py
+++ b/tests/dataset/test_streaming_composition.py
@@ -25,7 +25,12 @@ import pytest
 
 import genvarloader as gvl
 
-BACKENDS = ["svar1", "vcf", "pgen"]
+# Both tests here compose `with_seqs("annotated")`, which is a fail-fast
+# NotImplementedError for the VCF backend (its `var_idxs` are dataset-global ids
+# a VCF source cannot produce cheaply; issues #305, #311). SVAR1 (ids for free)
+# and PGEN (ids from the `.pvar` row index) cover the composition; VCF is excluded.
+# See test_streaming_annotated_parity.py::test_vcf_annotated_fails_fast.
+BACKENDS = ["svar1", "pgen"]
 
 # <= the smallest region length across all three `streaming_case` backends
 # (the SVAR1 multi-contig fixture uses 20bp sliding windows; VCF/PGEN span a

--- a/tests/dataset/test_streaming_vcf_parity.py
+++ b/tests/dataset/test_streaming_vcf_parity.py
@@ -233,12 +233,25 @@ def test_vcf_streaming_matches_written_all_cells_multi_region(
 # ---------------------------------------------------------------------------
 
 
+# VCF params are xfail: `with_seqs("annotated")` is a fail-fast NotImplementedError
+# for the VCF backend (its `var_idxs` are dataset-global ids a VCF source cannot
+# produce cheaply; issues #305, #311). These fixtures + assertions are preserved as
+# a strict tripwire — the day VCF global variant ids land and the guard is removed,
+# xpass will fail the suite and flag this test for un-xfailing. PGEN params run live
+# (PGEN derives global ids from the `.pvar` row index).
+_VCF_ANNOTATED_XFAIL = pytest.mark.xfail(
+    reason='with_seqs("annotated") is fail-fast for VCF until global variant ids land (#305/#311)',
+    raises=NotImplementedError,
+    strict=True,
+)
+
+
 @pytest.mark.parametrize(
     "fixture_name",
     [
-        "vcf_same_pos_nonlex",
+        pytest.param("vcf_same_pos_nonlex", marks=_VCF_ANNOTATED_XFAIL),
         "pgen_same_pos_nonlex",
-        "vcf_same_pos_triallelic",
+        pytest.param("vcf_same_pos_triallelic", marks=_VCF_ANNOTATED_XFAIL),
         "pgen_same_pos_triallelic",
     ],
 )
@@ -248,12 +261,14 @@ def test_same_pos_var_idxs_file_order(request, fixture_name, tmp_path):
     (see `vcf_same_pos_nonlex`/`vcf_same_pos_triallelic` docstrings in
     conftest.py for the exact variant tables and genotypes).
 
-    This is expected to PASS: both the streamed `ChunkAssembler` and the
-    written oracle tie-break same-POS atoms by file order (issue #300), so
-    their `var_idxs` must agree even though a lexicographic tie-break would
-    have produced a DIFFERENT (and here, wrong) answer -- a pass on these
-    fixtures is not a coincidence the way it would be on
-    `vcf_snp_ins_del_multi`'s pos=149 pair (see module docstring).
+    PGEN params PASS: both the streamed `ChunkAssembler` and the written
+    oracle tie-break same-POS atoms by file order (issue #300), so their
+    `var_idxs` must agree even though a lexicographic tie-break would have
+    produced a DIFFERENT (and here, wrong) answer -- a pass on these fixtures
+    is not a coincidence the way it would be on `vcf_snp_ins_del_multi`'s
+    pos=149 pair (see module docstring). VCF params are xfail: annotated
+    output is fail-fast for the VCF backend until VCF global variant ids land
+    (#305/#311); the fixtures are kept as a strict tripwire.
     """
     f = request.getfixturevalue(fixture_name)
     variants = str(f.vcf) if hasattr(f, "vcf") else str(f.pgen)


### PR DESCRIPTION
## Summary

`with_seqs("annotated")` emits per-position **dataset-global** variant ids (`AnnotatedHaps.var_idxs`). SVAR1 carries these for free and PGEN derives them from the `.pvar` row index (genoray #134), but a **VCF** source has no cheap per-record global id — genoray leaves `RawRecord.global_idx = -1`, so gvl's local→global gather is skipped and the emitted ids are **silently wrong** for any multi-contig, mid-contig (narrowed), or interior-exclusion window (#311). Merged Wave A parity passed only on trivial single-contig / whole-contig fixtures.

Making VCF ids correct needs a **one-time full-source record scan** (VCF has no `.pvar`-equivalent). Investigation showed that id is needed **only** for `annotated`:

- `RaggedVariants` / `_FlatVariants` / `_FlatVariantWindows` expose field **values** (`alt`/`ref`/`start`/`ilen`/`dosage`/`var_fields`) and **no `v_idxs` field**. The written path's `v_idxs` is an internal **gather index** into its on-disk variant table; streaming reads the same fields straight off each record, so **variants / variant-windows are self-contained from the records** — no global id needed.

So dropping annotated for VCF removes the entire reason to build the scan.

## Changes

**(a) Fail-fast guard.** In `StreamingDataset._materialize` (`_streaming.py`), raise `NotImplementedError` for `_VcfBackend` + annotated — *before* `build_engine`, so no Rust/FFI is involved. Points users to a PGEN/SVAR source. Converts the #311 silent-wrongness into an honest error.

- Drop `"vcf"` from the annotated-parity / composition `BACKENDS` lists (SVAR1 + PGEN still exercise the local→global gather); add `test_vcf_annotated_fails_fast`.
- `xfail(strict, raises=NotImplementedError)` the two VCF params of `test_same_pos_var_idxs_file_order` as a tripwire for when VCF ids eventually land.
- `with_seqs` docstring documents the limitation.

**(b) Record the finding.** Correct the Wave B spec (`2026-07-20-streaming-variants-output-wave-b-design.md`): variants output is self-contained from records for VCF (no `global_v_idxs` dependency); the genoray VCF scan is annotated-only and deferred. Add a design doc (`2026-07-21-vcf-annotated-failfast-design.md`).

## Not in scope

- **No genoray change.** VCF `RawRecord.global_idx` stays `-1`.
- No change to SVAR1/PGEN annotated, plain VCF haplotypes, `with_len`, or jitter.
- Revisit the VCF scan only when a concrete VCF-annotated streaming use case appears — the cross-contig base is then free from the CSI/TBI metadata pseudo-bins (`hts_idx_get_stat`; cf. standardmodelbio/seqlab#199), leaving only the within-contig offset.

## Verification

- `test_streaming_annotated_parity.py`, `test_streaming_vcf_parity.py`, `test_streaming_composition.py`, `test_streaming_config.py`, `test_flat*.py` → **59 passed, 2 xfailed** (built against `origin/streaming`; genoray pinned at the #134 merge).
- `ruff check` / `ruff format` clean; prek hooks (incl. Pyrefly, commitizen) pass.

Relates to #305, #311, #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)