### PR TITLE
fix(#315): double_buffered variant-windows slot-fit hardening (Layers 2a/2b/2c + Phase 0)

### DIFF
--- a/docs/superpowers/plans/2026-07-21-double-buffered-vw-slot-fit.md
+++ b/docs/superpowers/plans/2026-07-21-double-buffered-vw-slot-fit.md
@@ -1,0 +1,555 @@
+# double_buffered variant-windows slot-fit (#315) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Per project convention, implementer subagents run on **Sonnet or weaker**; escalate to a stronger model only for a second-pass fix where the implementer critically failed.
+
+**Goal:** Make `Dataset.to_dataloader(mode="double_buffered")` over flat `variant-windows` output fit its shared-memory slots on the real (Hartwig) corpus, and guarantee the slot-fit invariant by test so this class of estimator↔serializer drift can never silently recur.
+
+**Architecture:** The double-buffer slot is sized from a per-instance byte *estimate* (`Dataset._output_bytes_per_instance`) that must upper-bound what the *serializer* (`write_chunk`) actually writes. The estimate is byte-exact for all synthetic records but diverges on a real-corpus/backend record class (a variant-count/selection mismatch, not a length-formula error). We (a) pin the divergence, (b) restore the estimate's upper-bound invariant for it, and harden the mechanism with (c) a schema-derived slot-overhead bound replacing the magic 4096, (d) a producer write-time guard that fails loud instead of cryptically, and (e) a property test asserting the invariant across a record-type × backend matrix.
+
+**Tech Stack:** Python (numpy, seqpro.rag), Rust (PyO3 window kernel — read-only here), pixi (`-e dev`), pytest, maturin.
+
+## Global Constraints
+
+- Branch `fix/315-double-buffered-vw-slot` → **`main`** (released `Dataset.to_dataloader` double-buffer path; **not** StreamingDataset work — see PR #318). Do **not** target `streaming`.
+- Environment: all commands via `pixi run -e dev <...>`. Platform linux-64.
+- **Rebuild Rust before any pytest that imports the extension:** `pixi run -e dev maturin develop --release`. (No `src/` changes are planned here, so a one-time build at start suffices; `cargo test` compiles from source regardless.)
+- Ruff: E501 (line length) ignored. New/edited docstrings in `python/genvarloader/` must be Google-style. Lint BOTH `python/ tests/`.
+- Before pushing shared-code changes, run the **full tree**: `pixi run -e dev pytest tests -q` (scoped runs skip `tests/unit/`). `tests/data` fixtures require `pixi run -e dev gen` once.
+- Conventional-commit messages (commitizen). End commit messages with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- Public-API surface is unchanged; no `api.md`/SKILL.md update expected (confirm in Task 6).
+
+## Key facts the implementer needs (verified)
+
+- Slot capacity today: `_double_buffered_loader.py:275` → `capacity = HEADER_RESERVED + peak + 4096`, `HEADER_RESERVED = 4096` (`_shm_layout.py:62`). `peak = ChunkPlanner.peak_chunk_bytes`, itself derived from `bpi = ds._output_bytes_per_instance(include_offsets=True)`.
+- `write_chunk(buf, arrays, n_instances)` (`_shm_layout.py:400`) returns the final `cursor` (header+payload bytes). Real payload = `cursor - HEADER_RESERVED`. It raises the observed `ValueError: buffer is smaller than requested size` from an inner `np.frombuffer(buf, dtype, count, offset)` when `offset + count*itemsize > len(buf)`.
+- Materialize a chunk exactly as the producer does: `chunk = ds[r_idx, s_idx]; arrays = list(chunk) if isinstance(chunk, tuple) else [chunk]`.
+- Per-chunk un-estimated overhead (measured): `8 × n_offset_arrays` (missing `+1` terminator per serialized offset array) + `≤7 B`/serialized array (`_align` to 8). For variant-windows a chunk serializes: per scalar `.field` → 1 offset array + 1 data array; per window slot (exactly 2: one ref-derived, one alt-derived) → 2 offset arrays (outer+inner) + 1 data array; per active track → 1 offset array + 1 data array.
+- The estimate's variant-windows branch lives in `_dataset/_impl.py`, `seq_kind == "variant-windows"` (≈ lines 1564–1739); offsets accounting at ≈ 1677–1691.
+- Existing byte-accounting tests: `tests/unit/test_output_bytes_variant_windows.py`, `tests/unit/dataset/test_output_bytes_per_instance.py`, `tests/unit/test_shm_layout.py`, `tests/unit/test_double_buffered_loader.py`. Backend fixtures: `tests/data/phased_dataset.{vcf,pgen,svar}.gvl` (rebuild via `pixi run -e dev gen`; open with `gvl.Dataset.open(path, reference=...)`).
+- Investigation scripts (reference implementations for the comparisons): `/carter/users/dlaub/.claude/jobs/46f6d152/tmp/diag_315_realcorpus.py`, `diag_L128.py`.
+
+## Task dependency / parallelism
+
+- **Task 1 (Phase 0)** is a human-run investigation gate. It blocks only Task 5.
+- **Task 2** and **Task 3** are independent → can run in parallel.
+- **Task 4** depends on Task 2 (uses its `slot_overhead` helper).
+- **Task 5** depends on Task 1 (pinned cause) + Task 4 (property-test harness).
+- **Task 6** (docs/verify) is last.
+- Suggested parallel dispatch: start {Task 1 (you), Task 2, Task 3} together; then Task 4; then Task 5; then Task 6.
+
+---
+
+### Task 1 (GATE — human-run): Phase 0, pin the divergence on the real corpus
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-07-21-phase0-findings.md` (the recorded result)
+
+**Interfaces:**
+- Produces: the **pinned divergence** — which quantity the estimate mis-counts vs the writer, on which backend — and a **minimal reproducing fixture recipe** (dataset backend + a variant record pattern) that Task 5's property-test case will encode.
+
+- [ ] **Step 1: Run the instrumentation against the real dataset**
+
+```bash
+pixi run -e dev python /carter/users/dlaub/.claude/jobs/46f6d152/tmp/diag_315_realcorpus.py \
+    --dataset /path/to/hartwig.gvl --reference /path/to/ref.fa --flank 128
+```
+
+- [ ] **Step 2: Record the offending record class**
+
+Capture the "Offending instances" dump (ilen / ALT strings / backend) into `docs/superpowers/specs/2026-07-21-phase0-findings.md`: the exact under-counted quantity (e.g. "estimate's `n_variants()` counts N variants for (r,s) but the writer's `to_packed()` emits N+k because <pattern>"; or "`_allele_bytes_sum` under-counts alt bytes for <backend/record>"), and the backend (VCF/PGEN/SVAR2).
+
+- [ ] **Step 3: Derive a minimal reproducing fixture recipe**
+
+Write, in the same findings file, the smallest synthetic dataset (backend + variant pattern) that reproduces `real write_chunk payload > sum(estimate)` for a single instance. If synthetic data cannot reproduce it, record instead the exact failing `(r_idx, s_idx)` indices plus the dataset/backend so Task 5 can use a real fixture. **This recipe is the required input to Task 5.**
+
+- [ ] **Step 4: Commit the findings**
+
+```bash
+git add docs/superpowers/specs/2026-07-21-phase0-findings.md
+git commit -m "docs(spec): #315 Phase 0 findings — pinned slot under-count on real corpus"
+```
+
+---
+
+### Task 2: Layer 2c — schema-derived slot-overhead bound (drop the magic 4096)
+
+**Files:**
+- Create: `python/genvarloader/_slot_overhead.py`
+- Modify: `python/genvarloader/_double_buffered_loader.py:275`
+- Test: `tests/unit/test_slot_overhead.py`
+
+**Interfaces:**
+- Produces: `slot_overhead_bytes(dataset) -> int` — a per-chunk upper bound on serialization overhead not captured by `_output_bytes_per_instance` (offset-array terminators + `_align` padding), with a `4096` floor. Consumed by Task 4's property test and by the capacity calc.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_slot_overhead.py
+"""slot_overhead_bytes must upper-bound the real per-chunk serialization overhead
+(offset-array +1 terminators + _align padding) that _output_bytes_per_instance omits."""
+import numpy as np
+import seqpro as sp
+import genvarloader as gvl
+from genvarloader._slot_overhead import slot_overhead_bytes
+from genvarloader._shm_layout import write_chunk, HEADER_RESERVED
+
+
+def _vw(ds, L=8):
+    opt = gvl.VarWindowOpt(flank_length=L, token_alphabet=sp.alphabets.DNA,
+                           unknown_token=len(sp.alphabets.DNA), ref="window", alt="allele")
+    return (ds.with_tracks(False).with_output_format("flat")
+              .with_seqs("variant-windows", opt)
+              .with_settings(unphased_union=True, jitter=0))
+
+
+def test_overhead_covers_real_minus_estimate():
+    ds = _vw(gvl.get_dummy_dataset())
+    R, S = ds.shape[:2]
+    rr, ss = np.meshgrid(np.arange(R), np.arange(S), indexing="ij")
+    r, s = rr.reshape(-1), ss.reshape(-1)
+    chunk = ds[r, s]
+    arrays = list(chunk) if isinstance(chunk, tuple) else [chunk]
+    buf = memoryview(bytearray(64 * 1024 * 1024))
+    real = write_chunk(buf, arrays, n_instances=len(r)) - HEADER_RESERVED
+    est = int(np.asarray(ds._output_bytes_per_instance(r, s, include_offsets=True)).sum())
+    overhead = slot_overhead_bytes(ds)
+    assert real - est <= overhead, f"real-est={real-est} exceeds overhead={overhead}"
+    assert overhead >= 4096  # floor
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/unit/test_slot_overhead.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'genvarloader._slot_overhead'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# python/genvarloader/_slot_overhead.py
+"""Per-chunk serialization overhead not captured by _output_bytes_per_instance.
+
+The byte estimate charges exact per-instance payload + per-instance offset entries,
+but the serializer (_shm_layout.write_chunk) additionally writes, per serialized
+offset array, one +1 terminator entry (8 bytes), and _align-pads (<=8 bytes) before
+every serialized array. Those are per-chunk constants (independent of instance count)
+that must be covered by the slot's fixed slack. This module derives a true upper
+bound on them from the schema, replacing the historical magic 4096.
+"""
+from __future__ import annotations
+
+_OFF = 8  # int64 offset entry / terminator
+_ALIGN = 8  # max _align(8) padding per serialized array
+
+
+def _array_counts(dataset) -> tuple[int, int]:
+    """(n_offset_arrays, n_serialized_arrays) the serializer emits for one chunk
+    under the dataset's active output schema. Upper bound; over-counting is safe."""
+    seq = dataset.sequence_type
+    n_off = 0
+    n_arr = 0
+    seqs = getattr(dataset, "_seqs", None)
+    var_fields = list(getattr(seqs, "var_fields", []) or [])
+    # scalar .fields: always-emitted "start" plus non-allele var_fields.
+    scalars = {f for f in var_fields if f not in ("alt", "ref")}
+    scalars.add("start")
+    if seq == "variant-windows":
+        n_scalar = len(scalars)
+        n_window_slots = 2  # exactly one ref-derived + one alt-derived slot
+        n_off += n_scalar * 1 + n_window_slots * 2  # scalars: outer; windows: outer+inner
+        n_arr += n_scalar * 2 + n_window_slots * 3  # +1 data array each
+    elif seq == "variants":
+        n_scalar = len(scalars)
+        n_allele = sum(1 for f in var_fields if f in ("alt", "ref"))
+        n_off += n_scalar * 1 + n_allele * 2
+        n_arr += n_scalar * 2 + n_allele * 3
+    else:
+        # reference / haplotypes / annotated / none: few arrays; the 4096 floor
+        # dominates. Charge a generous constant so the floor is never exceeded.
+        n_off += 8
+        n_arr += 8
+    # active tracks: each is a single-level ragged (1 offset + 1 data array).
+    n_tracks = len(getattr(dataset, "active_tracks", None) or {})
+    n_off += n_tracks
+    n_arr += n_tracks * 2
+    return n_off, n_arr
+
+
+def slot_overhead_bytes(dataset) -> int:
+    """Upper bound on per-chunk overhead beyond the per-instance byte estimate.
+
+    Args:
+        dataset: The gvl Dataset whose active output schema fixes the field/array
+            structure serialized per chunk.
+
+    Returns:
+        Bytes to add to peak_chunk_bytes when sizing a double_buffered shm slot,
+        floored at 4096 (covers the header-adjacent slack the format has always
+        assumed).
+    """
+    n_off, n_arr = _array_counts(dataset)
+    return max(4096, _OFF * n_off + _ALIGN * n_arr)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/unit/test_slot_overhead.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire it into the slot capacity**
+
+In `python/genvarloader/_double_buffered_loader.py`, add near the top-level imports:
+
+```python
+from ._slot_overhead import slot_overhead_bytes
+```
+
+Replace line 275:
+
+```python
+        capacity = HEADER_RESERVED + peak + 4096
+```
+
+with:
+
+```python
+        capacity = HEADER_RESERVED + peak + slot_overhead_bytes(dataset)
+```
+
+- [ ] **Step 6: Run the double-buffered loader tests**
+
+Run: `pixi run -e dev pytest tests/unit/test_double_buffered_loader.py tests/unit/test_slot_overhead.py -v`
+Expected: PASS (no regression; slots are now sized with a derived, never-smaller overhead).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add python/genvarloader/_slot_overhead.py python/genvarloader/_double_buffered_loader.py tests/unit/test_slot_overhead.py
+git commit -m "fix(dataloader): derive double_buffered slot overhead from schema, drop magic 4096
+
+Replace the fixed 4096 slot slack with slot_overhead_bytes(dataset), an
+upper bound on the per-chunk serialization overhead (+1 offset-array
+terminators and _align padding) that _output_bytes_per_instance omits.
+Floored at 4096 so it is never smaller than before.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Layer 2a — producer write-time slot-fit guard (fail loud, not cryptic)
+
+**Files:**
+- Modify: `python/genvarloader/_shm_layout.py` (`write_chunk`, ≈ lines 400–454)
+- Test: `tests/unit/test_shm_layout.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `write_chunk` raises a `SlotOverflowError` (new, subclass of `ValueError`) with an actionable message when the serialized chunk exceeds `len(buf)`, instead of the raw inner `np.frombuffer` "buffer is smaller than requested size".
+
+**Design note:** rather than duplicate every `_write_*` helper's cursor math in a parallel "dry run" (which would create exactly the estimator↔serializer drift this effort exists to kill), wrap the existing write loop and translate the numpy overflow into an actionable error. On overflow the chunk is abandoned (the producer never marks the slot `ready`), so a partial write into the scratch slot is harmless.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/unit/test_shm_layout.py
+import numpy as np
+import pytest
+from genvarloader._shm_layout import write_chunk, SlotOverflowError, HEADER_RESERVED
+
+
+def test_write_chunk_raises_actionable_on_overflow():
+    # A dense array whose payload exceeds a deliberately tiny slot.
+    arr = np.arange(4096, dtype=np.int64)  # 32 KiB payload
+    tiny = memoryview(bytearray(HEADER_RESERVED + 1024))  # far too small
+    with pytest.raises(SlotOverflowError) as ei:
+        write_chunk(tiny, [arr], n_instances=1)
+    msg = str(ei.value)
+    assert "slot" in msg.lower()
+    assert "buffer_bytes" in msg or "batch_size" in msg  # actionable remedy
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/unit/test_shm_layout.py::test_write_chunk_raises_actionable_on_overflow -v`
+Expected: FAIL with `ImportError: cannot import name 'SlotOverflowError'`.
+
+- [ ] **Step 3: Add the exception class**
+
+In `python/genvarloader/_shm_layout.py`, near the top (after imports, before `HEADER_RESERVED`):
+
+```python
+class SlotOverflowError(ValueError):
+    """A serialized chunk does not fit its shared-memory slot.
+
+    Raised by write_chunk in place of the raw numpy "buffer is smaller than
+    requested size". Indicates the per-instance byte estimate under-sized the
+    slot for this chunk: lower batch_size or raise buffer_bytes.
+    """
+```
+
+- [ ] **Step 4: Translate the overflow in `write_chunk`**
+
+Wrap the existing per-array write loop in `write_chunk` (the `for a in arrays: ... descriptors.append(desc)` block, ≈ lines 424–439) so a buffer-overflow `ValueError` from any inner `np.frombuffer` becomes a `SlotOverflowError`:
+
+```python
+    for a in arrays:
+        try:
+            if isinstance(a, _FlatVariantWindows):
+                desc, cursor = _write_flat_variant_windows(buf, a, cursor)
+            elif isinstance(a, _FlatVariants):
+                desc, cursor = _write_flat_variants(buf, a, cursor)
+            elif isinstance(a, RaggedVariants):
+                desc, cursor = _write_rag_variants(buf, a, cursor)
+            elif isinstance(a, (RaggedAnnotatedHaps, _FlatAnnotatedHaps)):
+                desc, cursor = _write_rag_annotated(buf, a, cursor)
+            elif isinstance(a, (Ragged, _Flat)):
+                desc, cursor = _write_ragged(buf, a, cursor)
+            elif isinstance(a, np.ndarray):
+                desc, cursor = _write_dense(buf, a, cursor)
+            else:
+                raise TypeError(f"write_chunk: unsupported array type {type(a)}")
+        except ValueError as e:
+            # numpy raises "buffer is smaller than requested size" when a write
+            # offset+extent exceeds the slot. Re-raise with actionable context;
+            # let unrelated ValueErrors (e.g. the TypeError branch) propagate.
+            if "buffer is smaller than requested size" not in str(e):
+                raise
+            raise SlotOverflowError(
+                f"serialized chunk (n_instances={n_instances}) does not fit the "
+                f"shared-memory slot of {len(buf)} bytes. The per-instance byte "
+                f"estimate under-sized this slot. Lower batch_size or raise "
+                f"buffer_bytes."
+            ) from e
+        descriptors.append(desc)
+```
+
+- [ ] **Step 5: Run the guard test**
+
+Run: `pixi run -e dev pytest tests/unit/test_shm_layout.py::test_write_chunk_raises_actionable_on_overflow -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full shm-layout + double-buffered suites (no regression)**
+
+Run: `pixi run -e dev pytest tests/unit/test_shm_layout.py tests/unit/test_double_buffered_loader.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add python/genvarloader/_shm_layout.py tests/unit/test_shm_layout.py
+git commit -m "fix(dataloader): raise actionable SlotOverflowError on oversized chunk write
+
+Translate numpy's cryptic 'buffer is smaller than requested size' (raised
+when a chunk's serialized bytes exceed its shm slot) into a SlotOverflowError
+naming n_instances, slot size, and the remedy (lower batch_size / raise
+buffer_bytes). Wraps the existing write loop -- no parallel cursor math to
+drift from the real writer.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Layer 2b — upper-bound property test (record-type × backend matrix)
+
+**Files:**
+- Create: `tests/unit/test_slot_fit_property.py`
+
+**Interfaces:**
+- Consumes: `slot_overhead_bytes` (Task 2), `write_chunk`/`HEADER_RESERVED` (core), `_chunk_serialized_nbytes` (Task 3).
+- Produces: the standing invariant `sum(estimate) + slot_overhead_bytes(ds) >= real write_chunk payload` for every chunk in the matrix. This is the harness Task 5 extends with the Phase-0 case.
+
+- [ ] **Step 1: Write the property test (passes today; proves no regression + guards the invariant)**
+
+```python
+# tests/unit/test_slot_fit_property.py
+"""The double_buffered slot-fit invariant: the per-instance byte estimate plus the
+schema-derived slot overhead must upper-bound the real serialized payload for every
+chunk. This is the invariant #315 violated; it must hold across record types and
+storage backends."""
+import numpy as np
+import pytest
+import seqpro as sp
+import genvarloader as gvl
+from genvarloader._shm_layout import write_chunk, HEADER_RESERVED
+from genvarloader._slot_overhead import slot_overhead_bytes
+
+
+def _views(ds):
+    DNA = sp.alphabets.DNA
+    for ref, alt in [("window", "window"), ("window", "allele"), ("allele", "allele")]:
+        if ref == "allele" and getattr(ds._seqs.variants, "ref", None) is None:
+            continue
+        for uu in (True, False):
+            for L in (8, 128):
+                opt = gvl.VarWindowOpt(flank_length=L, token_alphabet=DNA,
+                                       unknown_token=len(DNA), ref=ref, alt=alt)
+                yield (ds.with_tracks(False).with_output_format("flat")
+                         .with_seqs("variant-windows", opt)
+                         .with_settings(unphased_union=uu, jitter=0))
+
+
+def _assert_upper_bound(view):
+    R, S = view.shape[:2]
+    rr, ss = np.meshgrid(np.arange(R), np.arange(S), indexing="ij")
+    r, s = rr.reshape(-1), ss.reshape(-1)
+    chunk = view[r, s]
+    arrays = list(chunk) if isinstance(chunk, tuple) else [chunk]
+    buf = memoryview(bytearray(64 * 1024 * 1024))
+    real = write_chunk(buf, arrays, n_instances=len(r)) - HEADER_RESERVED
+    est = int(np.asarray(view._output_bytes_per_instance(r, s, include_offsets=True)).sum())
+    assert est + slot_overhead_bytes(view) >= real, (
+        f"slot under-sized: est={est} overhead={slot_overhead_bytes(view)} real={real}")
+
+
+def test_slot_fit_dummy_backend():
+    for view in _views(gvl.get_dummy_dataset()):
+        _assert_upper_bound(view)
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pixi run -e dev pytest tests/unit/test_slot_fit_property.py -v`
+Expected: PASS (the estimate is byte-exact for synthetic records; the overhead covers the per-chunk constant).
+
+- [ ] **Step 3: Add file-backed backend coverage (VCF, PGEN, SVAR2)**
+
+First ensure fixtures exist: `pixi run -e dev gen`. Then add, using the same conftest helpers the other `tests/dataset` tests use to open `tests/data/phased_dataset.{vcf,pgen,svar}.gvl` with a reference (grep `tests/dataset/conftest.py` for the reference-open pattern):
+
+```python
+@pytest.mark.parametrize("backend", ["vcf", "pgen", "svar"])
+def test_slot_fit_file_backends(backend, request):
+    # Open tests/data/phased_dataset.<backend>.gvl with the shared reference
+    # fixture (mirror tests/dataset/conftest.py). Skip if the fixture/reference
+    # is unavailable in this environment.
+    ds = _open_phased_backend(request, backend)  # helper mirroring conftest
+    for view in _views(ds):
+        _assert_upper_bound(view)
+```
+
+Implement `_open_phased_backend` in the test module by copying the open pattern from `tests/dataset/conftest.py` (reference path + `gvl.Dataset.open`). If a backend fixture cannot be built in the environment, `pytest.skip(...)` with an explicit message (do not silently pass).
+
+- [ ] **Step 4: Run the full property suite**
+
+Run: `pixi run -e dev pytest tests/unit/test_slot_fit_property.py -v`
+Expected: PASS for every available backend; explicit SKIP (never silent) for any unavailable one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/test_slot_fit_property.py
+git commit -m "test(dataloader): property test — estimate+slot_overhead upper-bounds real payload
+
+Assert the double_buffered slot-fit invariant across ref/alt x unphased_union
+x flank_length x {VCF,PGEN,SVAR2} backends. This is the invariant #315 broke;
+it now guards against estimator<->serializer drift in CI.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5 (GATE on Task 1): Layer 1 — restore the estimate's upper-bound for the pinned case
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_impl.py` (`_output_bytes_per_instance`, `seq_kind == "variant-windows"` branch ≈ 1564–1739)
+- Test: `tests/unit/test_slot_fit_property.py` (extend with the Phase-0 case)
+
+**Interfaces:**
+- Consumes: Task 1's pinned divergence + reproducing fixture recipe; Task 4's `_assert_upper_bound`.
+- Produces: the estimate is a true upper bound for the pinned record class → the reported 40×7089 config no longer overflows.
+
+- [ ] **Step 1: Encode the Phase-0 case as a failing test**
+
+Using the fixture recipe from `docs/superpowers/specs/2026-07-21-phase0-findings.md`, add a parametrization/case to `tests/unit/test_slot_fit_property.py` that builds (or opens) the offending dataset+view and calls `_assert_upper_bound`. If the recipe is a real dataset + specific `(r_idx, s_idx)`, encode those indices directly.
+
+- [ ] **Step 2: Run it to confirm it fails (reproduces #315 at the estimate level)**
+
+Run: `pixi run -e dev pytest tests/unit/test_slot_fit_property.py -k phase0 -v`
+Expected: FAIL with `slot under-sized: est=... real=...` (real exceeds est+overhead) — the estimate-level reproduction of the overflow.
+
+- [ ] **Step 3: Fix the estimate to upper-bound the pinned quantity**
+
+Per Task 1's finding, correct the `variant-windows` branch of `_output_bytes_per_instance` so the mis-counted quantity becomes a provable upper bound. The fix takes one of these shapes (Task 1 selects which):
+- **Count/selection mismatch:** align the estimate's variant set with the writer's `genotypes.to_packed()` `v_idxs` for the failing backend (e.g. count the same records the writer emits, rather than `n_variants()` which diverges under the pinned pattern).
+- **Backend allele-byte mismatch:** replace/augment the `_allele_bytes_sum` term with the backend-correct stored-ALT byte count (matching what the Rust `gather_alleles` reads).
+Keep the change conservative (upper bound, never under-count) and localized to the variant-windows branch; add a short comment citing #315 and the pinned record class. Do **not** touch the writer.
+
+- [ ] **Step 4: Run the Phase-0 case + the whole property suite**
+
+Run: `pixi run -e dev pytest tests/unit/test_slot_fit_property.py -v`
+Expected: PASS for the Phase-0 case and all pre-existing cases (fix must not break the byte-exact synthetic cases — it may only ever *raise* the estimate).
+
+- [ ] **Step 5: End-to-end regression at the reported shape**
+
+Add a smoke test that builds the offending view at `flank_length=128` and iterates one batch under `mode="double_buffered"` with a `buffer_bytes` small enough to force a multi-instance chunk, asserting no `SlotOverflowError` / overflow. (If only a real dataset reproduces it, mark `@pytest.mark.slow` and gate on the fixture being present.)
+
+Run: `pixi run -e dev pytest tests/unit/test_slot_fit_property.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/genvarloader/_dataset/_impl.py tests/unit/test_slot_fit_property.py
+git commit -m "fix(dataloader): variant-windows byte estimate upper-bounds writer for <pinned record class> (#315)
+
+<one line naming the pinned divergence and backend from Phase 0>. Restores
+the double_buffered slot-fit invariant so the reported 40x7089 config no
+longer overflows; buffered/manual were already correct.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Verify, docs audit, finalize
+
+**Files:**
+- Modify (only if needed): `docs/source/dataset.md` / `docs/source/faq.md`
+- Modify: `docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md` (flip Status to Implemented; record Phase-0 result)
+
+- [ ] **Step 1: Rebuild + full tree + cargo**
+
+```bash
+pixi run -e dev maturin develop --release
+pixi run -e dev pytest tests -q
+pixi run -e dev cargo test
+```
+Expected: green (record counts).
+
+- [ ] **Step 2: Lint + typecheck**
+
+```bash
+pixi run -e dev ruff check python/ tests/
+pixi run -e dev ruff format --check python/ tests/
+pixi run -e dev typecheck
+```
+Expected: clean.
+
+- [ ] **Step 3: Public-API / docs gate**
+
+```bash
+python -c "import re,genvarloader as g; api=open('docs/source/api.md').read(); print('MISSING:', [n for n in g.__all__ if n not in api] or 'none')"
+```
+Expected: `MISSING: none`. Confirm no user-facing default/flag changed; update `dataset.md`/`faq.md` only if `double_buffered`/`buffer_bytes` guidance changed. `SlotOverflowError` is internal (not in `__all__`) unless you deliberately export it — do not export without adding an `api.md` entry.
+
+- [ ] **Step 4: Update the design spec status + push**
+
+Flip the spec Status to `Implemented`, summarize the Phase-0 result, commit, and push the branch. The draft PR #320 updates automatically.
+
+```bash
+git add docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md
+git commit -m "docs(spec): mark #315 slot-fit design implemented; record Phase 0 result"
+git push
+```
+
+- [ ] **Step 5: Comment on #315**
+
+Post the corrected repro params (flank_length=128 / 2 GiB) + the confirmed root cause + the fix summary to issue #315, and open the separate **Bug A** issue (`realign_tracks` not propagated to the producer) cross-linked to #315.
+
+---
+
+## Out of scope (tracked separately)
+
+- **Bug A — `realign_tracks` not propagated to the producer** (`_build_producer_schema` omits `realign_tracks`; producer defaults it to `True` and raises for variant-windows + tracks). Its own issue + PR: add `schema["realign_tracks"] = ds.realign_tracks` (schema dict at `_double_buffered_loader.py:85-92`) and thread it through `_producer._apply_schema`'s `settings_kwargs`, plus a regression test that `double_buffered` + variant-windows + an active track iterates.
+- **Producer grow-or-split auto-recovery** — the escalation path if Phase 0 shows the estimate cannot be made a clean upper bound. Re-approve scope with the user before implementing.

--- a/docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md
+++ b/docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md
@@ -1,0 +1,246 @@
+# double_buffered variant-windows slot-fit (#315)
+
+**Date:** 2026-07-21
+**Status:** Draft (design) — pending real-corpus root-cause confirmation
+**Issue:** [#315](https://github.com/mcvickerlab/GenVarLoader/issues/315)
+**Branch/target:** `fix/315-double-buffered-vw-slot` → `main` (this is the *released*
+`gvl.Dataset.to_dataloader` double-buffer path, **not** StreamingDataset work — see the
+CLAUDE.md scope clarification in PR #318).
+
+## Problem
+
+`Dataset.to_dataloader(..., mode="double_buffered")` over flat **`variant-windows`**
+output fails deterministically at scale with:
+
+```
+RuntimeError: ProducerError (ValueError): buffer is smaller than requested size
+  at _shm_layout.py::_write_flat_variant_windows  (np.frombuffer offset+count > len(buf))
+```
+
+The identical view is fine under `mode="buffered"` and `mode="manual"`, and all three
+are byte-identical in a per-variant parity check at small scale — so the **data is
+correct**. This is purely a shared-memory **slot-sizing** bug on the `double_buffered`
+path.
+
+**Reported failing configuration** (released PyPI wheel **0.40.0**; corrected params from
+the reporter — the issue's `flank_length=8` snippet was illustrative):
+
+- flat `variant-windows`, `ref="window"`, `alt="allele"`, `unphased_union=True`, `jitter=0`
+- **`flank_length=128`** (≈257-token windows), **tracks OFF** (trackless Hartwig corpus)
+- `buffer_bytes=2 GiB` (→ `slot_bytes ≈ 1 GiB`), `batch_size=4096`, `shuffle=True`
+- 40 regions × 7089 samples (region subset of full Hartwig via `restrict_footprint`)
+- Reproduced twice. A 2×4 subset with `buffer_bytes=16 MiB` passes.
+
+`v0.40.0` is the PR #312 merge (`0a6a0f0b`) plus a version-bump commit, so the failing
+wheel **includes** #312's byte-accounting fixes — this is not a stale pre-#312 report.
+
+## How slot sizing works today (and why it can overflow)
+
+- `_torch.py::_resolve_buffered_inputs` builds a per-instance byte table
+  `bpi = Dataset._output_bytes_per_instance(include_offsets=(mode=="double_buffered"))`.
+- `_chunked.py::ChunkPlanner` packs epoch-ordered `(r,s)` instances into chunks so that
+  `sum(bpi[r,s]) ≤ slot_bytes`, and exposes `peak_chunk_bytes` (max chunk estimate).
+- `_double_buffered_loader.py:275` sizes each shm slot as
+  `capacity = HEADER_RESERVED + peak_chunk_bytes + 4096`.
+- The producer materializes `chunk = ds[r_idx, s_idx]` and serializes it with
+  `_shm_layout.py::write_chunk` / `_write_flat_variant_windows`.
+
+**The invariant that must hold:** for every chunk, the real serialized payload must be
+`≤ peak_chunk_bytes + 4096`. Because `peak_chunk_bytes` is derived from the *same*
+estimate the chunker packs with, the only headroom for any un-estimated byte is the fixed
+**4096** slack. `buffered`/`manual` never serialize into fixed-size slots, so they never
+hit this — which is why only `double_buffered` fails.
+
+## Root-cause analysis
+
+Two independent empirical passes (dummy dataset; real file-backed dense multi-variant /
+dual-haplotype / indel data) plus a reading of the Rust window kernel establish:
+
+1. **The estimate is byte-exact per-instance for every record type synthetic data can
+   produce** — SNP, multiallelic, small/large ins+del (incl. 49 bp), contig-boundary
+   indels (padded to full `2L+span`, not clipped), homozygous-on-both-haps, multi-variant
+   groups — at **both `flank_length=8` and `128`** (172k variants → same fixed shortfall
+   as 673). The per-instance/per-variant under-count slope is **exactly zero**.
+
+2. **The only un-estimated cost is a fixed per-chunk constant** (~48–74 bytes): the
+   estimate omits the `+1` terminator entry of each serialized offset array
+   (`8 × n_offset_arrays`) and the `≤7 B`/array `_align` padding. This is real but bounded;
+   it needs **>~508 `var_fields`** to breach the 4096 slack, so it does **not** explain the
+   reported 40×7089 overflow on its own. It is nonetheless a correctness gap (Bug B below).
+
+3. **The writer sizes windows purely from `ilen` and stored allele bytes**, and the
+   estimate's *formulas* mirror it exactly (`src/variants/windows.rs`):
+   - `ref_window` length per variant `= (end + L) − (start − L) = 1 + max(−ilen, 0) + 2L`
+     — `end = start − min(ilen,0) + 1`. There is **no END/SVLEN path**; it is `ilen`-only.
+     Matches the estimate's `ref_span = 1 + max(−ilen,0)` + `2L` term-for-term.
+   - `alt` (bare, `alt="allele"`) length `=` gathered stored ALT bytes; `alt_window` length
+     `= 2L +` stored ALT bytes. Matches `_allele_bytes_sum`.
+
+4. **Symbolic / breakend ALTs are impossible in a written gvl dataset** — `gvl.write`
+   *rejects* them (genoray 2.9.1 guard; spec `2026-06-07-reject-symbolic-breakend`). The
+   Hartwig corpus was written successfully, so it contains none. (Earlier top suspect
+   ruled out.)
+
+**Conclusion.** Since the writer's length formulas and the estimate's formulas are
+identical, the overflow **cannot** be a per-window-length error. It must be a mismatch in
+**which / how many variants** each side accounts, because the two sides compute that
+through *separate code paths*:
+
+- **Estimate (Python):** `Dataset.n_variants()` + `Haps._allele_bytes_sum()` +
+  `real_ploidy` grouping.
+- **Writer (Rust):** `genotypes[r,s].to_packed()` → `v_idxs` → `gather_alleles()`.
+
+On synthetic VCF data these agree byte-for-byte. On the real corpus they diverge. The
+divergence is therefore **real-corpus-specific** — most probably backend-driven (Hartwig
+may be PGEN or SVAR2; all synthetic tests used VCF) or a genotype-pattern / `unphased_union`
+edge case the synthetic generator does not produce. **The exact term is not yet pinned**
+(see Phase 0).
+
+### Collateral bug found en route
+
+**Bug A — `realign_tracks` not propagated to the producer (independent, high severity).**
+`with_seqs("variant-windows")` + active tracks requires `realign_tracks=False` in the
+parent, but `_build_producer_schema` omits `realign_tracks` from the schema dict and
+`_producer._apply_schema` never sets it. The producer's fresh `Dataset.open()` defaults it
+to `True`, so replaying the schema raises
+`ValueError: with_seqs('variant-windows') with tracks requires with_settings(realign_tracks=False)`
+at `_reconstruct.py:539`. ⇒ **variant-windows + any active track is completely broken in
+`double_buffered` mode** — but it dies at schema replay with a *different* error, never
+reaching `write_chunk`, so it is **not** the #315 overflow. Tracked and fixed separately
+(its own issue + PR), not folded into this one.
+
+## Goals / non-goals
+
+**Goals**
+
+- Make `double_buffered` variant-windows **work** on the real Hartwig corpus at the
+  reported config (no `buffer is smaller than requested size`).
+- Guarantee the slot-fit invariant `estimate + slot_overhead ≥ real serialized bytes`
+  **by test**, across a record-type *and backend* matrix — so this class of drift is
+  caught in CI, not in production.
+- Turn any residual overflow into a **precise, actionable error** instead of a cryptic
+  `np.frombuffer` failure.
+
+**Non-goals**
+
+- Auto-recovery by growing/splitting oversized chunks (the "robust structural rewrite").
+  Deferred: viable only if Phase 0 shows the estimate cannot be made a clean upper bound
+  (escalation path below).
+- Any change to `buffered`/`manual` modes (they don't use fixed slots).
+- Bug A's fix (separate PR).
+
+## Design
+
+### Phase 0 — Pin the divergence (gate)
+
+Run the instrumentation script `diag_315_realcorpus.py` (a per-instance real-`write_chunk`
+vs estimate sweep that flags any instance under-counting by >256 B and dumps that
+instance's `ilen` / ALT strings / backend) against the actual Hartwig dataset at the
+failing params. Output pins **which variant-selection or allele-byte quantity** the
+estimate mis-counts relative to the writer, and on **which backend**.
+
+- If the sweep shows **no** per-instance under-count, the overflow is chunk-packing-scale
+  specific; re-capture the exact `(r_idx, s_idx)` of a failing chunk from a real
+  `to_dataloader` run and feed those indices in.
+- The pinned quantity determines Layer 1's exact correction. Layer 1 does **not** proceed
+  on a guess.
+
+### Layer 1 — Restore the upper-bound invariant in the estimate
+
+Correct the pinned divergence in the `seq_kind == "variant-windows"` branch of
+`Dataset._output_bytes_per_instance` (`_dataset/_impl.py`) so its variant count / allele
+bytes are a **provable upper bound** on what the writer emits for that record class and
+backend. "Correct" is defined operationally by the Layer 2b property test passing on a
+fixture reproducing the pinned record class.
+
+Likely shape (to be confirmed by Phase 0): align the estimate's variant selection with the
+writer's `to_packed()` `v_idxs` for the failing backend, or add the missing backend-specific
+allele-byte accounting (e.g. an SVAR2/PGEN path where stored ALT bytes differ from what
+`_allele_bytes_sum` assumes). If Phase 0 reveals the estimate genuinely cannot be made a
+tight upper bound cheaply, escalate (below) rather than bloat the estimate.
+
+### Layer 2a — Producer write-time slot-fit guard (fail loud, fail safe)
+
+Before `write_chunk` writes payload into a slot, compute (or accumulate) the real serialized
+size and verify it fits the slot capacity. On overflow, raise a precise error naming: chunk
+index, real bytes vs available bytes, the offending `(r_idx, s_idx)` (or the first field to
+overflow), and the actionable remedy (*lower `batch_size` or raise `buffer_bytes`*). This
+replaces the cryptic `np.frombuffer` ValueError and — critically — makes **any future
+estimator drift fail loud and safe** instead of surfacing as a mysterious crash.
+
+Implementation note: `write_chunk` already advances a `cursor`; add a size-only pre-pass (or
+a bounds check against `len(buf)` before each `np.frombuffer` write) so the guard fires with
+context *before* the raw overflow. Cheap; no format change.
+
+### Layer 2b — Upper-bound property test (the durable fix)
+
+Add a test asserting, for a **matrix of schemas × record types × backends**, that
+
+```
+sum(_output_bytes_per_instance(include_offsets=True)) + slot_overhead(schema)
+    ≥ real write_chunk cursor − HEADER_RESERVED
+```
+
+for every chunk. Matrix must include: SNP, indel (incl. large), contig-boundary, multi-
+allelic-atomized, homozygous, multi-variant groups, `unphased_union` on/off, `ref`/`alt` ∈
+{window, allele}, `flank_length` ∈ {small, 128}, **VCF *and* PGEN *and* SVAR2 backends**,
+and the Phase-0 record class once pinned. This is the test that would have caught #315 and
+the #312 drift saga; it is the primary defense against recurrence.
+
+### Layer 2c — Fold per-chunk overhead into slot capacity (Bug B)
+
+Replace the magic `4096` slack with a **derived** per-chunk overhead bound: the offset-array
+`+1` terminators (`8 × n_offset_arrays`) and `_align` padding (`8 × n_serialized_arrays`),
+computable from the schema (field count, window-slot count). `slot_overhead(schema)` in
+Layer 2b uses the same derivation, so the test and the runtime bound stay in lockstep. This
+removes the last un-accounted term and makes `peak_chunk_bytes + slot_overhead` a true
+upper bound independent of field count.
+
+### Layer 3 — Bug A (`realign_tracks` propagation) — *separate issue + PR*
+
+Add `schema["realign_tracks"] = ds.realign_tracks` in `_build_producer_schema` and thread it
+through `_apply_schema`'s `settings_kwargs`, plus a regression test that
+`double_buffered` + variant-windows + an active track iterates. Filed as its own issue,
+cross-linked to #315; not in this PR.
+
+## Testing strategy
+
+- **Layer 2b property test** is the centerpiece (record-type × backend matrix).
+- **Regression test** reproducing #315's shape: a variant-windows view at `flank_length=128`
+  with the Phase-0 record class, packed into a slot sized to just fit the *estimate*, must
+  serialize without overflow (i.e. estimate is a true upper bound).
+- **Guard test** (Layer 2a): force an intentional under-count (monkeypatch the estimate low)
+  and assert the producer raises the precise, actionable error — not the raw `np.frombuffer`
+  ValueError.
+- Before pushing: full tree (`pixi run -e dev pytest tests -q`) + `cargo test`, since this
+  touches shared shm-layout / dataloader code. Rebuild Rust (`maturin develop --release`)
+  before any pytest that imports the extension.
+
+## Docs & skill upkeep (per CLAUDE.md gates)
+
+No public-API surface change is expected (internal slot sizing + a producer guard). Confirm
+`docs/source/*` and `skills/genvarloader/SKILL.md` need no update; if Layer 1 changes any
+user-facing `double_buffered` guidance or `buffer_bytes` advice, update `dataset.md`/`faq.md`
+accordingly. Add a `changelog`-worthy conventional-commit message (does **not** substitute
+for prose docs).
+
+## Risks & open questions
+
+- **Phase 0 may not reproduce a per-instance under-count** on the corpus subset available to
+  the maintainer. Mitigation: capture the exact failing `(r_idx, s_idx)` from a real run.
+- **The divergence may be intractable to model cheaply in the estimate** (e.g. requires
+  replicating `to_packed()`'s selection). → **Escalation path:** fall back to the deferred
+  producer-side *grow-or-split* handling (reallocate a larger slot and signal the consumer,
+  or split the chunk), which guarantees correctness without an exact estimate. This changes
+  scope and would be re-approved with the user before implementing.
+- **Backend coverage gap:** if the property-test matrix can't cheaply build a PGEN/SVAR2
+  fixture matching Hartwig, note the gap explicitly rather than claim full coverage.
+
+## Rollout
+
+1. Phase 0 (instrumentation) → pin divergence.
+2. Implement Layer 2b (property test, expected to fail on the pinned case) → Layer 1 (fix
+   until it passes) → Layer 2c → Layer 2a.
+3. Full-tree + cargo verification; update #315 with the corrected repro + confirmed root
+   cause + fix.
+4. Layer 3 (`realign_tracks`) as a separate issue + PR.

--- a/docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md
+++ b/docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md
@@ -1,7 +1,9 @@
 # double_buffered variant-windows slot-fit (#315)
 
 **Date:** 2026-07-21
-**Status:** Draft (design) — pending real-corpus root-cause confirmation
+**Status:** Partially implemented — Layers 2a/2b/2c + Phase 0 done; **Layer 1 (estimate
+fix) deferred**, blocked on the real-corpus pin. See
+[Phase 0 findings](./2026-07-21-phase0-findings.md).
 **Issue:** [#315](https://github.com/mcvickerlab/GenVarLoader/issues/315)
 **Branch/target:** `fix/315-double-buffered-vw-slot` → `main` (this is the *released*
 `gvl.Dataset.to_dataloader` double-buffer path, **not** StreamingDataset work — see the
@@ -244,3 +246,19 @@ for prose docs).
 3. Full-tree + cargo verification; update #315 with the corrected repro + confirmed root
    cause + fix.
 4. Layer 3 (`realign_tracks`) as a separate issue + PR.
+
+## Implementation status (2026-07-21)
+
+| Layer | Status | Commit / note |
+|-------|--------|---------------|
+| **Phase 0** — pin divergence | ✅ done (negative) | Estimate is a **verified per-instance upper bound** for every synthetic record type × VCF/PGEN/SVAR on the released `Haps` path; `M == K == W`; `real − est` is a per-chunk constant covered by `slot_overhead`. Real-corpus divergence **not reproducible** synthetically. See [Phase 0 findings](./2026-07-21-phase0-findings.md). |
+| **2c** — schema-derived slot overhead (drop magic 4096) | ✅ done | `slot_overhead_bytes(dataset)` in `_slot_overhead.py`, wired into `_double_buffered_loader.py`; floored at 4096. |
+| **2a** — producer write-time guard | ✅ done | `SlotOverflowError(ValueError)` in `_shm_layout.py`; `write_chunk` translates the cryptic numpy overflow into an actionable "lower batch_size / raise buffer_bytes" error. |
+| **2b** — upper-bound property test | ✅ done | `tests/unit/test_slot_fit_property.py`; asserts `est + slot_overhead ≥ real` across ref/alt × unphased_union × flank × {dummy,VCF,PGEN,SVAR} (44 views, all pass). |
+| **1** — estimate upper-bound fix for the pinned case | ⏸ **deferred / blocked** | No reproducible divergence to fix; the design doc's hypothesized `to_packed()` mismatch is structurally impossible on the `Haps` path (Phase 0). Needs the **real Hartwig corpus** to pin, or a scope decision to adopt the **grow-or-split** escalation. Layer 1 must not proceed on a guess. |
+| **3** — `realign_tracks` propagation (Bug A) | ⬜ separate issue + PR | Out of scope for this PR. |
+
+**Net effect shipped so far:** the reported Hartwig config no longer fails with a cryptic
+`np.frombuffer` error — it now raises `SlotOverflowError` with an actionable remedy — and
+the slot-fit invariant is locked in CI. Making that config *fit* (rather than fail loud)
+still requires Layer 1, which is blocked as above.

--- a/docs/superpowers/specs/2026-07-21-phase0-findings.md
+++ b/docs/superpowers/specs/2026-07-21-phase0-findings.md
@@ -1,0 +1,122 @@
+# Phase 0 findings — #315 double_buffered variant-windows slot under-count
+
+**Date:** 2026-07-21
+**Issue:** [#315](https://github.com/mcvickerlab/GenVarLoader/issues/315)
+**Gate for:** Task 5 (Layer 1 — restore the estimate's upper-bound for the pinned case)
+
+## Summary (the pin)
+
+**The estimate `Dataset._output_bytes_per_instance` is a byte-exact per-instance
+upper bound for every record type and storage backend reproducible with the
+project's synthetic generator, on the released `Haps` read path — which is the only
+path `Dataset.to_dataloader(mode="double_buffered")` uses.** The per-instance and
+per-variant under-count slope is **exactly zero**; the only gap between the estimate
+and the real serialized payload is a fixed **per-chunk** constant (~48–55 bytes) that
+`slot_overhead_bytes` (Task 2) now covers with a 4096 floor.
+
+**The reported real-corpus (Hartwig) divergence could NOT be reproduced** with any
+available synthetic data. Pinning the exact offending record class therefore
+**requires the real Hartwig dataset**, which is not present in this environment.
+Task 5 cannot proceed on a synthetic reproduction; see "Required input to Task 5".
+
+## What was measured
+
+The real Hartwig corpus and reference are not available here, so Phase 0 was run
+against the shared synthetic `session_document` (`tests/_builders/case.py`) — the
+standardized 14-record VCF with **multiallelic** (`chr2:1110696 G>A,T`;
+`chr2:1234567 A>GA,AC` microsatellite), **indel** (`chr1:1010696 GAGA…>G`,
+`chr1:1110696 A>TTT`), **homozygous-ALT** (`1|1`, `1/1`, `2/2`), and **missing/half-call**
+(`1|.`, `.|1`, `./.`) records — built through **all three variant backends** (VCF,
+PGEN, SVAR) and opened with the synthetic reference.
+
+Reported failing view encoded exactly: flat `variant-windows`, `ref="window"`,
+`alt="allele"`, `unphased_union=True`, `jitter=0`, tracks OFF, `flank_length ∈ {8, 128}`.
+
+Scripts (this session's scratch): `phase0_backend_sweep.py` (per-instance real vs
+estimate), `phase0_scaling.py` (per-chunk vs per-instance decomposition, the decisive
+one), `phase0_MKW.py` (variant-count identity).
+
+### Result 1 — `real − est` is a per-CHUNK constant, not per-instance
+
+Packing the full 8×3 grid into one chunk and tiling it to N = 24 → 192 instances:
+
+| backend | uu | N=24 | N=48 | N=96 | N=192 | d(real−est)/d(inst) |
+|---------|-----|------|------|------|-------|---------------------|
+| vcf/pgen/svar | True/False | ~55 | ~54 | ~52 | ~48 | **≈ 0 (slightly negative)** |
+
+`delta = real − est` stays flat (actually *decreases* slightly with N, from
+`_align` padding amortizing). `est + slot_overhead_bytes(view) ≥ real` holds for
+every backend, every N, both `unphased_union` values, at `flank_length=128`. A
+per-instance under-count would grow `delta` linearly with N; it does not.
+
+The earlier single-instance sweep (`phase0_backend_sweep.py`) reported a ~63 B
+"under-count" on *every* instance of *every* backend — that was a **methodology
+artifact**: a 1-instance chunk pays the full per-chunk overhead once, so it looks
+per-instance. The multi-instance tiling above is the correct measurement and shows
+the term is per-chunk (the known Bug B constant, now covered by Task 2).
+
+### Result 2 — variant-count identity `M == K == W`
+
+For every synthetic instance, every backend, `unphased_union` on/off (including the
+homozygous sites):
+
+- `M` = `n_variants()` folded (the estimate's flank-token multiplier `n_vars_total`)
+- `K` = `len(to_packed(genotypes[r,s]).data)` (the estimate's `ref_span`/`alt` set)
+- `W` = emitted window count (`len(ref-slot.seq_offsets) − 1`, the writer's truth)
+
+**`M == K == W` in 100% of instances.** This is structural, not luck: on the `Haps`
+path `self.n_variants = self.genotypes.lengths` (`_haps.py:298`) and `to_packed().data`
+are the *same ragged array's* length, so `M == K` by construction, and the Rust window
+kernel emits one window per packed v_idx, so `W == K`.
+
+## Why the design doc's hypothesized mechanism does not apply here
+
+The design doc (`…-double-buffered-vw-slot-fit-design.md`, "Conclusion") proposed the
+divergence was the estimate's variant *selection* (`n_variants()` + `_allele_bytes_sum`)
+disagreeing with the writer's `to_packed()` → `v_idxs`. On the `Haps` path this
+disagreement is **structurally impossible** (Result 2): both derive from the same
+`genotypes` ragged array. The `ref_span`/`alt_alleles` terms already consume
+`to_packed()` directly (`_impl.py:1615`, `_haps.py:779`). So Task 5's suggested
+"align the estimate with `to_packed()`" fix would be a no-op — they are already aligned.
+
+`Svar2Haps` (the SVAR2 / StreamingDataset reconstructor) has separate variant-counting
+logic (`_svar2_haps.py`, `p_eff = 1 if unphased_union else P`), but it is **not reachable**
+from the released `Dataset.open` + `to_dataloader` path (#315's scope): every backend —
+including a SparseVar source — opens as `Haps`, verified this session. SVAR2 is
+StreamingDataset-only (out of scope per the design doc and CLAUDE.md).
+
+## Consequence for the plan
+
+Because the estimate is *already* a correct per-instance upper bound for everything
+reproducible, and the real overflow still occurs on Hartwig, the true cause is one the
+synthetic generator cannot produce and this environment cannot pin. This is the plan's
+anticipated escalation branch (design doc "Risks & open questions" → escalation path):
+**the estimate cannot be corrected by a guess**, and the plan forbids guessing
+("Layer 1 does not proceed on a guess").
+
+Tasks 2 (slot_overhead), 3 (SlotOverflowError guard), 4 (upper-bound property test),
+and 6 (verify/docs) are valid and valuable independent of the pin — they harden the
+mechanism and turn any residual overflow (including Hartwig's) into an actionable
+error. They are being completed. **Task 5 is blocked** pending one of the two inputs
+below.
+
+## Required input to Task 5 (one of)
+
+1. **Real-corpus pin.** Run, on the actual Hartwig dataset + its reference, this
+   session's `diag_315_realcorpus.py` (per-instance real-`write_chunk` vs estimate
+   sweep) — OR the corrected `phase0_scaling.py` adapted to that dataset — and capture:
+   the offending `(r_idx, s_idx)`, the `ilen`/ALT strings/genotype pattern of the
+   variants in that instance, the backend, and whether `d(real−est)/d(inst) > 0`
+   (per-instance under-count) vs a per-chunk constant that only breaches the slack at
+   large chunk sizes. That dump is the fixture recipe Task 5's failing test encodes.
+
+2. **Escalate to grow-or-split (scope change, needs user approval).** If the divergence
+   cannot be modeled cheaply in the estimate, adopt the deferred producer-side
+   grow-or-split auto-recovery (reallocate a larger slot / split the chunk on overflow),
+   which guarantees correctness without an exact estimate. This is a current non-goal;
+   re-approve scope with the user before implementing.
+
+Until one of these arrives, the SlotOverflowError guard (Task 3) ensures the reported
+Hartwig config fails with an actionable message ("lower batch_size or raise
+buffer_bytes") rather than the cryptic `np.frombuffer` `ValueError` — a strict
+improvement even without the estimate fix.

--- a/python/genvarloader/_double_buffered_loader.py
+++ b/python/genvarloader/_double_buffered_loader.py
@@ -13,6 +13,7 @@ from multiprocessing.shared_memory import SharedMemory
 
 from ._chunked import ChunkPlanner, slice_chunk
 from ._shm_layout import read_chunk, HEADER_RESERVED
+from ._slot_overhead import slot_overhead_bytes
 
 if TYPE_CHECKING:
     import torch.utils.data as td
@@ -272,7 +273,7 @@ class _DoubleBufferedIterable:
         self._chunks: list[tuple[np.ndarray, np.ndarray, int]] = list(planner)
         peak = planner.peak_chunk_bytes
 
-        capacity = HEADER_RESERVED + peak + 4096
+        capacity = HEADER_RESERVED + peak + slot_overhead_bytes(dataset)
         suffix = uuid.uuid4().hex[:8]
         self._shm_names = [f"gvl-{os.getpid()}-{suffix}-{i}" for i in range(2)]
         self._shms = [

--- a/python/genvarloader/_shm_layout.py
+++ b/python/genvarloader/_shm_layout.py
@@ -59,6 +59,16 @@ from typing import Sequence
 
 import numpy as np
 
+
+class SlotOverflowError(ValueError):
+    """A serialized chunk does not fit its shared-memory slot.
+
+    Raised by write_chunk in place of the raw numpy "buffer is smaller than
+    requested size". Indicates the per-instance byte estimate under-sized the
+    slot for this chunk: lower batch_size or raise buffer_bytes.
+    """
+
+
 HEADER_RESERVED = 4096
 
 _PREAMBLE = struct.Struct("<QQB")  # n_instances, payload_bytes, n_arrays
@@ -422,20 +432,33 @@ def write_chunk(
     cursor = HEADER_RESERVED
 
     for a in arrays:
-        if isinstance(a, _FlatVariantWindows):
-            desc, cursor = _write_flat_variant_windows(buf, a, cursor)
-        elif isinstance(a, _FlatVariants):
-            desc, cursor = _write_flat_variants(buf, a, cursor)
-        elif isinstance(a, RaggedVariants):
-            desc, cursor = _write_rag_variants(buf, a, cursor)
-        elif isinstance(a, (RaggedAnnotatedHaps, _FlatAnnotatedHaps)):
-            desc, cursor = _write_rag_annotated(buf, a, cursor)
-        elif isinstance(a, (Ragged, _Flat)):
-            desc, cursor = _write_ragged(buf, a, cursor)
-        elif isinstance(a, np.ndarray):
-            desc, cursor = _write_dense(buf, a, cursor)
-        else:
-            raise TypeError(f"write_chunk: unsupported array type {type(a)}")
+        try:
+            if isinstance(a, _FlatVariantWindows):
+                desc, cursor = _write_flat_variant_windows(buf, a, cursor)
+            elif isinstance(a, _FlatVariants):
+                desc, cursor = _write_flat_variants(buf, a, cursor)
+            elif isinstance(a, RaggedVariants):
+                desc, cursor = _write_rag_variants(buf, a, cursor)
+            elif isinstance(a, (RaggedAnnotatedHaps, _FlatAnnotatedHaps)):
+                desc, cursor = _write_rag_annotated(buf, a, cursor)
+            elif isinstance(a, (Ragged, _Flat)):
+                desc, cursor = _write_ragged(buf, a, cursor)
+            elif isinstance(a, np.ndarray):
+                desc, cursor = _write_dense(buf, a, cursor)
+            else:
+                raise TypeError(f"write_chunk: unsupported array type {type(a)}")
+        except ValueError as e:
+            # numpy raises "buffer is smaller than requested size" when a write
+            # offset+extent exceeds the slot. Re-raise with actionable context;
+            # let unrelated ValueErrors (e.g. the TypeError branch) propagate.
+            if "buffer is smaller than requested size" not in str(e):
+                raise
+            raise SlotOverflowError(
+                f"serialized chunk (n_instances={n_instances}) does not fit the "
+                f"shared-memory slot of {len(buf)} bytes. The per-instance byte "
+                f"estimate under-sized this slot. Lower batch_size or raise "
+                f"buffer_bytes."
+            ) from e
         descriptors.append(desc)
 
     payload_bytes = cursor - HEADER_RESERVED

--- a/python/genvarloader/_shm_layout.py
+++ b/python/genvarloader/_shm_layout.py
@@ -449,8 +449,12 @@ def write_chunk(
                 raise TypeError(f"write_chunk: unsupported array type {type(a)}")
         except ValueError as e:
             # numpy raises "buffer is smaller than requested size" when a write
-            # offset+extent exceeds the slot. Re-raise with actionable context;
-            # let unrelated ValueErrors (e.g. the TypeError branch) propagate.
+            # offset+extent exceeds the slot. Re-raise those with actionable
+            # context; let any other ValueError propagate unchanged. (The
+            # unsupported-type branch above raises TypeError, not ValueError, so
+            # it bypasses this handler entirely.) NOTE: this couples to numpy's
+            # exact message; if numpy rewords it, the guard degrades to the raw
+            # error -- test_write_chunk_raises_actionable_on_overflow pins it.
             if "buffer is smaller than requested size" not in str(e):
                 raise
             raise SlotOverflowError(

--- a/python/genvarloader/_slot_overhead.py
+++ b/python/genvarloader/_slot_overhead.py
@@ -1,0 +1,68 @@
+"""Per-chunk serialization overhead not captured by _output_bytes_per_instance.
+
+The byte estimate charges exact per-instance payload + per-instance offset entries,
+but the serializer (_shm_layout.write_chunk) additionally writes, per serialized
+offset array, one +1 terminator entry (8 bytes), and _align-pads (<=8 bytes) before
+every serialized array. Those are per-chunk constants (independent of instance count)
+that must be covered by the slot's fixed slack. This module derives a true upper
+bound on them from the schema, replacing the historical magic 4096.
+"""
+
+from __future__ import annotations
+
+_OFF = 8  # int64 offset entry / terminator
+_ALIGN = 8  # max _align(8) padding per serialized array
+
+
+def _array_counts(dataset) -> tuple[int, int]:
+    """(n_offset_arrays, n_serialized_arrays) the serializer emits for one chunk.
+
+    Derived from the dataset's active output schema. Upper bound; over-counting
+    is safe.
+    """
+    seq = dataset.sequence_type
+    n_off = 0
+    n_arr = 0
+    seqs = getattr(dataset, "_seqs", None)
+    var_fields = list(getattr(seqs, "var_fields", []) or [])
+    # scalar .fields: always-emitted "start" plus non-allele var_fields.
+    scalars = {f for f in var_fields if f not in ("alt", "ref")}
+    scalars.add("start")
+    if seq == "variant-windows":
+        n_scalar = len(scalars)
+        n_window_slots = 2  # exactly one ref-derived + one alt-derived slot
+        n_off += (
+            n_scalar * 1 + n_window_slots * 2
+        )  # scalars: outer; windows: outer+inner
+        n_arr += n_scalar * 2 + n_window_slots * 3  # +1 data array each
+    elif seq == "variants":
+        n_scalar = len(scalars)
+        n_allele = sum(1 for f in var_fields if f in ("alt", "ref"))
+        n_off += n_scalar * 1 + n_allele * 2
+        n_arr += n_scalar * 2 + n_allele * 3
+    else:
+        # reference / haplotypes / annotated / none: few arrays; the 4096 floor
+        # dominates. Charge a generous constant so the floor is never exceeded.
+        n_off += 8
+        n_arr += 8
+    # active tracks: each is a single-level ragged (1 offset + 1 data array).
+    n_tracks = len(getattr(dataset, "active_tracks", None) or {})
+    n_off += n_tracks
+    n_arr += n_tracks * 2
+    return n_off, n_arr
+
+
+def slot_overhead_bytes(dataset) -> int:
+    """Upper bound on per-chunk overhead beyond the per-instance byte estimate.
+
+    Args:
+        dataset: The gvl Dataset whose active output schema fixes the field/array
+            structure serialized per chunk.
+
+    Returns:
+        Bytes to add to peak_chunk_bytes when sizing a double_buffered shm slot,
+        floored at 4096 (covers the header-adjacent slack the format has always
+        assumed).
+    """
+    n_off, n_arr = _array_counts(dataset)
+    return max(4096, _OFF * n_off + _ALIGN * n_arr)

--- a/python/genvarloader/_slot_overhead.py
+++ b/python/genvarloader/_slot_overhead.py
@@ -40,6 +40,11 @@ def _array_counts(dataset) -> tuple[int, int]:
         n_allele = sum(1 for f in var_fields if f in ("alt", "ref"))
         n_off += n_scalar * 1 + n_allele * 2
         n_arr += n_scalar * 2 + n_allele * 3
+        # optional flank_tokens payload: _write_flat_variants emits one extra
+        # data + offset array when present. Charge it unconditionally (an
+        # upper bound; harmless over-count when flanks are absent).
+        n_off += 1
+        n_arr += 2
     else:
         # reference / haplotypes / annotated / none: few arrays; the 4096 floor
         # dominates. Charge a generous constant so the floor is never exceeded.

--- a/tests/unit/test_shm_layout.py
+++ b/tests/unit/test_shm_layout.py
@@ -2,8 +2,15 @@
 
 import multiprocessing as mp
 import numpy as np
+import pytest
 from multiprocessing.shared_memory import SharedMemory
-from genvarloader._shm_layout import write_chunk, read_chunk, slot_capacity_for
+from genvarloader._shm_layout import (
+    write_chunk,
+    read_chunk,
+    slot_capacity_for,
+    SlotOverflowError,
+    HEADER_RESERVED,
+)
 
 
 def test_dense_roundtrip_single_array():
@@ -347,3 +354,14 @@ def test_flat_read_avoids_awkward_variant_funcs(monkeypatch):
     finally:
         shm.close()
         shm.unlink()
+
+
+def test_write_chunk_raises_actionable_on_overflow():
+    # A dense array whose payload exceeds a deliberately tiny slot.
+    arr = np.arange(4096, dtype=np.int64)  # 32 KiB payload
+    tiny = memoryview(bytearray(HEADER_RESERVED + 1024))  # far too small
+    with pytest.raises(SlotOverflowError) as ei:
+        write_chunk(tiny, [arr], n_instances=1)
+    msg = str(ei.value)
+    assert "slot" in msg.lower()
+    assert "buffer_bytes" in msg or "batch_size" in msg  # actionable remedy

--- a/tests/unit/test_slot_fit_property.py
+++ b/tests/unit/test_slot_fit_property.py
@@ -1,0 +1,63 @@
+"""The double_buffered slot-fit invariant: the per-instance byte estimate plus the
+schema-derived slot overhead must upper-bound the real serialized payload for every
+chunk. This is the invariant #315 violated; it must hold across record types and
+storage backends."""
+
+import numpy as np
+import pytest
+import seqpro as sp
+
+import genvarloader as gvl
+from genvarloader._shm_layout import HEADER_RESERVED, write_chunk
+from genvarloader._slot_overhead import slot_overhead_bytes
+
+
+def _views(ds):
+    DNA = sp.alphabets.DNA
+    for ref, alt in [("window", "window"), ("window", "allele"), ("allele", "allele")]:
+        if ref == "allele" and getattr(ds._seqs.variants, "ref", None) is None:
+            continue
+        for uu in (True, False):
+            for L in (8, 128):
+                opt = gvl.VarWindowOpt(
+                    flank_length=L,
+                    token_alphabet=DNA,
+                    unknown_token=len(DNA),
+                    ref=ref,
+                    alt=alt,
+                )
+                yield (
+                    ds.with_tracks(False)
+                    .with_output_format("flat")
+                    .with_seqs("variant-windows", opt)
+                    .with_settings(unphased_union=uu, jitter=0)
+                )
+
+
+def _assert_upper_bound(view):
+    R, S = view.shape[:2]
+    rr, ss = np.meshgrid(np.arange(R), np.arange(S), indexing="ij")
+    r, s = rr.reshape(-1), ss.reshape(-1)
+    chunk = view[r, s]
+    arrays = list(chunk) if isinstance(chunk, tuple) else [chunk]
+    buf = memoryview(bytearray(64 * 1024 * 1024))
+    real = write_chunk(buf, arrays, n_instances=len(r)) - HEADER_RESERVED
+    est = int(
+        np.asarray(view._output_bytes_per_instance(r, s, include_offsets=True)).sum()
+    )
+    assert est + slot_overhead_bytes(view) >= real, (
+        f"slot under-sized: est={est} overhead={slot_overhead_bytes(view)} real={real}"
+    )
+
+
+def test_slot_fit_dummy_backend():
+    for view in _views(gvl.get_dummy_dataset()):
+        _assert_upper_bound(view)
+
+
+@pytest.mark.parametrize("backend", ["vcf", "pgen", "svar"])
+def test_slot_fit_file_backends(backend, request, reference):
+    path = request.getfixturevalue(f"phased_{backend}_gvl")
+    ds = gvl.Dataset.open(path, reference=reference)
+    for view in _views(ds):
+        _assert_upper_bound(view)

--- a/tests/unit/test_slot_overhead.py
+++ b/tests/unit/test_slot_overhead.py
@@ -1,0 +1,41 @@
+"""slot_overhead_bytes must upper-bound the real per-chunk serialization overhead
+(offset-array +1 terminators + _align padding) that _output_bytes_per_instance omits."""
+
+import numpy as np
+import seqpro as sp
+import genvarloader as gvl
+from genvarloader._slot_overhead import slot_overhead_bytes
+from genvarloader._shm_layout import write_chunk, HEADER_RESERVED
+
+
+def _vw(ds, L=8):
+    opt = gvl.VarWindowOpt(
+        flank_length=L,
+        token_alphabet=sp.alphabets.DNA,
+        unknown_token=len(sp.alphabets.DNA),
+        ref="window",
+        alt="allele",
+    )
+    return (
+        ds.with_tracks(False)
+        .with_output_format("flat")
+        .with_seqs("variant-windows", opt)
+        .with_settings(unphased_union=True, jitter=0)
+    )
+
+
+def test_overhead_covers_real_minus_estimate():
+    ds = _vw(gvl.get_dummy_dataset())
+    R, S = ds.shape[:2]
+    rr, ss = np.meshgrid(np.arange(R), np.arange(S), indexing="ij")
+    r, s = rr.reshape(-1), ss.reshape(-1)
+    chunk = ds[r, s]
+    arrays = list(chunk) if isinstance(chunk, tuple) else [chunk]
+    buf = memoryview(bytearray(64 * 1024 * 1024))
+    real = write_chunk(buf, arrays, n_instances=len(r)) - HEADER_RESERVED
+    est = int(
+        np.asarray(ds._output_bytes_per_instance(r, s, include_offsets=True)).sum()
+    )
+    overhead = slot_overhead_bytes(ds)
+    assert real - est <= overhead, f"real-est={real - est} exceeds overhead={overhead}"
+    assert overhead >= 4096  # floor


### PR DESCRIPTION
## #315 — `double_buffered` variant-windows slot-fit

Fixes the deterministic overflow of `Dataset.to_dataloader(mode="double_buffered")` over
flat `variant-windows` output at scale. The shared-memory slot is sized from a per-instance
byte **estimate** that must upper-bound what the serializer (`_shm_layout.write_chunk`) writes.

### What landed (mechanism hardening — Layers 2a/2b/2c + Phase 0)

- **2c — schema-derived slot overhead** (`_slot_overhead.py`): `slot_overhead_bytes(dataset)`
  replaces the magic `4096` slack with a derived per-chunk upper bound (offset-array `+1`
  terminators + `_align` padding), floored at 4096.
- **2a — actionable overflow guard** (`_shm_layout.py`): `SlotOverflowError(ValueError)`;
  `write_chunk` translates numpy's cryptic *"buffer is smaller than requested size"* into a
  precise error naming `n_instances`, slot size, and the remedy (lower `batch_size` / raise
  `buffer_bytes`). Verified to propagate through the producer subprocess to the user.
- **2b — upper-bound property test** (`tests/unit/test_slot_fit_property.py`): asserts
  `est + slot_overhead ≥ real payload` across ref/alt × `unphased_union` × `flank_length` ×
  {dummy, VCF, PGEN, SVAR} (44 views). Locks the invariant in CI.

### Phase 0 result (root-cause gate) — see `docs/superpowers/specs/2026-07-21-phase0-findings.md`

The estimate is a **verified per-instance upper bound** for every record type the synthetic
generator produces across all three backends on the released `Haps` path (`n_variants() ==
len(to_packed()) == emitted windows`; `real − est` is a flat per-chunk constant). The design
doc's hypothesized estimate↔`to_packed()` selection mismatch is **structurally impossible** on
that path. **The real-corpus (Hartwig) divergence could not be reproduced** without the
dataset, which is absent from the dev environment.

### Deferred — Layer 1 (estimate fix) is blocked, not omitted

There is no reproducible case to fix, and the plan forbids guessing. Unblocking needs **either**
the real Hartwig corpus (run `diag_315_realcorpus.py`, capture the offending record) **or** a
scope decision to adopt the deferred **grow-or-split** producer auto-recovery (tracked in #322). Until then, the
2a guard turns the Hartwig config's crash into an actionable error (fail loud, not fix).

Relates to #315 (does **not** close it — the remaining "make it fit" work is tracked in #322). Out of scope, filed separately: **Bug A** (#321) — `realign_tracks` not propagated to the producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
