### PR TITLE
fix(dataloader): #315 SVAR2 variant-windows double_buffered slot under-allocation (Layer 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-svar2-variant-windows-slot-fit.md
+++ b/docs/superpowers/plans/2026-07-23-svar2-variant-windows-slot-fit.md
@@ -1,0 +1,345 @@
+# SVAR2 variant-windows slot-fit (#315 Layer 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Dataset.to_dataloader(mode="double_buffered")` over flat `variant-windows` work on the real SVAR2-backed Hartwig corpus by restoring `_output_bytes_per_instance` as a provable upper bound on the `Svar2Haps` reconstruction path.
+
+**Architecture:** The double-buffered producer packs instances into a fixed shared-memory slot sized from `_output_bytes_per_instance`. That estimate's `variant-windows` branch (`_impl.py:1564`) derives its per-instance variant count and window spans from the `Haps` quantities (`self.n_variants` = `genotypes.lengths`; `genotypes[r,s].to_packed()`). For an **SVAR2-format-2.0.0** dataset the reconstruction runs through `Svar2Haps._call_svar2` at `p_eff = 1 if unphased_union else P`, and the estimate no longer matches what the writer emits — it under-counts so severely that the whole corpus packs into one undersized slot and overflows. We (1) pin the exact diverging term against the real corpus, (2) lock it with a failing in-tree test on an SVAR2 dataset, (3) correct the estimate to mirror the `Svar2Haps` count, (4) verify the reported config end-to-end.
+
+**Tech Stack:** Python 3.12, NumPy, Rust extension (maturin/PyO3), genoray SparseVar2, pixi (`dev` env), pytest, cargo.
+
+## Global Constraints
+
+- **This is a debug-gated plan.** Task 1 (Phase 0 spike) pins the diverging term; Task 3's fix code is confirmed against that pin, not guessed — the predecessor rule "Layer 1 does not proceed on a guess" holds. Tasks are **sequential**: 1 → 2 (red) → 3 (green) → 4. There is no safe parallelism (the fix depends on the pin; the test's record class depends on the pin).
+- **Rebuild the Rust extension before any pytest that imports it:** `pixi run -e dev maturin develop --release` (run from the worktree root). The slot-fit path calls into the compiled window/svar2 kernels.
+- **Run tests via** `pixi run -e dev pytest ...`. Do **not** use `--frozen` here — this repo's `dev` env is not shared with a co-tenant (that constraint was aster-specific).
+- **Real Hartwig corpus (read-only), symlink into the worktree before Task 1:**
+  `data/corpus/hartwig` → `/carter/users/dlaub/projects/aster/data/corpus/hartwig`, and the reference assets under `refs/` if the corpus's reference is needed (the corpus is trackless; variant-windows `ref="window"` reads the reference genome, so `refs/GRCh38.ensembl.fa.bgz{,.fai,.gzi,.gvlfa}` must resolve — symlink from `/carter/users/dlaub/projects/aster/refs/`).
+- **Commit hooks:** the `pyrefly-check` pre-commit hook type-checks the whole tree (`pixi run -e dev pyrefly check python/genvarloader tests`, ~7+ min) with no file filter. For **docs-only** commits use `git commit --no-verify`. For **code** commits, let the hook run (it is the type-check gate); if iterating, run `pixi run -e dev pyrefly check python/genvarloader tests` manually once and keep commits batched.
+- **Issue/scope:** [#315](https://github.com/mcvickerlab/GenVarLoader/issues/315). Out of scope: `buffered`/`manual` modes, Bug A (`realign_tracks`, separate issue), producer grow-or-split (escalation only). Spec: `docs/superpowers/specs/2026-07-23-svar2-variant-windows-slot-fit-design.md`.
+
+---
+
+## File Structure
+
+- `python/genvarloader/_dataset/_impl.py` — `Dataset._output_bytes_per_instance`, `variant-windows` branch at **1564-1669**. The only production file Task 3 edits.
+- `python/genvarloader/_dataset/_svar2_haps.py` — `Svar2Haps(Haps)`; `self.n_variants = self.genotypes.lengths` (208); window/allele reconstruction at `p_eff = 1 if unphased_union else P` (821, 964, 1049…). Task 3 reuses a counting entry point from here; edits only if none can be reused (small extract).
+- `tests/unit/test_slot_fit_property.py` — the slot-fit invariant harness (`_views`, `_assert_upper_bound`). Task 2 adds SVAR2 coverage.
+- `tests/conftest.py` — fixtures; `phased_svar_gvl` at 127. Task 2 adds a `phased_svar2_gvl` fixture (or a real-slice fixture per the Phase-0 decision).
+- `tests/test_svar2_reconstruct.py:34` (`svar2_store`) — reference recipe for building a `.svar2` store from genoray for the synthetic fixture.
+- `docs/superpowers/specs/2026-07-23-phase0-realcorpus-findings.md` — **created by Task 1** (the pin).
+- `docs/superpowers/specs/2026-07-21-phase0-findings.md`, `…-double-buffered-vw-slot-fit-design.md` — predecessor docs Task 4 corrects/updates.
+- Scratch (not committed to `python/`): `scratch/diag_315_realcorpus.py` under the worktree — Task 1's instrumentation.
+
+---
+
+### Task 1: Phase 0 — pin the divergence on the real corpus (spike)
+
+This is an **investigation spike**, not TDD. Its deliverable is a committed findings doc that pins which quantity the estimate mis-counts, captured from the real corpus. Task 3's fix is written against this pin.
+
+**Files:**
+- Create (scratch, not committed under `python/`): `scratch/diag_315_realcorpus.py`
+- Create (committed): `docs/superpowers/specs/2026-07-23-phase0-realcorpus-findings.md`
+
+**Interfaces:**
+- Consumes: `gvl.Dataset.open`, `Dataset._output_bytes_per_instance`, `Dataset.__getitem__` (`view[r,s]`), `genvarloader._shm_layout.write_chunk`, `HEADER_RESERVED`, `genvarloader._slot_overhead.slot_overhead_bytes`, `Svar2Haps`.
+- Produces (consumed by Tasks 2/3): the pinned diverging term (one of: `n_vars_total`/`self.n_variants` count, `ref_span`, `alt_alleles`, or a `p_eff`/ploidy grouping error), a captured overflowing `(r_idx, s_idx)`, the variant record class driving it, and whether the fixture reproducing it can be synthetic or must be a real slice.
+
+- [ ] **Step 1: Symlink the real corpus + reference into the worktree**
+
+```bash
+cd ~/projects/GenVarLoader/.claude/worktrees/315-svar2-slot
+mkdir -p data/corpus refs
+ln -sfn /carter/users/dlaub/projects/aster/data/corpus/hartwig data/corpus/hartwig
+for f in GRCh38.ensembl.fa.bgz GRCh38.ensembl.fa.bgz.fai GRCh38.ensembl.fa.bgz.gzi GRCh38.ensembl.fa.bgz.gvlfa; do
+  ln -sfn /carter/users/dlaub/projects/aster/refs/$f refs/$f
+done
+ls -l data/corpus/hartwig refs/
+```
+Expected: symlinks resolve (corpus `hartwig.gvl/` + `tumor.xolars/` visible; reference files listed).
+
+- [ ] **Step 2: Build the Rust extension**
+
+Run: `pixi run -e dev maturin develop --release`
+Expected: builds and installs the extension into the `dev` env without error.
+
+- [ ] **Step 3: Write the instrumentation script**
+
+Create `scratch/diag_315_realcorpus.py`. It reproduces the reported config, confirms the reconstructor is `Svar2Haps`, and — for a sample of instances and for at least one instance from an overflowing chunk — compares the estimate's internal quantities against the real serialized payload. `main()` MUST sit under `if __name__ == "__main__":` (the producer spawns and re-imports).
+
+```python
+"""Pin the #315 estimate divergence against the real SVAR2 Hartwig corpus.
+Not committed under python/. Run: pixi run -e dev python scratch/diag_315_realcorpus.py
+"""
+import sys
+import numpy as np
+import seqpro as sp
+import genvarloader as gvl
+from genvarloader._dataset._svar2_haps import Svar2Haps
+from genvarloader._shm_layout import HEADER_RESERVED, write_chunk
+from genvarloader._slot_overhead import slot_overhead_bytes
+
+CORPUS = "data/corpus/hartwig/hartwig.gvl"
+REF = "refs/GRCh38.ensembl.fa.bgz"
+N_REGIONS = 40
+
+
+def make_view():
+    DNA = sp.alphabets.DNA
+    ds = gvl.Dataset.open(CORPUS, reference=REF)
+    # subset to the reported region count (all samples)
+    ds = ds.subset_to(regions=slice(N_REGIONS))
+    opt = gvl.VarWindowOpt(
+        flank_length=128, token_alphabet=DNA, unknown_token=len(DNA),
+        ref="window", alt="allele",
+    )
+    return (
+        ds.with_tracks(False).with_output_format("flat")
+          .with_seqs("variant-windows", opt)
+          .with_settings(unphased_union=True, jitter=0)
+    )
+
+
+def main() -> int:
+    view = make_view()
+    print("reconstructor:", type(view._seqs).__name__,
+          "is Svar2Haps:", isinstance(view._seqs, Svar2Haps))
+    R, S = view.shape[:2]
+    print(f"shape: {R} regions x {S} samples")
+
+    # Per-instance estimate vs real, over a growing instance count, to test whether
+    # the under-count is per-instance (grows with N) or a per-chunk constant.
+    rng = np.random.default_rng(0)
+    for N in (S, 4 * S, 16 * S):  # 1, 4, 16 regions worth of instances
+        n_reg = N // S
+        rr, ss = np.meshgrid(np.arange(n_reg), np.arange(S), indexing="ij")
+        r, s = rr.reshape(-1), ss.reshape(-1)
+        chunk = view[r, s]
+        arrays = list(chunk) if isinstance(chunk, tuple) else [chunk]
+        buf = memoryview(bytearray(512 * 1024 * 1024))
+        real = write_chunk(buf, arrays, n_instances=len(r)) - HEADER_RESERVED
+        est = int(np.asarray(
+            view._output_bytes_per_instance(r, s, include_offsets=True)).sum())
+        ovh = slot_overhead_bytes(view)
+        print(f"N={len(r):>7}  est={est:>12}  overhead={ovh:>8}  real={real:>12}  "
+              f"est+ovh-real={est + ovh - real:>12}  per_inst_gap={(real - est) / len(r):.1f}")
+
+    # Decompose one region's estimate: n_vars_total vs emitted window count W.
+    r = np.zeros(S, np.int64)
+    s = np.arange(S, np.int64)
+    haps = view._seqs
+    n_vars = view.n_variants(r, s)
+    n_vars_total = n_vars.reshape(-1, n_vars.shape[-1]).astype(np.int64).sum(-1)
+    chunk = view[r, s]
+    ref_slot = (chunk[0] if isinstance(chunk, tuple) else chunk)
+    # emitted window count W per instance = len(ref window seq_offsets) - 1, per instance
+    print("sum n_vars_total (estimate M):", int(n_vars_total.sum()))
+    print("real_ploidy:", haps.genotypes.shape[-2],
+          "unphased_union:", view.unphased_union)
+    # Dump the worst-under-counted instance for its record class.
+    est_pi = np.asarray(view._output_bytes_per_instance(r, s, include_offsets=True))
+    worst = int(np.argmin(est_pi - 0))  # smallest estimate; refine vs per-instance real if needed
+    print("example instance (r=0, s=%d): est_bytes=%d n_vars_total=%d"
+          % (worst, int(est_pi[worst]), int(n_vars_total[worst])))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run the instrumentation and capture the pin**
+
+Run: `pixi run -e dev python scratch/diag_315_realcorpus.py 2>&1 | tee scratch/diag_315_out.txt`
+Expected observations to record: `is Svar2Haps: True`; `est+ovh-real` goes **negative** (the overflow), and `per_inst_gap` stays roughly constant as N grows (⇒ per-instance under-count, not per-chunk). Compare `sum n_vars_total (estimate M)` against the emitted window count — a mismatch (M ≠ W) localizes the divergence to the variant-count path; if M == W but bytes still under-count, the divergence is in `ref_span`/`alt_alleles`. If the per-instance decomposition needs the emitted `W`, extend the script to read `ref_slot.seq_offsets`/`var_offsets` per instance (the `_FlatVariantWindows` layout) and diff against `n_vars_total`.
+
+- [ ] **Step 5: Write the findings doc (the pin)**
+
+Create `docs/superpowers/specs/2026-07-23-phase0-realcorpus-findings.md` recording: confirmation the corpus opens as `Svar2Haps`; the `est/overhead/real` table across N with the sign of the gap and the per-instance slope; **the pinned diverging term** (M-vs-W count, or `ref_span`, or `alt_alleles`, or `p_eff`/ploidy grouping) with the numbers that localize it; the captured `(r_idx, s_idx)` and its variant record class (dense-vs-vk range, `ilen`, ALT, genotype/`unphased_union` pattern); and the **fixture decision** — whether a synthetic `.svar2` store can reproduce the pinned class (preferred) or a real-corpus slice is required (with size/policy note). End with an explicit statement of what Task 3 must change and what Task 2's fixture must contain.
+
+- [ ] **Step 6: Commit the findings doc (docs-only)**
+
+```bash
+git add docs/superpowers/specs/2026-07-23-phase0-realcorpus-findings.md
+git commit --no-verify -m "docs(spec): #315 Phase 0 on real corpus — pin the SVAR2 estimate divergence"
+```
+(Scratch under `scratch/` is left uncommitted; confirm `scratch/` is gitignored or add it to `.git/info/exclude`.)
+
+---
+
+### Task 2: Failing SVAR2 slot-fit test (TDD red — lock the bug in-tree)
+
+Add SVAR2 coverage to the slot-fit property harness so #315 is reproduced by the test suite itself, and confirm it **fails** before the fix. Fixture source follows Task 1's decision.
+
+**Files:**
+- Modify: `tests/conftest.py` (add `phased_svar2_gvl` fixture)
+- Modify: `tests/unit/test_slot_fit_property.py:58-63` (add the SVAR2 case)
+
+**Interfaces:**
+- Consumes: Task 1's fixture decision + pinned record class; existing `_views(ds)` and `_assert_upper_bound(view)` in `test_slot_fit_property.py`; `gvl.write` with a `.svar2` source; the `svar2_store` recipe at `tests/test_svar2_reconstruct.py:34`; `reference` fixture.
+- Produces (consumed by Task 3): a red test `test_slot_fit_svar2_backend` that goes green exactly when the estimate becomes an upper bound on the `Svar2Haps` path.
+
+- [ ] **Step 1: Add the SVAR2 dataset fixture**
+
+In `tests/conftest.py`, add a fixture that produces an **SVAR2-format** gvl dataset (opens as `Svar2Haps`) reproducing the Phase-0 record class. Preferred synthetic form (adapt the `svar2_store` recipe at `tests/test_svar2_reconstruct.py:34` to build a `.svar2` store, then `gvl.write` from it so `metadata["svar2_link"]` is set):
+
+```python
+@pytest.fixture(scope="session")
+def phased_svar2_gvl(tmp_path_factory, reference, synthetic_case) -> Path:
+    """A gvl dataset written from a .svar2 source -> opens as Svar2Haps.
+    Reproduces the Phase-0-pinned record class (see
+    docs/superpowers/specs/2026-07-23-phase0-realcorpus-findings.md).
+    """
+    # Build a .svar2 store from the shared synthetic case (see
+    # tests/test_svar2_reconstruct.py::svar2_store for the genoray recipe),
+    # then write a gvl dataset from that .svar2 path.
+    svar2_path = ...  # per svar2_store recipe, including the pinned record class
+    out = tmp_path_factory.mktemp("svar2_gvl") / "ds.gvl"
+    gvl.write(out, variants=svar2_path, bed=..., reference=reference)
+    return out
+```
+
+> If Task 1 decided a synthetic store cannot reproduce the pin, instead add a fixture returning a **tiny committed real-corpus slice** (bounded regions×samples) as a test asset under `tests/data/`, and note the data-policy check in the findings doc. If neither is possible, add the SVAR2 case as `@pytest.mark.xfail(strict=True, reason="#315 SVAR2 coverage gap — see findings")` and document the gap; the plan then relies on Task 4's real-corpus e2e as the acceptance gate.
+
+- [ ] **Step 2: Add the SVAR2 slot-fit test**
+
+In `tests/unit/test_slot_fit_property.py`, after `test_slot_fit_file_backends`:
+
+```python
+def test_slot_fit_svar2_backend(phased_svar2_gvl, reference):
+    """SVAR2 datasets open as Svar2Haps via the released reconstruct path — the
+    coverage gap that let #315 through. The estimate must upper-bound the real
+    serialized payload here too."""
+    from genvarloader._dataset._svar2_haps import Svar2Haps
+    ds = gvl.Dataset.open(phased_svar2_gvl, reference=reference)
+    assert isinstance(ds._seqs, Svar2Haps), "fixture must open as Svar2Haps"
+    for view in _views(ds):
+        _assert_upper_bound(view)
+```
+
+- [ ] **Step 3: Build the extension and run the new test — expect FAIL**
+
+Run:
+```bash
+pixi run -e dev maturin develop --release
+pixi run -e dev pytest tests/unit/test_slot_fit_property.py::test_slot_fit_svar2_backend -v
+```
+Expected: **FAIL** with `AssertionError: slot under-sized: est=... overhead=... real=...` (est+overhead < real) — the in-tree reproduction of #315. If it PASSES, the fixture does not reproduce the pinned class; return to Task 1 (the synthetic fixture is insufficient → use the real-slice path).
+
+- [ ] **Step 4: Commit the failing test**
+
+```bash
+git add tests/conftest.py tests/unit/test_slot_fit_property.py
+pixi run -e dev pyrefly check python/genvarloader tests   # hook parity; must pass
+git commit -m "test(dataloader): #315 SVAR2 slot-fit reproduction (red)"
+```
+Expected: commit succeeds (the test file is red but committed intentionally as the reproduction; the pre-commit type-check still passes).
+
+---
+
+### Task 3: Layer 1 — make the estimate an upper bound on the Svar2Haps path (TDD green)
+
+Correct the `variant-windows` branch of `_output_bytes_per_instance` so its per-instance count/spans mirror what `Svar2Haps._call_svar2` emits, per Task 1's pin. Acceptance = Task 2's test flips to green with no regression elsewhere.
+
+**Files:**
+- Modify: `python/genvarloader/_dataset/_impl.py:1564-1669` (`variant-windows` branch)
+- Modify (only if no reusable count exists): `python/genvarloader/_dataset/_svar2_haps.py` (extract a per-instance emitted-window-count entry point)
+
+**Interfaces:**
+- Consumes: Task 1's pinned term; `Svar2Haps` counting (`self.n_variants`, `p_eff`, the `_call_svar2` window kernel's emitted count); Task 2's red test.
+- Produces: `test_slot_fit_svar2_backend` green; `est + slot_overhead ≥ real` holds on the `Svar2Haps` path.
+
+- [ ] **Step 1: Apply the pinned correction**
+
+Edit the `variant-windows` branch (`_impl.py:1564`). The correction shape depends on Task 1's pin; write the one the findings doc specifies. The most-likely pin (confirm against findings before applying) is that the estimate's variant count / window span must be taken from the **same quantity `Svar2Haps` emits at `p_eff`**, not the `Haps` `genotypes[r,s].to_packed()` path. Prefer **reusing** a `Svar2Haps` counting method over duplicating its `p_eff` logic (duplication is what drifted). Concretely, when `isinstance(haps_obj, Svar2Haps)`, derive `n_vars_total`/`ref_span`/`alt_alleles` from the Svar2Haps-emitted per-instance window count `W` (add a small method on `Svar2Haps` returning emitted windows per instance if none exists), so `estimate ≥ real`.
+
+> **If Task 1 pins a term this shape does not cover** (e.g. an allele-byte backend difference, or a genuinely post-reconstruction-only quantity), implement the findings doc's specified correction instead. **If the findings doc invoked the escalation branch** (estimate cannot be made a cheap upper bound), STOP and return to the user for the grow-or-split scope decision — do not force an estimate hack.
+
+- [ ] **Step 2: Build the extension and run the SVAR2 test — expect PASS**
+
+Run:
+```bash
+pixi run -e dev maturin develop --release
+pixi run -e dev pytest tests/unit/test_slot_fit_property.py::test_slot_fit_svar2_backend -v
+```
+Expected: **PASS**.
+
+- [ ] **Step 3: Run the whole slot-fit + variants/svar2 suites — expect no regression**
+
+Run:
+```bash
+pixi run -e dev pytest tests/unit/test_slot_fit_property.py tests/test_svar2_reconstruct.py tests/unit/test_producer.py tests/unit/test_producer_schema.py tests/unit/test_shm_layout.py -v
+```
+Expected: all PASS (the dummy/vcf/pgen/svar Haps cases still hold — the fix must be gated on `Svar2Haps` and not change the `Haps` estimate).
+
+- [ ] **Step 4: Commit the fix**
+
+```bash
+git add python/genvarloader/_dataset/_impl.py python/genvarloader/_dataset/_svar2_haps.py
+pixi run -e dev pyrefly check python/genvarloader tests
+git commit -m "fix(dataloader): #315 estimate upper-bounds Svar2Haps variant-windows payload"
+```
+
+---
+
+### Task 4: End-to-end verification on the real corpus + report
+
+Confirm the reported config now *works* on the real corpus, run the full tree + cargo, update predecessor docs, and post the resolution to #315.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md` (status table: Layer 1 → done)
+- Modify: `docs/superpowers/specs/2026-07-21-phase0-findings.md` (correct the "SVAR2 unreachable / every backend opens as Haps" claim; point to the real-corpus findings)
+
+**Interfaces:**
+- Consumes: the shipped fix; the real corpus symlink from Task 1.
+- Produces: a green e2e run of the exact #315 repro; updated docs; an issue update.
+
+- [ ] **Step 1: Re-run the exact reported repro on the real corpus — expect it to complete**
+
+Create `scratch/repro_315_e2e.py` (guarded `__main__`) that opens the real corpus, builds the reported view (40 regions × all samples, flat variant-windows, `ref="window"`, `alt="allele"`, `unphased_union=True`, `jitter=0`, `flank_length=128`), and iterates a few batches of `to_dataloader(batch_size=4096, mode="double_buffered")` with the default `buffer_bytes`.
+
+Run: `pixi run -e dev python scratch/repro_315_e2e.py`
+Expected: yields batches; **no** `SlotOverflowError` / `ProducerError`. (If it raises `SlotOverflowError` naming a *specific* oversized instance, the estimate is still short for that class — return to Task 1 with that instance.)
+
+- [ ] **Step 2: Full test tree + Rust**
+
+Run:
+```bash
+pixi run -e dev maturin develop --release
+pixi run -e dev pytest tests -q
+cargo test
+```
+Expected: full suite green; `cargo test` green.
+
+- [ ] **Step 3: Update predecessor docs**
+
+Edit the two predecessor specs: in `…-double-buffered-vw-slot-fit-design.md` flip the status table's Layer 1 row to ✅ done with a pointer to `2026-07-23-svar2-variant-windows-slot-fit-design.md` and the real-corpus findings; in `2026-07-21-phase0-findings.md` add a correction note that SVAR2-format-2.0.0 datasets open as `Svar2Haps` on the released `to_dataloader` path (contradicting the earlier "SVAR2 unreachable" conclusion), with the pin.
+
+- [ ] **Step 4: Commit docs + push branch**
+
+```bash
+git add docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md docs/superpowers/specs/2026-07-21-phase0-findings.md
+git commit --no-verify -m "docs(spec): #315 Layer 1 done — SVAR2 estimate fix; correct Phase 0 reachability claim"
+git push -u origin fix/315-svar2-slot
+```
+
+- [ ] **Step 5: Post the resolution to #315**
+
+Comment on #315 with: corrected repro params (SVAR2-backed corpus, `flank_length=128`, default 2 GiB `buffer_bytes`, 40×7089), the confirmed root cause (estimate used the `Haps` count; SVAR2 reconstructs via `Svar2Haps` at `p_eff`), the fix, and that the slot-fit property test now covers the SVAR2 path. (Draft in `scratch/`; post via `gh issue comment 315` after user review.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Phase 0-real (pin) → Task 1. ✅
+- Layer 1 (estimate upper bound on Svar2Haps path) → Task 3. ✅
+- Layer 2b-svar2 (property test covers SVAR2 via released path) → Task 2. ✅
+- Verify reported config works + full pytest/cargo + docs + #315 → Task 4. ✅
+- Escalation branch (grow-or-split) → Task 3 Step 1 stop-and-return-to-user guard. ✅
+- Fixture-source decision deferred to Phase 0 → Task 1 Step 5 + Task 2 Step 1 ladder. ✅
+- Non-goals (buffered/manual, Bug A, slot_overhead) → untouched; not in any task. ✅
+
+**Placeholder scan:** Task 2/3 intentionally carry a *pin-dependent* branch — this is a debug-gated plan, so the exact fix line and the exact fixture record class are outputs of Task 1, not omissions. Each such point names the precise file/function/location, the reuse target, and an executable pass/fail condition (red→green test, e2e no-overflow), plus an explicit escalation stop. The `...` in the fixture code marks the Phase-0-pinned record class and the `svar2_store` recipe to copy, both cross-referenced — not vague "implement later" work.
+
+**Type consistency:** `_output_bytes_per_instance(r, s, include_offsets=True)`, `write_chunk(buf, arrays, n_instances=...) - HEADER_RESERVED`, `slot_overhead_bytes(view)`, `_views(ds)`/`_assert_upper_bound(view)`, and `Svar2Haps`/`gvl.Dataset.open(path, reference=...)` are used identically across tasks and match the source read at plan time (`test_slot_fit_property.py`, `_impl.py:1339/1564`, `_svar2_haps.py:182/208`).

--- a/docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md
+++ b/docs/superpowers/specs/2026-07-21-double-buffered-vw-slot-fit-design.md
@@ -1,9 +1,10 @@
 # double_buffered variant-windows slot-fit (#315)
 
 **Date:** 2026-07-21
-**Status:** Partially implemented — Layers 2a/2b/2c + Phase 0 done; **Layer 1 (estimate
-fix) deferred**, blocked on the real-corpus pin. See
-[Phase 0 findings](./2026-07-21-phase0-findings.md).
+**Status:** ✅ Fully implemented — Layers 2a/2b/2c + Phase 0 done; **Layer 1 (estimate
+fix) done (2026-07-23)**, resolved via the real-corpus pin. See
+[Phase 0 findings](./2026-07-21-phase0-findings.md) and
+[2026-07-23-phase0-realcorpus-findings.md](./2026-07-23-phase0-realcorpus-findings.md).
 **Issue:** [#315](https://github.com/mcvickerlab/GenVarLoader/issues/315)
 **Branch/target:** `fix/315-double-buffered-vw-slot` → `main` (this is the *released*
 `gvl.Dataset.to_dataloader` double-buffer path, **not** StreamingDataset work — see the
@@ -255,7 +256,7 @@ for prose docs).
 | **2c** — schema-derived slot overhead (drop magic 4096) | ✅ done | `slot_overhead_bytes(dataset)` in `_slot_overhead.py`, wired into `_double_buffered_loader.py`; floored at 4096. |
 | **2a** — producer write-time guard | ✅ done | `SlotOverflowError(ValueError)` in `_shm_layout.py`; `write_chunk` translates the cryptic numpy overflow into an actionable "lower batch_size / raise buffer_bytes" error. |
 | **2b** — upper-bound property test | ✅ done | `tests/unit/test_slot_fit_property.py`; asserts `est + slot_overhead ≥ real` across ref/alt × unphased_union × flank × {dummy,VCF,PGEN,SVAR} (44 views, all pass). |
-| **1** — estimate upper-bound fix for the pinned case | ⏸ **deferred / blocked** | No reproducible divergence to fix; the design doc's hypothesized `to_packed()` mismatch is structurally impossible on the `Haps` path (Phase 0). Needs the **real Hartwig corpus** to pin, or a scope decision to adopt the **grow-or-split** escalation. Layer 1 must not proceed on a guess. |
+| **1** — estimate upper-bound fix for the pinned case | ✅ **done (2026-07-23)** | Real-corpus pin (not synthetic): the Hartwig corpus is SVAR2-format and reconstructs via `Svar2Haps`, not `Haps` — the estimate's `n_vars_total`/`ref_span`/`alt_alleles` terms all read `Svar2Haps`'s permanently-empty SVAR1-shaped placeholders (`.genotypes`/`.variants`), collapsing to a flat 32 B/instance regardless of real content. Fixed via a shared `Svar2Haps.measure_variant_payload` entry point that re-sources all three terms from the same read-bound decode/fold the reconstructor itself uses, so estimator and reconstructor cannot drift apart again. Confirmed on the real corpus: `to_dataloader(mode="double_buffered")` over the exact reported 40×7089 config now yields batches with no `SlotOverflowError`. See [2026-07-23-svar2-variant-windows-slot-fit-design.md](./2026-07-23-svar2-variant-windows-slot-fit-design.md) and [2026-07-23-phase0-realcorpus-findings.md](./2026-07-23-phase0-realcorpus-findings.md). |
 | **3** — `realign_tracks` propagation (Bug A) | ⬜ separate issue + PR | Out of scope for this PR. |
 
 **Net effect shipped so far:** the reported Hartwig config no longer fails with a cryptic

--- a/docs/superpowers/specs/2026-07-21-phase0-findings.md
+++ b/docs/superpowers/specs/2026-07-21-phase0-findings.md
@@ -4,6 +4,25 @@
 **Issue:** [#315](https://github.com/mcvickerlab/GenVarLoader/issues/315)
 **Gate for:** Task 5 (Layer 1 — restore the estimate's upper-bound for the pinned case)
 
+> **Correction (2026-07-23):** the "SVAR2 unreachable / every backend opens as `Haps`"
+> claim below (see "Why the design doc's hypothesized mechanism does not apply here") is
+> **wrong**. The real Hartwig corpus is SVAR2-format-2.0.0 and **does** reach `Svar2Haps`
+> on the released `Dataset.open` + `to_dataloader` path — that is exactly what this doc's
+> "not available in this environment" gap was hiding. Once the real corpus was symlinked
+> in, `type(view._seqs).__name__ == "Svar2Haps"` was confirmed directly. The real
+> divergence this doc couldn't pin turned out to be `Svar2Haps`-specific: its
+> `n_vars_total`/`ref_span`/`alt_alleles` terms all read the permanently-empty
+> SVAR1-shaped placeholders (`Svar2Haps.genotypes`/`.variants`) that exist only to satisfy
+> `isinstance(_, Haps)` checks, so the estimate under-counts to a flat 32 B/instance
+> regardless of real content. This is a genuinely separate root cause from anything on the
+> `Haps` path analyzed below (which remains correct as measured — `M == K == W` still
+> holds there). See
+> [2026-07-23-phase0-realcorpus-findings.md](./2026-07-23-phase0-realcorpus-findings.md)
+> for the full pin and
+> [2026-07-23-svar2-variant-windows-slot-fit-design.md](./2026-07-23-svar2-variant-windows-slot-fit-design.md)
+> for the fix design. The rest of this document (below) is preserved as originally
+> written for the historical record of the `Haps`-path analysis, which is still accurate.
+
 ## Summary (the pin)
 
 **The estimate `Dataset._output_bytes_per_instance` is a byte-exact per-instance
@@ -84,6 +103,12 @@ logic (`_svar2_haps.py`, `p_eff = 1 if unphased_union else P`), but it is **not 
 from the released `Dataset.open` + `to_dataloader` path (#315's scope): every backend —
 including a SparseVar source — opens as `Haps`, verified this session. SVAR2 is
 StreamingDataset-only (out of scope per the design doc and CLAUDE.md).
+
+> **This paragraph is superseded — see the 2026-07-23 correction note at the top of this
+> document.** A SVAR2-format-2.0.0 dataset (the real Hartwig corpus) *does* open as
+> `Svar2Haps` on this exact released path; "every backend opens as `Haps`" was true only
+> of the backends available to this session (VCF/PGEN/SVAR1), not SVAR2, which was
+> untested here for lack of a real corpus.
 
 ## Consequence for the plan
 

--- a/docs/superpowers/specs/2026-07-23-phase0-realcorpus-findings.md
+++ b/docs/superpowers/specs/2026-07-23-phase0-realcorpus-findings.md
@@ -1,0 +1,219 @@
+# Phase 0 findings — #315 SVAR2 variant-windows slot under-count, real corpus
+
+**Date:** 2026-07-23
+**Issue:** [#315](https://github.com/mcvickerlab/GenVarLoader/issues/315)
+**Gate for:** Task 3 (correct `_output_bytes_per_instance` for the `Svar2Haps` path)
+**Predecessors:**
+- [`2026-07-21-phase0-findings.md`](./2026-07-21-phase0-findings.md) — Phase 0 on the `Haps`
+  (SVAR1/VCF/PGEN) path; concluded the estimate is a correct per-instance upper bound there,
+  and (incorrectly) that `Svar2Haps` was unreachable from the released `to_dataloader` path.
+- [`2026-07-23-svar2-variant-windows-slot-fit-design.md`](./2026-07-23-svar2-variant-windows-slot-fit-design.md) —
+  corrects that: the real Hartwig corpus is SVAR2-format and does reach `Svar2Haps`. This
+  doc is that design's "Phase 0-real" gate, executed against the real corpus.
+
+## Corpus confirmation
+
+Symlinked in from `/carter/users/dlaub/projects/aster/{data/corpus/hartwig,refs}` per the
+task brief. Opened with `gvl.Dataset.open("data/corpus/hartwig/hartwig.gvl",
+reference="refs/GRCh38.ensembl.fa.bgz")`: full shape `(1044 regions, 7089 samples)`.
+Subset to the reported 40 regions (`ds.subset_to(regions=slice(40))`), configured exactly as
+reported (flat `variant-windows`, `ref="window"`, `alt="allele"`, `flank_length=128`,
+`unphased_union=True`, `jitter=0`, tracks off):
+
+```
+reconstructor: Svar2Haps  is Svar2Haps: True
+shape: 40 regions x 7089 samples
+unphased_union: True
+var_fields: ['alt', 'ilen', 'start']
+window_opt: VarWindowOpt(flank_length=128, token_alphabet=b'ACGT', unknown_token=4, ref='window', alt='allele')
+```
+
+Confirmed: **this dataset reconstructs through `Svar2Haps`**, not `Haps`.
+
+## est / overhead / real table (growing N)
+
+Instrumentation script: `scratch/diag_315_realcorpus.py` (adapted from the brief — `view.shape`
+is already `(R, S)`; `unphased_union` lives on `view._seqs`, not `view`). For N ∈ {1, 4, 16}
+regions' worth of instances (all 7089 samples each), comparing
+`_output_bytes_per_instance(..., include_offsets=True)` against a direct `write_chunk` of the
+real reconstructed `_FlatVariantWindows`:
+
+| N (instances) | est | overhead | real | est+overhead−real | per-instance gap `(real−est)/N` |
+|---:|---:|---:|---:|---:|---:|
+| 7,089 (1 region) | 226,848 | 4,096 | 121,039,709 | **−120,808,765** | 17,042.3 |
+| 28,356 (4 regions) | 907,392 | 4,096 | 447,023,623 | **−446,112,135** | 15,732.7 |
+| 113,424 (16 regions) | 3,629,568 | 4,096 | 1,939,754,801 | **−1,936,121,137** | 17,069.8 |
+
+`est + overhead − real` is **massively negative** and grows in magnitude with N (not a fixed
+per-chunk constant): `est` itself is *exactly* `32 bytes × N` at every N (`226848/7089 =
+907392/28356 = 3629568/113424 = 32.0`), i.e. the estimate is a **flat, content-independent
+per-instance constant**, while `real` scales with N and the actual variant density (up to
+~17 KB/instance here). `per_inst_gap` stays in the same 15.7–17.1 K band across a 16×
+increase in N — this is the per-instance under-count signature the brief asks to
+distinguish from a per-chunk constant (Phase 0's `Haps`-path finding was the latter, at
+~50 B/chunk; this is the former, at **~16 KB/instance**, ~500× larger and scaling with N).
+Reported over the full 40×7089 = 283,560-instance subset this is why the real chunk
+(`n_instances=283560`) blew a single ~17 MB slot with room to spare only for the
+estimate's own delusion — the trace's `SlotOverflowError` matches the design doc's repro
+exactly.
+
+## The pinned diverging term: `n_vars_total` (M) is unconditionally 0
+
+Decomposed one region (`r=0`, all 7089 samples):
+
+```
+sum n_vars_total (estimate M): 0
+real_ploidy: 2   unphased_union: True
+sum emitted window count (W): 427592
+M == W (per-instance) all equal: False
+n mismatched instances: 7044 / 7089        # the 45 matches are (0==0): samples with no real variants in this region
+estimate's alt_alleles term (_allele_bytes_sum): all zero (sum = 0), first 5 = [0, 0, 0, 0, 0]
+sum real alt (bare) token-bytes:  388,485
+Across the FULL 40-region subset (283,560 instances): estimate's alt_alleles term all zero: True
+```
+
+**`M` (the estimate's `n_vars_total`, from `Dataset.n_variants()`) is identically `0` for
+every one of the 283,560 instances in the subset**, regardless of how many real variants
+that `(region, sample)` group actually has. `W` (the real emitted window count) is not:
+427,592 total over the single sampled region alone (mean ≈ 60/instance, but heavily skewed —
+see the worst instance below).
+
+### Root cause (traced to source, not just measured)
+
+`Dataset.n_variants()` (`_impl.py:1293-1337`) does `n_vars =
+self._seqs.n_variants[r_idx, s_idx]` for any `isinstance(self._seqs, Haps)` — `Svar2Haps`
+*is* a `Haps` subclass, so it takes this branch. But `Svar2Haps.__post_init__`
+(`_svar2_haps.py:208`) sets `self.n_variants = self.genotypes.lengths`, and
+`self.genotypes` is the **permanently-empty SVAR1-shaped placeholder** `Svar2Haps.from_path`
+constructs once at open time (`_svar2_haps.py:281-285`):
+
+```python
+empty_geno = Ragged.from_offsets(
+    np.empty(0, V_IDX_TYPE), (R, S, P, None), np.zeros(R * S * P + 1, np.int64)
+)
+```
+
+— all offsets zero, by construction, for every `(region, sample, ploid)` group, forever. It
+exists **only** so the many `isinstance(_, Haps)` / `case Haps()` checks scattered through
+`_impl.py`/`_haps.py` keep type-checking; `Svar2Haps` never populates it with real per-region
+membership, because SVAR2 reconstructs read-bound directly from the on-disk `.svar2` store via
+Rust FFI (`decode_variants_from_svar2_readbound`), not through an in-memory sparse genotypes
+table the way SVAR1 `Haps` does. So `.lengths` (`seqpro.rag.Ragged.lengths`, which derives
+purely from the offsets array) is an all-zero array of shape `(R, S, P)` — **not** a lazily-
+computed real count. `M = 0` always.
+
+The same empty placeholder poisons two more terms in `_output_bytes_per_instance`'s
+`"variant-windows"` branch (`_impl.py:1564-1743`), independently of `n_vars_total`:
+
+- **`alt_alleles`** (`_impl.py:1590-1594`) calls `Haps._allele_bytes_sum(ds_idx, "alt")`
+  (`_haps.py:770-809`), which reads `self.genotypes[r, s].to_packed()` (empty → `v_idxs`
+  always empty) *and* `self.variants.alt.offsets` — `self.variants` is likewise a
+  `dummy_variants` placeholder with an empty `RaggedAlleles` (`_svar2_haps.py:286-296`).
+  **Directly confirmed by measurement**: `haps._allele_bytes_sum(ds_idx, "alt")` is
+  identically `0` for all 283,560 instances in the subset (printed above).
+- **`ref_span`** for `ref="window"` (`_impl.py:1605-1642`) computes
+  `haps_obj.genotypes[r_idx_grp, s_idx_grp].to_packed()` — the *same* empty placeholder —
+  so `v_idxs` is empty and `ref_span = 0` for every instance too (same code path, not
+  separately re-measured but structurally identical to the `alt_alleles` case above; both
+  read `self.genotypes` with the same all-zero offsets).
+
+With `n_vars_total = ref_span = alt_alleles = 0` for every instance, the entire payload term
+of the branch collapses to 0 bytes; the only surviving (nonzero) contribution is the
+schema-derived, content-independent offset-array overhead:
+`8 bytes × folded_ploidy(1) × (n_scalar_fields(2: start+ilen) + n_window_slots(2)) = 32
+bytes/instance` — which is exactly the flat `32 × N` observed above. **This is not a
+`p_eff`/ploidy-grouping bug** (the folded-ploidy bookkeeping is internally consistent, and
+the design doc's original `p_eff` hypothesis is refuted by this trace) **and not a
+formula bug in the `ref_span`/`alt_alleles` expressions themselves** — it is a **wrong
+data source**: three independent terms all read `Svar2Haps.genotypes`/`.variants`, objects
+that are structurally incapable of ever holding real content for this reconstructor.
+
+### The captured worst instance
+
+`(r_idx=0, s_idx=5856)`, within the sampled region:
+
+```
+est_bytes=32   n_vars_total (M)=0   W (real emitted windows)=4438
+real_ref_tok=1,140,590 bytes   real_alt_tok=4,544 bytes
+```
+
+`real_ref_tok / W = 1,140,590 / 4,438 = 257.0` exactly = `1 + 2×flank_length(128)` — i.e.
+**every one of the 4,438 real variants in this instance has ref-window span exactly 1**
+(no net deletion: SNVs and/or non-deleting insertions, `ilen ≥ 0` for all of them).
+`real_alt_tok / W = 4,544 / 4,438 ≈ 1.02` bytes/variant — almost all bare ALT alleles are
+1 byte (biallelic SNVs), with a handful of longer (multi-byte) insertion ALTs pulling the
+mean above 1. `W = 4,438` is the `unphased_union` fold of `P=2` haplotypes via
+`var_off[::P]` in `Svar2Haps._reconstruct_variant_windows` (`_svar2_haps.py:1010-1013`) —
+the **naive sum of both haplotypes' per-sample variant counts, no dedup** — which is
+semantically the same "no-dedup union" contract `Dataset.n_variants()`'s own docstring
+describes for the `Haps` path (`_impl.py:1323-1327`); the two are not in semantic conflict,
+`Svar2Haps` just never reports its side of that count into the shared `self.n_variants`.
+This sample sits in a SNP-dense region (likely covering a segmental-duplication /
+high-variant-density locus of the tumor cohort) with `P=2, unphased_union=True` — a common,
+unremarkable record class, not an edge case (multiallelic, exotic ALT, or missing-genotype
+pattern). **The overflow is triggered by ordinary dense SNP content, not a rare record.**
+
+## Fixture decision: synthetic — confirmed, not just recommended
+
+The defect is **structural and content-independent** (it is a wrong data *source*, not a
+formula error keyed to any particular record shape), so it does not require reproducing the
+real corpus's specific variant density or record types. Verified directly with
+`scratch/diag_315_synthetic.py`, built from the exact fixture pattern
+`tests/dataset/test_svar2_dataset.py` already uses (`_src`/`svar2_fixture`/`bed`: a 40 bp
+`chr1` reference, a 4-record VCF — SNP, insertion, dense SNP, deletion — 2 samples,
+converted via `genoray._core.run_conversion_pipeline` into a `.svar2` store), opened via
+the release path (`gvl.write` + `gvl.Dataset.open(...).with_seqs("variant-windows", opt)`,
+`ref="window", alt="allele", unphased_union=True`) over a single 15 bp region:
+
+```
+reconstructor: Svar2Haps  is Svar2Haps: True
+estimate n_vars_total (M) per sample: [0, 0]
+estimate bytes per sample: [32, 32]
+real total payload bytes (both samples): 445
+estimate total (both samples): 64
+PIN REPRODUCES on synthetic fixture: True
+```
+
+**A tiny synthetic SVAR2 store — 1 region, 2 samples, 4 ordinary variants — reproduces the
+identical `M=0`-while-`real>0` defect** at the same 32-bytes/instance constant seen on the
+real corpus. **Fixture ladder option 1 (preferred, per the design doc) applies: no real-data
+slice is required.** `tests/dataset/test_svar2_dataset.py` already has ready-made
+`svar2_fixture`/`bed`/`_src` pytest fixtures building exactly this kind of store and already
+exercises `with_seqs("variant-windows", ...)` on it (`_open_windows_pair`,
+`test_svar2_variant_windows_ref_window_matches_svar1`) — Task 2 can reuse that
+fixture/pattern directly rather than inventing a new one.
+
+## What Task 3 must change
+
+In `Dataset._output_bytes_per_instance`'s `"variant-windows"` branch (`_impl.py`, currently
+`elif seq_kind == "variant-windows":` at line 1564), when `isinstance(self._seqs,
+Svar2Haps)`, **do not** derive `n_vars_total` from `self.n_variants(...)` (→
+`Svar2Haps.n_variants`, permanently empty) nor `ref_span`/`alt_alleles` from
+`haps_obj.genotypes[...]`/`Haps._allele_bytes_sum` (same empty placeholders). Instead source
+all three from the real per-instance decode `Svar2Haps` itself uses at read time
+(`decode_variants_from_svar2_readbound`, already invoked by
+`_reconstruct_variant_windows`/`_reconstruct_variants`): factor out a lightweight
+count/measure entry point (real per-instance `var_off` boundaries — folded by the same
+`p_eff = 1 if unphased_union else P` rule `_reconstruct_variant_windows` already applies —
+plus `ilen`-derived ref span and ALT byte lengths) that both the reconstructor and the
+estimator call, so the two cannot drift apart again (this mirrors the design doc's stated
+preference: "prefer reusing `Svar2Haps`' own counting entry point over duplicating its
+logic"). The `Haps`-path branch logic proved correct in the predecessor Phase 0 should be
+left untouched; only the `Svar2Haps` data source needs replacing. Also apply the *same* fix
+to the `"variants"` (non-window) branch (`_impl.py:1437-1563`), which reads
+`_allele_bytes_sum` unconditionally too, and is presumably similarly under-counting for
+`Svar2Haps` even though it is out of this issue's reported repro.
+
+## What Task 2's fixture must contain
+
+A `Svar2Haps`-backed dataset (any `.svar2` store — the existing
+`tests/dataset/test_svar2_dataset.py::svar2_fixture` pattern is sufficient and preferred: a
+handful of regions/samples, ≥1 ordinary variant of any type) opened through the released
+`Dataset.open(...).with_seqs("variant-windows", VarWindowOpt(...))` path with
+`ref="window"` (or `alt="window"`) and/or `var_fields` including `"alt"`/`"ilen"`, at least
+one `(region, sample)` group with `n_variants > 0`, `unphased_union` both `True` and
+`False`. The regression test asserts `sum(_output_bytes_per_instance(include_offsets=True))
++ slot_overhead_bytes(view) >= real write_chunk payload bytes` — **red** before Task 3 (per
+this doc, the estimate side is `32 × n_instances` regardless of real content, so any
+instance with a real variant already fails the inequality) and **green** after. No
+real-corpus data needs to be committed.

--- a/docs/superpowers/specs/2026-07-23-svar2-variant-windows-slot-fit-design.md
+++ b/docs/superpowers/specs/2026-07-23-svar2-variant-windows-slot-fit-design.md
@@ -1,0 +1,190 @@
+# SVAR2 variant-windows slot-fit — #315 Layer 1 (the real-corpus unblock)
+
+**Date:** 2026-07-23
+**Status:** Approved design — implementation pending.
+**Issue:** [#315](https://github.com/mcvickerlab/GenVarLoader/issues/315)
+**Branch/target:** `fix/315-svar2-slot` → `main`
+**Predecessors (already on `main`):**
+- Design: [`2026-07-21-double-buffered-vw-slot-fit-design.md`](./2026-07-21-double-buffered-vw-slot-fit-design.md) (Layers 2a/2b/2c shipped, **Layer 1 deferred**)
+- Phase 0: [`2026-07-21-phase0-findings.md`](./2026-07-21-phase0-findings.md) (divergence declared unreproducible synthetically)
+
+This spec resolves the **deferred Layer 1** of the predecessor design, using the real
+Hartwig corpus that was unavailable in the earlier session.
+
+## What changed since the predecessor design
+
+The predecessor shipped the mechanism hardening (schema-derived `slot_overhead`, a
+`SlotOverflowError` write-time guard, and an `est + slot_overhead ≥ real` property test)
+but **deferred Layer 1** — the actual estimate correction — because it could not
+reproduce the real-corpus divergence. Phase 0 concluded (findings §"Why the design doc's
+hypothesized mechanism does not apply here"):
+
+> every backend — including a SparseVar source — opens as `Haps` … SVAR2 is
+> StreamingDataset-only (out of scope).
+
+**That conclusion is incorrect for SVAR2-format (`format_version 2.0.0`) datasets.** It
+was reached by testing only VCF / PGEN / old-format-SVAR fixtures, all of which *do* open
+as `Haps`. The real Hartwig corpus is SVAR2-backed and is now available, which both
+falsifies the assumption and supplies the missing fixture.
+
+### Evidence
+
+1. **The corpus is SVAR2-backed.** `data/corpus/hartwig/hartwig.gvl/metadata.json` has
+   `svar2_link` set (`svar_link: null`), `format_version 2.0.0`, ploidy 2, and a
+   `genotypes/svar2_ranges/` genotype store (`{dense,vk}_{snp,indel}_range.npy`,
+   `svar2_meta.json`).
+
+2. **`Svar2Haps` IS reachable from the released `to_dataloader` path.**
+   `_dataset/_reconstruct.py:149` — `if isinstance(self.haps, Svar2Haps): return
+   self._call_svar2(...)`; `_dataset/_impl.py:350` branches on `isinstance(self._seqs,
+   Svar2Haps)` too. So `Dataset.open(...).to_dataloader(mode="double_buffered")` on this
+   corpus reconstructs through `_call_svar2`, **not** the `Haps` path Phase 0 measured.
+
+3. **The estimate under-counts massively on this corpus (the #315 overflow).** Re-running
+   the exact reported config (40 regions × 7089 samples, flat `variant-windows`,
+   `ref="window"`, `alt="allele"`, `unphased_union=True`, `jitter=0`, tracks OFF,
+   `flank_length=128`, default `buffer_bytes=2 GiB`, `batch_size=4096`) against
+   genvarloader **0.40.1** (≈ current `main`; includes the 2a `SlotOverflowError`):
+
+   ```
+   RuntimeError: ProducerError (SlotOverflowError): serialized chunk (n_instances=283560)
+   does not fit the shared-memory slot of 18156032 bytes. The per-instance byte estimate
+   under-sized this slot.
+   ```
+
+   **283560 = 40 × 7089** — i.e. the estimate packed the *entire* subset into **one**
+   ~17 MB slot (~64 B/instance). At `flank_length=128` each emitted window is ≈257 ref
+   tokens plus allele + offset bytes, so the true payload is tens of MB. The estimate is
+   accounting ≈0 variant-data bytes per instance. This is a large **per-instance**
+   under-count, not the per-chunk constant Phase 0 found on the `Haps` path.
+
+4. **Phase 0 already flagged the mechanism.** Findings §"Why … does not apply here" notes
+   `Svar2Haps` has separate variant-counting logic (`_svar2_haps.py`, `p_eff = 1 if
+   unphased_union else P`) — it simply assumed that path was unreachable. It is reachable;
+   that separate counting is the prime suspect for the divergence.
+
+## Root-cause hypothesis (to be pinned, not assumed)
+
+`Dataset._output_bytes_per_instance`'s `variant-windows` branch derives its per-instance
+window count and allele bytes from the **`Haps`** quantities (`n_variants =
+genotypes.lengths`; `to_packed().data`), for which Phase 0 proved the identity
+`M == K == W`. On an SVAR2 dataset the reconstruction runs through `Svar2Haps` /
+`_call_svar2`, whose emitted window count and/or `unphased_union` `p_eff` handling differ
+from the `Haps` quantities the estimate uses — so `M` (estimate) < `W` (emitted), and the
+estimate is no longer an upper bound. **The exact diverging term (window count vs `p_eff`
+vs allele bytes) is pinned by Phase-0-on-real-corpus before any fix is written** — the
+predecessor plan's rule "Layer 1 does not proceed on a guess" is retained.
+
+## Goals / non-goals
+
+**Goals**
+- Make `double_buffered` variant-windows **work** on the real SVAR2 Hartwig corpus at the
+  reported config — the reported command completes instead of raising `SlotOverflowError`.
+- Restore `estimate + slot_overhead ≥ real serialized bytes` as a **provable upper bound
+  on the SVAR2 read path**, defined operationally by the extended property test passing.
+- Close the coverage gap **by test**: the slot-fit property test must exercise an SVAR2
+  dataset through the released `to_dataloader`/reconstruct path, so this class of drift is
+  caught in CI.
+
+**Non-goals**
+- Changes to `buffered` / `manual` modes (they don't serialize into fixed slots).
+- Bug A (`realign_tracks` propagation) — remains its own issue + PR.
+- The producer-side grow-or-split auto-recovery — still deferred; only the escalation
+  branch if Layer 1 proves intractable (below).
+- Re-deriving `slot_overhead` (Layer 2c) — already shipped and correct; unchanged.
+
+## Design
+
+### Phase 0-real — Pin the divergence (gate)
+
+In the worktree, with the real corpus symlinked in (as done for the aster env) and Rust
+built (`maturin develop --release`), run an instrumentation script (adapt the predecessor's
+referenced `diag_315_realcorpus.py`; it is scratch, not committed) against the Hartwig
+dataset at the failing config. For a sample of instances — and for at least one instance
+from a chunk that overflows — capture and compare:
+
+- `M` = the estimate's per-instance window/variant count (`_output_bytes_per_instance`
+  internals) and its byte breakdown (ref_span, allele bytes, flank, offsets);
+- `W` = the window count actually emitted by `_call_svar2` / the Rust svar2 window kernel
+  (`len(seq_offsets) − 1` of the produced ref slot), and the real serialized payload from a
+  direct `write_chunk`;
+- the reconstructor class actually in use (assert `Svar2Haps`);
+- `d(real − est)/d(inst)` across instance counts, to confirm the under-count is
+  per-instance (expected from Evidence §3), not the per-chunk constant Phase 0 saw.
+
+**Output:** the offending `(r_idx, s_idx)`, the diverging term, the variant record class
+(ilen / ALT / genotype pattern / dense-vs-vk range) driving it, and whether it is
+`unphased_union`-dependent. This dump is the recipe for the Layer-1 fix and the regression
+fixture. Layer 1 does not start until this pins the term.
+
+### Layer 1 — Make the estimate an upper bound on the SVAR2 path
+
+Correct the `variant-windows` branch of `Dataset._output_bytes_per_instance`
+(`_dataset/_impl.py`) so that, when the dataset reconstructs via `Svar2Haps`, its
+per-instance window count / allele-byte accounting is derived from the **same quantity
+`_call_svar2` emits** (mirroring `Svar2Haps`' counting, incl. its `p_eff = 1 if
+unphased_union else P` rule), making `M ≥ W` and the estimate a provable upper bound for
+that record class and backend. Prefer reusing `Svar2Haps`' own counting entry point over
+duplicating its logic, so the estimate and reconstructor cannot drift again. "Correct" is
+defined operationally: the Layer-2b-extended property test (below) passes on a fixture
+reproducing the pinned record class.
+
+### Layer 2b-svar2 — Extend the upper-bound property test (the durable fix)
+
+Extend `tests/unit/test_slot_fit_property.py` to add an **SVAR2 dataset opened through the
+released `Dataset.open` + `to_dataloader`/reconstruct path** (not the synthetic `Haps`
+matrix it covers today) and assert, for every chunk,
+
+```
+sum(_output_bytes_per_instance(include_offsets=True)) + slot_overhead(schema)
+    ≥ real write_chunk cursor − HEADER_RESERVED
+```
+
+across `ref`/`alt` ∈ {window, allele}, `unphased_union` on/off, `flank_length` ∈ {small,
+128}, and the Phase-0-pinned record class. This is the coverage gap that let #315 through.
+
+**Fixture source — decided by Phase 0, not now:**
+1. *Preferred* — a small **synthetic SVAR2 fixture** reproducing the pinned record class,
+   built through the project's generator + the SVAR2 write path, if that path can produce
+   the divergence.
+2. *Fallback* — a **tiny committed slice of the real corpus** (few regions × few samples,
+   size-bounded, checked whether license/data policy permits committing) as a test asset.
+3. *If neither is cheap* — document the backend-coverage gap explicitly in the test and
+   spec (matching the predecessor's "note the gap rather than claim coverage" rule) and
+   rely on Layer 2a to keep any residual overflow loud.
+
+### Verify & report
+
+- The reported config now completes: re-run the repro; assert it yields batches and does
+  **not** raise `SlotOverflowError`.
+- Full `pixi run -e dev pytest tests -q` + `cargo test`; rebuild Rust
+  (`maturin develop --release`) before any pytest importing the extension.
+- Update the predecessor spec's status table (Layer 1 → done) and **correct** the Phase 0
+  findings' "SVAR2 unreachable / every backend opens as Haps" claim with a pointer here.
+- Post the resolution to #315: corrected repro params, confirmed SVAR2 root cause, fix.
+
+## Escalation branch (unchanged)
+
+If Phase 0 shows the estimate genuinely cannot cheaply mirror `Svar2Haps`' emitted count
+(e.g. it depends on data only known after reconstruction), fall back to the deferred
+producer-side **grow-or-split** auto-recovery — a scope change requiring re-approval. The
+Evidence above points to a clean counting mismatch, so Layer 1 is expected to be tractable.
+
+## Risks & open questions
+
+- **Fixture reproducibility.** Whether a *synthetic* SVAR2 fixture can reproduce the pin is
+  itself a Phase-0 output; the fallback ladder above handles a negative result.
+- **`Svar2Haps` counting reuse.** If `Svar2Haps` has no clean per-instance count entry
+  point to reuse, Layer 1 must factor one out (small refactor) rather than duplicate the
+  `p_eff` logic — duplication is what drifted in the first place.
+- **Committing real data.** The fallback fixture must respect data-sharing policy and size
+  limits; if disallowed, drop to option 3.
+- **`p_eff` vs ploidy.** The corpus is ploidy 2 with `unphased_union=True` (→ `p_eff = 1`);
+  the fix and test must cover both `unphased_union` values so the ploidy-collapse path is
+  not the only one exercised.
+
+## Docs & skill upkeep
+
+No public-API change expected (internal estimate + test). Confirm `docs/source/*` and
+`skills/genvarloader/SKILL.md` need no change; add a conventional-commit changelog entry.
+```

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -1454,6 +1454,24 @@ class Dataset:
             # union semantics require either way.
             real_ploidy = haps_obj.genotypes.shape[-2]
 
+            # Svar2Haps: self.n_variants (-> self.genotypes.lengths) and
+            # _allele_bytes_sum (-> self.genotypes[...]/self.variants.alt) both
+            # read permanently-empty SVAR1-shaped placeholders for this
+            # reconstructor (see Svar2Haps.from_path) -- they are never
+            # populated because svar2 reconstructs read-bound straight from the
+            # on-disk store. Re-derive n_vars_total (and, below, the alt byte
+            # sum) from the SAME per-instance decode
+            # measure_variant_payload/_reconstruct_variants use, instead of
+            # those placeholders (issue #315).
+            from ._svar2_haps import Svar2Haps
+
+            svar2_alt_bytes: NDArray[np.int64] | None = None
+            if isinstance(haps_obj, Svar2Haps):
+                regions_arr = self._full_regions[r_idx]
+                n_vars_total, _svar2_ref_span_unused, svar2_alt_bytes = (
+                    haps_obj.measure_variant_payload(ds_idx, regions_arr)
+                )
+
             # "start" is unconditionally emitted by the flat/ragged variant
             # builders regardless of var_fields (see get_variants_flat's
             # "start: ALWAYS"), so charge it independent of var_fields
@@ -1471,9 +1489,17 @@ class Dataset:
                     dosage_dtype = haps_obj.dosages.data.dtype
                     total += n_vars_total * dosage_dtype.itemsize
                 elif f in ("alt", "ref"):
-                    # Allele scan: _allele_bytes_sum returns (len(ds_idx) * real_ploidy,).
-                    per_ploid = haps_obj._allele_bytes_sum(ds_idx, f)
-                    total += per_ploid.reshape(-1, real_ploidy).sum(-1)
+                    if svar2_alt_bytes is not None:
+                        # Svar2Haps: "ref" is never in available_var_fields (its
+                        # .variants.ref is always None), so this is always "alt".
+                        assert f == "alt", (
+                            "Svar2Haps does not support the bare 'ref' var_field"
+                        )
+                        total += svar2_alt_bytes
+                    else:
+                        # Allele scan: _allele_bytes_sum returns (len(ds_idx) * real_ploidy,).
+                        per_ploid = haps_obj._allele_bytes_sum(ds_idx, f)
+                        total += per_ploid.reshape(-1, real_ploidy).sum(-1)
                 else:
                     # INFO column: numeric, known dtype from on-disk schema.
                     # _info_field_dtype guards Svar2Haps, whose .variants is a
@@ -1583,16 +1609,34 @@ class Dataset:
             # what unphased_union's un-deduped union semantics require either
             # way (see the "variants" branch above for the same fix).
             real_ploidy = haps_obj.genotypes.shape[-2]
-            # alt bytes are always stored on disk (unlike ref); exact sum
-            # reused by both alt="window" (flank5 . alt . flank3) and
-            # alt="allele" (bare alt), same primitive the "variants" branch
-            # uses for alt/ref.
-            alt_alleles = (
-                haps_obj._allele_bytes_sum(ds_idx, "alt")
-                .reshape(-1, real_ploidy)
-                .sum(-1)
-            )
-            if opt.ref == "allele":
+
+            # Svar2Haps: self.n_variants/self.genotypes/self.variants are
+            # permanently-empty SVAR1-shaped placeholders for this
+            # reconstructor (see Svar2Haps.from_path) -- svar2 reconstructs
+            # read-bound straight from the on-disk store, never populating
+            # them. Re-derive n_vars_total/ref_span/alt_alleles from the SAME
+            # per-instance decode _reconstruct_variant_windows uses, instead of
+            # those placeholders (issue #315). ref="allele" is unreachable
+            # here for Svar2Haps -- with_seqs already rejects it (its
+            # .variants.ref is always None) -- so ref="window" (the ilen-span
+            # branch below) is the only case that needs covering.
+            from ._svar2_haps import Svar2Haps
+
+            if isinstance(haps_obj, Svar2Haps):
+                regions_arr = self._full_regions[r_idx]
+                n_vars_total, ref_span, alt_alleles = haps_obj.measure_variant_payload(
+                    ds_idx, regions_arr
+                )
+            elif opt.ref == "allele":
+                # alt bytes are always stored on disk (unlike ref); exact sum
+                # reused by both alt="window" (flank5 . alt . flank3) and
+                # alt="allele" (bare alt), same primitive the "variants" branch
+                # uses for alt/ref.
+                alt_alleles = (
+                    haps_obj._allele_bytes_sum(ds_idx, "alt")
+                    .reshape(-1, real_ploidy)
+                    .sum(-1)
+                )
                 # bare REF allele bytes. with_seqs('variant-windows', ...)
                 # already rejects ref="allele" when self.variants.ref is
                 # None, so _allele_bytes_sum is safe to call here.
@@ -1602,6 +1646,15 @@ class Dataset:
                     .sum(-1)
                 )
             else:
+                # alt bytes are always stored on disk (unlike ref); exact sum
+                # reused by both alt="window" (flank5 . alt . flank3) and
+                # alt="allele" (bare alt), same primitive the "variants" branch
+                # uses for alt/ref.
+                alt_alleles = (
+                    haps_obj._allele_bytes_sum(ds_idx, "alt")
+                    .reshape(-1, real_ploidy)
+                    .sum(-1)
+                )
                 # ref="window" reads [start-L, end+L) from the *reference
                 # genome*, not the stored REF allele -- which may not even be
                 # present (e.g. an ALT-only Haps, like get_dummy_dataset()).

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -1467,6 +1467,13 @@ class Dataset:
 
             svar2_alt_bytes: NDArray[np.int64] | None = None
             if isinstance(haps_obj, Svar2Haps):
+                # NB: unlike the reference/track branches, we do NOT widen
+                # regions_arr by self.jitter here. The Svar2Haps read-bound
+                # decode guards jitter>0 (raises NotImplementedError, "right-
+                # clip"; see _svar2_haps.py and its jitter_guard tests), so this
+                # branch only ever runs at jitter=0 and the raw region is the
+                # exact decode window. If that guard is ever lifted (right-clip
+                # added), widen by self.jitter here to keep est an upper bound.
                 regions_arr = self._full_regions[r_idx]
                 n_vars_total, _svar2_ref_span_unused, svar2_alt_bytes = (
                     haps_obj.measure_variant_payload(ds_idx, regions_arr)
@@ -1623,6 +1630,13 @@ class Dataset:
             from ._svar2_haps import Svar2Haps
 
             if isinstance(haps_obj, Svar2Haps):
+                # NB: not widened by self.jitter (unlike the reference/track
+                # branches) -- the Svar2Haps read-bound decode guards jitter>0
+                # (raises NotImplementedError, "right-clip"; see _svar2_haps.py
+                # and its jitter_guard tests), so this branch only runs at
+                # jitter=0 and the raw region is the exact decode window. If that
+                # guard is lifted, widen by self.jitter here to keep est an
+                # upper bound.
                 regions_arr = self._full_regions[r_idx]
                 n_vars_total, ref_span, alt_alleles = haps_obj.measure_variant_payload(
                     ds_idx, regions_arr

--- a/python/genvarloader/_dataset/_svar2_haps.py
+++ b/python/genvarloader/_dataset/_svar2_haps.py
@@ -798,6 +798,111 @@ class Svar2Haps(Haps[_H]):
             typed.append(np.asarray(bufs[j], np.uint8).view(dt))
         return typed
 
+    def measure_variant_payload(
+        self, idx: NDArray[np.integer], regions: NDArray[np.integer]
+    ) -> tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.int64]]:
+        """Per-instance variant count, ref-window span, and ALT-allele byte sum.
+
+        Runs the SAME per-instance decode (``decode_variants_from_svar2_readbound``)
+        that :meth:`_reconstruct_variants`/:meth:`_reconstruct_variant_windows` use, so
+        callers that only need cheap per-instance *measures* -- not the full
+        reconstructed output -- can share this single counting entry point instead of
+        re-deriving the ``p_eff``/fold logic (or, worse, reading
+        ``self.genotypes``/``self.variants``, which are permanently-empty SVAR1-shaped
+        placeholders for this reconstructor -- see issue #315). Used by
+        ``Dataset._output_bytes_per_instance`` for the ``"variants"``/``"variant-windows"``
+        estimate branches.
+
+        Args:
+            idx: Flat ``(region, sample)`` query indices for the block.
+            regions: ``(n_regions, 3)`` array of ``(contig_id, start, end)``.
+
+        Returns:
+            ``(n_vars_total, ref_span_sum, alt_bytes_sum)``, each shape ``(len(idx),)``
+            int64:
+
+            - ``n_vars_total``: total variant count per instance, folded across ploidy
+              per the ``unphased_union`` union-count contract (naive sum of
+              per-haplotype counts, no dedup) -- the same semantics
+              ``Dataset.n_variants()`` documents for the SVAR1 path.
+            - ``ref_span_sum``: sum of ``1 + max(-ilen, 0)`` (the ``ref="window"``
+              per-variant span) over the instance's variants.
+            - ``alt_bytes_sum``: sum of bare ALT-allele byte lengths over the
+              instance's variants.
+        """
+        regions = np.asarray(regions, np.int32)
+        P = int(self.genotypes.shape[-2])
+        b = len(idx)
+        R_all, S_all = int(self.genotypes.shape[0]), int(self.genotypes.shape[1])
+        r_q, si_q = np.unravel_index(np.asarray(idx), (R_all, S_all))
+        contig_ids = regions[:, 0].astype(np.int64)
+        groups = self._contig_groups(contig_ids)
+
+        n_vars_total = np.zeros(b, np.int64)
+        ref_span_sum = np.zeros(b, np.int64)
+        alt_bytes_sum = np.zeros(b, np.int64)
+
+        for ci, qsel in groups:
+            gi = self._gather_inputs(r_q[qsel], si_q[qsel], regions[qsel], P)
+            work_bytes = max(
+                len(qsel) * P * 64,
+                sum(
+                    int(np.maximum(0, ranges[:, 1] - ranges[:, 0]).sum())
+                    for ranges in gi[2:]
+                )
+                * 16,
+            )
+            pos, ilen, alt_bytes, str_off, var_off, field_bufs, field_isizes = (
+                decode_variants_from_svar2_readbound(
+                    self.store,
+                    self.ds_contigs[ci],
+                    gi[0],
+                    gi[1],
+                    gi[2],
+                    gi[3],
+                    gi[4],
+                    gi[5],
+                    P,
+                    [],  # no extra fields needed -- only counts/spans/bytes
+                    np.ascontiguousarray(regions[qsel, 2], np.uint32),
+                    self.filter == "exonic",
+                    should_parallelize(work_bytes),
+                )
+            )
+            ilen = np.asarray(ilen, np.int32)
+            str_off = np.asarray(str_off, np.int64)
+            var_off = np.asarray(var_off, np.int64)
+
+            # Fold ploidy per the SAME p_eff/union rule the reconstructors apply:
+            # var_off[::P] takes each query's FIRST haplotype-row start offset,
+            # which (haplotype rows are contiguous per query) equals the start of
+            # the whole P-haplotype block -- i.e. the un-deduped union count.
+            row_off = (
+                np.ascontiguousarray(var_off[::P]) if self.unphased_union else var_off
+            )
+            row_lens = np.diff(row_off)
+
+            span = (1 + np.maximum(-ilen, 0)).astype(np.int64)
+            span_csum = np.concatenate([[np.int64(0)], np.cumsum(span, dtype=np.int64)])
+            row_span = span_csum[row_off[1:]] - span_csum[row_off[:-1]]
+
+            bytelen = np.diff(str_off)
+            byte_csum = np.concatenate(
+                [[np.int64(0)], np.cumsum(bytelen, dtype=np.int64)]
+            )
+            row_bytes = byte_csum[row_off[1:]] - byte_csum[row_off[:-1]]
+
+            if self.unphased_union:
+                n_vars_total[qsel] = row_lens
+                ref_span_sum[qsel] = row_span
+                alt_bytes_sum[qsel] = row_bytes
+            else:
+                n_vars_total[qsel] = row_lens.reshape(len(qsel), P).sum(-1)
+                ref_span_sum[qsel] = row_span.reshape(len(qsel), P).sum(-1)
+                alt_bytes_sum[qsel] = row_bytes.reshape(len(qsel), P).sum(-1)
+
+        return n_vars_total, ref_span_sum, alt_bytes_sum
+
     def _reconstruct_variants(
         self, idx: NDArray[np.integer], regions: NDArray[np.integer]
     ) -> RaggedVariants:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,6 +202,17 @@ def phased_svar2_gvl(_svar2_slot_src, tmp_path_factory) -> Path:
     store uses its own tiny reference, see `_svar2_slot_src`). Written with
     ``max_jitter=0``: variant-windows/variants mode raises NotImplementedError
     on an SVAR2 dataset written with max_jitter>0 (no right-clip support).
+
+    The bed repeats the same 4-variant window 80x (still only 4 distinct
+    variants / 2 samples -- "tiny" in data terms): the "variants" (non-window)
+    output branch's real payload for this fixture's handful of variants is
+    small enough to sit under slot_overhead_bytes' 4096-byte floor at low
+    instance counts, masking the #315 defect there even though the same
+    zeroed-placeholder bug applies (see _impl.py:1437-1563). Per-instance
+    offset overhead in the (buggy) estimate grows slower than per-instance
+    real payload, so replicating windows (not variant complexity) is enough
+    to cross the floor and expose the sibling defect too -- confirmed
+    empirically before picking 80 (green up to ~40 regions, red by 60+).
     """
     import polars as pl
     from genoray import SparseVar2, _core
@@ -223,8 +234,13 @@ def phased_svar2_gvl(_svar2_slot_src, tmp_path_factory) -> Path:
     )
     assert (store / "meta.json").exists(), "svar2 conversion did not finish"
 
+    n_regions = 80
     bed = pl.DataFrame(
-        {"chrom": ["chr1", "chr1"], "chromStart": [0, 20], "chromEnd": [20, 40]}
+        {
+            "chrom": ["chr1"] * n_regions,
+            "chromStart": [0] * n_regions,
+            "chromEnd": [40] * n_regions,
+        }
     )
     out = tmp_path_factory.mktemp("svar2_slot_gvl") / "ds.gvl"
     gvl.write(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ predictable. Where a session-scoped opened Dataset is genuinely useful,
 prefer adding it inside the integration test file that needs it.
 """
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -126,6 +127,115 @@ def phased_pgen_gvl(synthetic_case) -> Path:
 @pytest.fixture(scope="session")
 def phased_svar_gvl(synthetic_case) -> Path:
     return synthetic_case.gvl_path["svar"]
+
+
+# --- SVAR2 dataset (opens as Svar2Haps) --------------------------------------
+#
+# Deliberately NOT built from `synthetic_case`/`reference` above: those cover
+# the SVAR1/VCF/PGEN `Haps` read path. `Svar2Haps` is a structurally different
+# reconstructor (reads a `.svar2` store read-bound via Rust FFI, see
+# docs/superpowers/specs/2026-07-23-phase0-realcorpus-findings.md), and the
+# tiny fixture below (mirroring tests/dataset/test_svar2_dataset.py::_src /
+# svar2_fixture, already verified in that Phase-0 doc to reproduce #315) is
+# sufficient -- the defect is content-independent. It needs its own matching
+# reference (a different contig/length than the shared `reference` fixture),
+# hence the paired `svar2_slot_reference` fixture below rather than reuse of
+# `reference`.
+
+# 40 bp reference (chr1). VCF POS (1-based) -> 0-based: SNP@2 (A>G), INS@6
+# (C>CAT), dense SNP@9 (G>C, carried by 3 haps), DEL@11 (GTA>G, ilen -2).
+_SVAR2_SLOT_REF = "ACAGTACATGGGTACTAGCTAGGCTAACCGGTTAACCGGT"
+_SVAR2_SLOT_VCF = """\
+##fileformat=VCFv4.2
+##contig=<ID=chr1,length=40>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1
+chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0
+chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1
+chr1\t10\t.\tG\tC\t.\t.\t.\tGT\t1|1\t1|0
+chr1\t12\t.\tGTA\tG\t.\t.\t.\tGT\t1|1\t0|1
+"""
+
+
+@pytest.fixture(scope="session")
+def _svar2_slot_src(tmp_path_factory) -> tuple[Path, Path]:
+    """(bcf, ref) reproducing the #315 pinned record class: ordinary SNP,
+    insertion, dense SNP, and deletion content over 2 samples -- enough for
+    >=1 (region, sample) group with n_variants > 0 (the defect is
+    content-independent, see the Phase-0 findings doc)."""
+    d = tmp_path_factory.mktemp("svar2_slot_src")
+    ref = d / "ref.fa"
+    ref.write_text(f">chr1\n{_SVAR2_SLOT_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+
+    vcf = d / "in.vcf"
+    vcf.write_text(_SVAR2_SLOT_VCF)
+    bcf = d / "in.bcf"
+    subprocess.run(["bcftools", "view", "-Ob", "-o", str(bcf), str(vcf)], check=True)
+    subprocess.run(["bcftools", "index", str(bcf)], check=True)
+    return bcf, ref
+
+
+@pytest.fixture(scope="session")
+def svar2_slot_reference(_svar2_slot_src):
+    """Opened ``gvl.Reference`` matching `phased_svar2_gvl`'s tiny chr1.
+
+    Carve-out vs. the "yield paths, not Datasets" convention (see module
+    docstring): same rationale as `reference` above -- ``in_memory=False`` is
+    metadata-only, and the paired dataset fixture needs an exactly-matching
+    reference to open against.
+    """
+    import genvarloader as gvl
+
+    _bcf, ref = _svar2_slot_src
+    return gvl.Reference.from_path(ref, in_memory=False)
+
+
+@pytest.fixture(scope="session")
+def phased_svar2_gvl(_svar2_slot_src, tmp_path_factory) -> Path:
+    """A gvl dataset written from a ``.svar2`` source -> opens as ``Svar2Haps``.
+
+    Reproduces the Phase-0-pinned record class for #315 (see
+    docs/superpowers/specs/2026-07-23-phase0-realcorpus-findings.md): >=1
+    (region, sample) group with n_variants > 0 via ordinary SNP/indel content.
+    Open with `svar2_slot_reference`, not the shared `reference` fixture (this
+    store uses its own tiny reference, see `_svar2_slot_src`). Written with
+    ``max_jitter=0``: variant-windows/variants mode raises NotImplementedError
+    on an SVAR2 dataset written with max_jitter>0 (no right-clip support).
+    """
+    import polars as pl
+    from genoray import SparseVar2, _core
+
+    import genvarloader as gvl
+
+    bcf, ref = _svar2_slot_src
+    store = tmp_path_factory.mktemp("svar2_slot_store") / "store.svar2"
+    _core.run_conversion_pipeline(
+        str(bcf),
+        str(ref),
+        ["chr1"],
+        str(store),
+        ["S0", "S1"],
+        25_000,
+        2,
+        1,
+        8 * 1024 * 1024,
+    )
+    assert (store / "meta.json").exists(), "svar2 conversion did not finish"
+
+    bed = pl.DataFrame(
+        {"chrom": ["chr1", "chr1"], "chromStart": [0, 20], "chromEnd": [20, 40]}
+    )
+    out = tmp_path_factory.mktemp("svar2_slot_gvl") / "ds.gvl"
+    gvl.write(
+        out,
+        bed,
+        variants=SparseVar2(store),
+        samples=None,
+        max_jitter=0,
+        overwrite=True,
+    )
+    return out
 
 
 # --- 1kg datasets (slow tier) ------------------------------------------------

--- a/tests/unit/test_slot_fit_property.py
+++ b/tests/unit/test_slot_fit_property.py
@@ -61,3 +61,37 @@ def test_slot_fit_file_backends(backend, request, reference):
     ds = gvl.Dataset.open(path, reference=reference)
     for view in _views(ds):
         _assert_upper_bound(view)
+
+
+def test_slot_fit_svar2_backend(phased_svar2_gvl, svar2_slot_reference):
+    """SVAR2 datasets open as Svar2Haps via the released reconstruct path -- the
+    coverage gap that let #315 through. The estimate must upper-bound the real
+    serialized payload here too.
+
+    Opens with `svar2_slot_reference`, not the `reference` fixture used by
+    test_slot_fit_file_backends: the SVAR2 store is built over its own tiny
+    reference (see tests/conftest.py::_svar2_slot_src), not the shared
+    synthetic_case one -- the two are structurally different reconstructors
+    (Svar2Haps vs. Haps), so there is no reason to force a shared reference.
+    """
+    from genvarloader._dataset._svar2_haps import Svar2Haps
+
+    ds = gvl.Dataset.open(phased_svar2_gvl, reference=svar2_slot_reference)
+    assert isinstance(ds._seqs, Svar2Haps), "fixture must open as Svar2Haps"
+    for view in _views(ds):
+        _assert_upper_bound(view)
+
+    # SCOPE ADD-ON: the sibling "variants" (non-window) output branch reads
+    # the same permanently-empty Svar2Haps.genotypes/.variants placeholders
+    # (n_vars_total via self.n_variants(), alt bytes via _allele_bytes_sum),
+    # so it is presumed similarly under-counting (see "What Task 3 must
+    # change" in the Phase-0 findings doc). Locks the sibling defect so
+    # Task 3's shared fix must cover it too.
+    for uu in (True, False):
+        variants_view = (
+            ds.with_tracks(False)
+            .with_output_format("flat")
+            .with_seqs("variants")
+            .with_settings(unphased_union=uu, jitter=0)
+        )
+        _assert_upper_bound(variants_view)

--- a/tests/unit/test_slot_fit_property.py
+++ b/tests/unit/test_slot_fit_property.py
@@ -84,9 +84,15 @@ def test_slot_fit_svar2_backend(phased_svar2_gvl, svar2_slot_reference):
     # SCOPE ADD-ON: the sibling "variants" (non-window) output branch reads
     # the same permanently-empty Svar2Haps.genotypes/.variants placeholders
     # (n_vars_total via self.n_variants(), alt bytes via _allele_bytes_sum),
-    # so it is presumed similarly under-counting (see "What Task 3 must
-    # change" in the Phase-0 findings doc). Locks the sibling defect so
-    # Task 3's shared fix must cover it too.
+    # so it under-counts identically (see "What Task 3 must change" in the
+    # Phase-0 findings doc). This is also RED before the fix -- confirmed by
+    # running it in isolation -- because `phased_svar2_gvl` replicates the
+    # variant window 80x (see its docstring): "variants" mode's real payload
+    # for a handful of variants sits under slot_overhead_bytes' 4096-byte
+    # floor at low instance counts, masking the defect there even though it
+    # applies; enough instances make the (buggy, ~flat) estimate fall behind
+    # the (correctly variant-count-scaling) real payload. Locks the sibling
+    # defect so Task 3's shared fix must cover it too.
     for uu in (True, False):
         variants_view = (
             ds.with_tracks(False)


### PR DESCRIPTION
## Summary

Completes the deferred **Layer 1** of [#315](https://github.com/mcvickerlab/GenVarLoader/issues/315): `Dataset.to_dataloader(mode="double_buffered")` over flat `variant-windows` failed deterministically at scale on **SVAR2-format** datasets with `RuntimeError: ProducerError (ValueError): buffer is smaller than requested size` (later `SlotOverflowError`). The shared-memory slot was sized from a per-instance byte **estimate that under-counted the real serialized payload** on the SVAR2 reconstruction path.

## Root cause

The reported corpus is **SVAR2-format-2.0.0** and reconstructs through `Svar2Haps` (a `Haps` subclass), not `Haps`. `Dataset._output_bytes_per_instance`'s `variant-windows` branch derives its estimate from three terms — `n_vars_total`, `ref_span`, and `alt_alleles` — all read from `Svar2Haps.genotypes` / `Svar2Haps.variants`. For `Svar2Haps` those are **permanently-empty SVAR1-shaped placeholders**, constructed once at open time only so scattered `isinstance(_, Haps)` checks keep working; they are never populated, because SVAR2 reconstructs read-bound from the on-disk `.svar2` store via Rust FFI (`decode_variants_from_svar2_readbound`), not through an in-memory sparse genotypes table.

Effect: all three terms collapse to `0` for every instance, so the estimate degenerates to a flat, content-independent **32 bytes/instance** while the real payload scales with variant content (up to ~17 KB/instance on the real corpus). The 40×7089 chunk overran its estimate-sized slot → overflow. This is **not** a formula bug and **not** a `p_eff`/ploidy bug — it is a *wrong data source*.

## Fix

- Added `Svar2Haps.measure_variant_payload(...)`: a shared per-instance measure that runs the **same** `decode_variants_from_svar2_readbound` + `unphased_union → p_eff` fold (`var_off[::P]`) the reconstructors already use, returning `(n_vars_total, ref_span_sum, alt_bytes_sum)`.
- `Dataset._output_bytes_per_instance` now sources those three terms from that shared entry point when `isinstance(haps_obj, Svar2Haps)`, so the **estimator and reconstructor derive their variant accounting from the same code and cannot drift apart again**. Applied to both the `variant-windows` branch (the reported repro) and the sibling `variants` (non-window) branch, which had the identical defect.
- The `Haps` (SVAR1/VCF/PGEN) estimate is byte-for-byte unchanged — the fix is gated on `Svar2Haps`.

## Test coverage

`tests/unit/test_slot_fit_property.py` gains `test_slot_fit_svar2_backend`: a SVAR2-backed dataset opened via the released `Dataset.open` + `to_dataloader`/reconstruct path (the coverage gap that let #315 through), asserting `est + slot_overhead ≥ real serialized payload` across `ref`/`alt` × `unphased_union` for both `variant-windows` and `variants` output modes — **red** before the fix, **green** after. Existing `Haps`-path cases (dummy/VCF/PGEN/SVAR1) pass unchanged.

## Real-corpus confirmation

Re-ran the exact reported repro (40 regions × 7089 samples, flat `variant-windows`, `ref="window"`, `alt="allele"`, `unphased_union=True`, `jitter=0`, `flank_length=128`, default 2 GiB `buffer_bytes`, `batch_size=4096`) against the real Hartwig SVAR2 corpus post-fix: `to_dataloader(mode="double_buffered")` now iterates batches with **no** `SlotOverflowError`/`ProducerError`.

## Notes

- Scope: the released `double_buffered` path over a written, file-backed dataset — normal `main`-targeted work, **not** StreamingDataset.
- Out of scope (unchanged): `buffered`/`manual` modes, Bug A (`realign_tracks`), the producer-side grow-or-split escalation.
- `jitter>0` on SVAR2 `variant-windows`/`variants` remains guarded by the existing `NotImplementedError` ("right-clip") in `_svar2_haps.py`, so the measure intentionally does not widen by jitter (that path is unreachable).
- Design/pin docs: `docs/superpowers/specs/2026-07-23-svar2-variant-windows-slot-fit-design.md` and `…-phase0-realcorpus-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
