### PR TITLE
feat(threads): let a dataset state its own parallelism policy

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -68,8 +68,28 @@ plink2 --pgen-info $prefix
 GVL's read path (haplotype reconstruction and track re-alignment) is parallelized in Rust with [rayon](https://github.com/rayon-rs/rayon). By default it uses one worker per available CPU, detected from the Linux cgroup cpuset (`sched_getaffinity`) so it respects container limits, and falling back to `os.cpu_count()` elsewhere. Three environment variables tune this:
 
 - **`GVL_NUM_THREADS`** — set the worker count explicitly (e.g. `GVL_NUM_THREADS=4`). Overrides cgroup detection. Resolved once, on first use, so set it before your first GVL call.
-- **`GVL_FORCE_PARALLEL`** — set to a truthy value (`1`, `true`, `yes`, `on`) to force the multithreaded paths even on small inputs. By default GVL runs a batch serially when its output is under 1 MiB, because thread overhead would dominate; this bypasses that size gate. Mainly useful for benchmarking. The gate is an **absolute** byte floor — it does not scale with `GVL_NUM_THREADS`, so raising the worker count never pushes a batch back onto the serial path.
+- **`GVL_FORCE_PARALLEL`** — set to a truthy value (`1`, `true`, `yes`, `on`) to force the multithreaded paths even on small inputs. By default GVL runs a batch serially when its output is under 1 MiB, because thread overhead would dominate; this bypasses that size gate. Mainly useful for benchmarking. The gate is an **absolute** byte floor — it does not scale with `GVL_NUM_THREADS`, so raising the worker count never pushes a batch back onto the serial path. This variable sets the *default*; a dataset that states its own policy overrides it (see below).
 - **`RAYON_NUM_THREADS`** — GVL **overwrites** this with its own resolved count so an inherited value (e.g. baked into a base image) can't defeat the cgroup-aware cap. To size the pool yourself, use `GVL_NUM_THREADS` instead.
+
+### Setting parallelism in code instead of the environment
+
+Environment variables configure a whole process, which means a script's parallelism can't be determined by reading the script — a value in a shell profile, a Dockerfile, or a SLURM template changes how it runs. To state the policy where a reader can see it, set it on the dataset:
+
+```python
+ds = ds.with_settings(parallel=False)   # True | False | "auto"
+```
+
+- `True` — always hand batches to rayon, whatever their size.
+- `False` — always run serial.
+- `"auto"` (default) — decide per batch from the output size, deferring to `GVL_FORCE_PARALLEL`.
+
+**An explicit `True`/`False` beats `GVL_FORCE_PARALLEL`.** Precedence is *explicit setting > environment > size gate*, so a script that says `parallel=False` runs serial no matter what the environment says. Datasets that never set it stay on `"auto"` and behave exactly as before.
+
+The setting is per-dataset and travels with it, including into dataloader worker processes.
+
+```{note}
+This governs *whether* to parallelize, not how many threads to use. The worker count is fixed at import from `GVL_NUM_THREADS`, because rayon reads it when its global thread pool initializes — so it cannot be varied per dataset.
+```
 
 ## Should I use `.svar` or `.svar2` as my variant source?
 

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -12,6 +12,7 @@ from numpy.typing import NDArray
 from seqpro.rag import Ragged
 from typing_extensions import Self, assert_never
 
+from .._threads import Parallel, _check_parallel, parallel_policy
 from .._ragged import (
     RaggedAnnotatedHaps,
     RaggedIntervals,
@@ -242,6 +243,7 @@ class Dataset:
         dummy_variant: "DummyVariant | Literal[False] | None" = None,
         unphased_union: bool | None = None,
         realign_tracks: bool | None = None,
+        parallel: "Parallel | None" = None,
     ) -> Self:
         """Modify settings of the dataset, returning a new dataset without modifying the old one.
 
@@ -292,8 +294,22 @@ class Dataset:
                 for reference-coordinate (as-is) tracks; required ``False`` for
                 ``variant-windows`` + tracks and for ``kind="intervals"`` with any
                 variant-aware seq mode.
+            parallel: Parallelism policy for this dataset's reads. :code:`True` forces the
+                Rust kernels multithreaded, :code:`False` forces them serial, and
+                :code:`"auto"` (default) decides per batch from the output size. An
+                explicit :code:`True`/:code:`False` overrides the ``GVL_FORCE_PARALLEL``
+                environment variable; :code:`"auto"` defers to it. Note this governs
+                *whether* to parallelize, not how many threads to use -- the worker
+                count is fixed at import from ``GVL_NUM_THREADS``, because rayon reads
+                it when its global pool initializes.
+
+        Raises:
+            ValueError: If ``parallel`` is not :code:`True`, :code:`False`, or :code:`"auto"`.
         """
         to_evolve = {}
+
+        if parallel is not None:
+            to_evolve["parallel"] = _check_parallel(parallel)
 
         if jitter is not None:
             if jitter != self.jitter:
@@ -949,6 +965,15 @@ class Dataset:
     (as-is) tracks. Only affects ``Haps`` + float tracks; a no-op otherwise.
     Required ``False`` for ``variant-windows`` + tracks and for ``kind="intervals"``
     with any variant-aware seq mode."""
+    parallel: "Parallel" = "auto"
+    """Parallelism policy for this dataset's reads: :code:`True` forces the Rust
+    kernels to run multithreaded, :code:`False` forces them serial, and
+    :code:`"auto"` (default) decides per batch from the output size.
+
+    An explicit :code:`True`/:code:`False` beats the ``GVL_FORCE_PARALLEL``
+    environment variable, so a script's parallelism can be determined by reading
+    the script (issue #352). :code:`"auto"` defers to the environment, so a
+    dataset that never sets this behaves exactly as it did before."""
 
     @property
     def is_subset(self) -> bool:
@@ -2118,7 +2143,16 @@ class Dataset:
             rc_neg=self.rc_neg,
             flat_output=self.output_format == "flat",
         )
-        return getitem(view, idx)
+        if self.parallel == "auto":
+            # Default policy: nothing to establish, so skip the scope entirely
+            # and leave the hot path exactly as cheap as it was before #352.
+            return getitem(view, idx)
+        # Set at read time, not when the setting was chosen: this is what carries
+        # the policy into dataloader worker processes, which receive a pickled
+        # copy of this dataset and re-enter here. A ContextVar set in the parent
+        # would not survive a spawn.
+        with parallel_policy(self.parallel):
+            return getitem(view, idx)
 
 
 def _lazy_load_dosages(dataset: Dataset, haps: Haps) -> Haps:

--- a/python/genvarloader/_threads.py
+++ b/python/genvarloader/_threads.py
@@ -21,10 +21,30 @@ from __future__ import annotations
 
 import math
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
+from typing import Literal, TypeAlias
+
+Parallel: TypeAlias = bool | Literal["auto"]
+"""A parallelism policy: force on, force off, or decide per batch by size."""
 
 _MIN_PARALLEL_BYTES = 1 << 20  # 1 MiB
 _NUM_THREADS: int | None = None
+
+_PARALLEL: ContextVar[Parallel] = ContextVar("gvl_parallel", default="auto")
+"""In-process parallelism policy, consulted by :func:`should_parallelize`.
+
+A `ContextVar` rather than a plain global for two reasons: it is restored
+exactly on scope exit even if the read raises, and it is per-thread, so
+concurrent reads of differently-configured datasets cannot clobber each other.
+
+Set at *read* time by ``Dataset.__getitem__``, not when the setting is chosen.
+That is what carries the policy into dataloader worker processes: the `Dataset`
+is pickled to the worker and re-establishes the scope there, whereas a
+`ContextVar` set in the parent would never have propagated across a spawn.
+"""
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
@@ -121,6 +141,34 @@ def num_threads() -> int:
     return cap_threads()
 
 
+def _check_parallel(value: Parallel) -> Parallel:
+    """Reject anything that is not a valid policy, at the boundary."""
+    if value is not True and value is not False and value != "auto":
+        raise ValueError(f"parallel must be True, False, or 'auto'; got {value!r}")
+    return value
+
+
+@contextmanager
+def parallel_policy(value: Parallel) -> Iterator[None]:
+    """Apply a parallelism policy for the duration of the block.
+
+    Restores the previous policy on exit, including when the block raises, so a
+    failed read cannot leave the process configured for the next one.
+
+    Args:
+        value: :code:`True` to force parallel, :code:`False` to force serial, or
+            :code:`"auto"` to decide per batch by output size.
+
+    Raises:
+        ValueError: If ``value`` is not a valid policy.
+    """
+    token = _PARALLEL.set(_check_parallel(value))
+    try:
+        yield
+    finally:
+        _PARALLEL.reset(token)
+
+
 def should_parallelize(total_bytes: int) -> bool:
     """True iff a batch of ``total_bytes`` output is worth handing to rayon.
 
@@ -132,9 +180,25 @@ def should_parallelize(total_bytes: int) -> bool:
     ``current_num_threads()`` and work-steals, so the gate only has to answer
     "is there enough work to bother", which does not depend on the pool size.
 
-    GVL_FORCE_PARALLEL bypasses the gate so the multithreaded paths run on
-    small inputs (tests, repro harnesses). See issue #263.
+    Precedence is **explicit > environment > size gate** (issue #352). An
+    in-code policy set via ``Dataset.with_settings(parallel=...)`` wins over
+    GVL_FORCE_PARALLEL, so a script that says ``parallel=False`` runs serial
+    regardless of what a shell profile or base image set. Deferring to the
+    environment instead would mean a script's behavior could not be determined
+    by reading it -- the same trap :func:`cap_threads` already refused when it
+    chose to overwrite an inherited RAYON_NUM_THREADS (issue #263).
+
+    The default policy is ``"auto"``, which *does* defer to the environment and
+    then to the size floor, so a process that never sets a policy behaves
+    exactly as it did before #352.
+
+    GVL_FORCE_PARALLEL bypasses the size gate so the multithreaded paths run on
+    small inputs (tests, repro harnesses). It is read live, so it can be
+    toggled mid-process. See issue #263.
     """
+    policy = _PARALLEL.get()
+    if policy is True or policy is False:
+        return policy  # explicit: never consult the environment
     if _force_parallel():
         return True
     return total_bytes >= _MIN_PARALLEL_BYTES

--- a/skills/genvarloader/SKILL.md
+++ b/skills/genvarloader/SKILL.md
@@ -259,6 +259,8 @@ Scalar fields (`start`/`ilen`/`dosage`/`info[...]`) are still filled from `Dummy
 
 Track **re-alignment** to haplotype coordinates is controlled by `with_settings(realign_tracks=True)` (default). Set `realign_tracks=False` for reference-coordinate ("as-is") tracks. `realign_tracks=False` is **required** for `kind="intervals"` with any variant-aware seq mode, and for `variant-windows` + tracks. `with_insertion_fill` requires `realign_tracks=True`.
 
+**`with_settings(parallel=...)`** — parallelism policy for this dataset's reads. `True` forces the Rust kernels multithreaded, `False` forces them serial, `"auto"` (default) decides per batch from the output size. An explicit `True`/`False` **overrides** the `GVL_FORCE_PARALLEL` environment variable — precedence is *explicit setting > environment > size gate* — so a script's parallelism can be read off the script rather than depending on ambient state. `"auto"` defers to the environment, so datasets that never set it behave as before. The setting is per-dataset and travels with it into dataloader worker processes. It governs *whether* to parallelize, not thread count: the worker count is fixed at import from `GVL_NUM_THREADS` because rayon reads it at global-pool init, so it cannot vary per dataset. See issue #352.
+
 `with_len(L)` controls output shape:
 - `"ragged"` (default): returns `gvl.Ragged` (variable length per item).
 - `"variable"`: NumPy array right-padded to the batch's longest item (`N` for seqs, `0` for tracks).

--- a/tests/unit/dataset/test_parallel_setting.py
+++ b/tests/unit/dataset/test_parallel_setting.py
@@ -1,0 +1,108 @@
+"""``Dataset.with_settings(parallel=...)`` reaches the kernels (issue #352).
+
+The value has to arrive at ``should_parallelize`` call sites that live in free
+functions with no ``Dataset`` in scope (``_genotypes``, ``_intervals``,
+``_reference``), which is why it travels as a context-scoped policy rather than
+a threaded-through argument. These tests pin that it actually gets there, that
+it beats the environment, and that it cannot leak past the read.
+"""
+
+import genvarloader as gvl
+import pytest
+
+from genvarloader import _threads as th
+
+
+@pytest.fixture(scope="module")
+def ds(phased_svar_gvl, reference):
+    return gvl.Dataset.open(phased_svar_gvl, reference=reference).with_seqs(
+        "haplotypes"
+    )
+
+
+def _observed_policy(dataset, monkeypatch) -> list[bool]:
+    """Record what the gate answers during one read of ``dataset``."""
+    seen: list[bool] = []
+    real = th.should_parallelize
+
+    def spy(total_bytes: int) -> bool:
+        answer = real(total_bytes)
+        seen.append(answer)
+        return answer
+
+    # Patch at the definition site AND in every module that imported the name
+    # by value -- `from .._threads import should_parallelize` binds a reference,
+    # so patching only `_threads` would not be observed by any caller.
+    monkeypatch.setattr(th, "should_parallelize", spy)
+    for mod in th_importers():
+        monkeypatch.setattr(mod, "should_parallelize", spy, raising=False)
+    dataset[:2, :]
+    return seen
+
+
+def th_importers():
+    from genvarloader._dataset import (
+        _genotypes,
+        _haps,
+        _intervals,
+        _reconstruct,
+        _reference,
+        _svar2_haps,
+    )
+
+    return (_genotypes, _haps, _intervals, _reconstruct, _reference, _svar2_haps)
+
+
+def test_parallel_false_forces_every_kernel_serial(ds, monkeypatch):
+    monkeypatch.setenv("GVL_FORCE_PARALLEL", "1")  # would force parallel on "auto"
+    seen = _observed_policy(ds.with_settings(parallel=False), monkeypatch)
+    assert seen, "no kernel consulted the gate; the test proves nothing"
+    assert not any(seen), "an explicit parallel=False did not reach every kernel"
+
+
+def test_parallel_true_forces_every_kernel_parallel(ds, monkeypatch):
+    monkeypatch.delenv("GVL_FORCE_PARALLEL", raising=False)
+    seen = _observed_policy(ds.with_settings(parallel=True), monkeypatch)
+    assert seen
+    assert all(seen), "an explicit parallel=True did not reach every kernel"
+
+
+def test_auto_still_defers_to_the_environment(ds, monkeypatch):
+    """The default is unchanged behaviour -- env still wins on "auto"."""
+    monkeypatch.setenv("GVL_FORCE_PARALLEL", "1")
+    seen = _observed_policy(ds, monkeypatch)
+    assert seen
+    assert all(seen), "auto stopped deferring to GVL_FORCE_PARALLEL"
+
+
+def test_policy_does_not_leak_past_the_read(ds, monkeypatch):
+    monkeypatch.delenv("GVL_FORCE_PARALLEL", raising=False)
+    ds.with_settings(parallel=False)[:2, :]
+    assert th._PARALLEL.get() == "auto"
+    assert th.should_parallelize(1 << 30) is True
+
+
+def test_setting_is_per_dataset_not_global(ds, monkeypatch):
+    """Configuring one dataset must not reconfigure another."""
+    monkeypatch.setenv("GVL_FORCE_PARALLEL", "1")
+    serial = ds.with_settings(parallel=False)
+    assert serial.parallel is False
+    assert ds.parallel == "auto", "with_settings mutated the original dataset"
+    # Reading the serial one must leave the untouched one still on "auto",
+    # where GVL_FORCE_PARALLEL still applies.
+    _observed_policy(serial, monkeypatch)
+    assert all(_observed_policy(ds, monkeypatch)), "policy leaked between datasets"
+
+
+def test_output_is_identical_regardless_of_policy(ds):
+    import numpy as np
+
+    a = ds.with_settings(parallel=False)[:2, :]
+    b = ds.with_settings(parallel=True)[:2, :]
+    assert np.array_equal(a.data, b.data)
+    assert np.array_equal(a.offsets, b.offsets)
+
+
+def test_invalid_policy_rejected_at_with_settings(ds):
+    with pytest.raises(ValueError, match="parallel"):
+        ds.with_settings(parallel="sometimes")

--- a/tests/unit/test_threads.py
+++ b/tests/unit/test_threads.py
@@ -160,3 +160,97 @@ def test_cap_threads_sets_when_unset(monkeypatch):
     monkeypatch.setenv("GVL_NUM_THREADS", "3")
     th.cap_threads()
     assert os.environ["RAYON_NUM_THREADS"] == "3"
+
+
+# --- parallelism policy override (issue #352) -------------------------------
+#
+# Precedence is explicit > environment > size gate. The environment sets the
+# *default*; an in-code setting overrides it. See #352 for why: a script that
+# reads `parallel=False` must not run parallel because of a variable baked into
+# a base image that the reader of the script cannot see. This is the same call
+# #263 already made when `cap_threads` chose to overwrite an inherited
+# RAYON_NUM_THREADS.
+
+
+def test_parallel_default_is_auto(monkeypatch):
+    """An untouched process behaves exactly as it did before #352."""
+    monkeypatch.delenv("GVL_FORCE_PARALLEL", raising=False)
+    assert th._PARALLEL.get() == "auto"
+    assert th.should_parallelize(0) is False
+    assert th.should_parallelize(th._MIN_PARALLEL_BYTES) is True
+
+
+@pytest.mark.parametrize(
+    ("override", "env", "total_bytes", "expected"),
+    [
+        # explicit True wins over every environment and every size
+        (True, None, 0, True),
+        (True, "0", 0, True),
+        (True, "1", 0, True),
+        # explicit False wins over GVL_FORCE_PARALLEL -- the point of #352
+        (False, None, 1 << 30, False),
+        (False, "1", 1 << 30, False),
+        (False, "1", 0, False),
+        # "auto" defers to the environment...
+        ("auto", "1", 0, True),
+        # ...and then to the size gate
+        ("auto", None, 0, False),
+        ("auto", None, 1 << 30, True),
+        ("auto", "0", 1 << 30, True),
+        ("auto", "0", 0, False),
+    ],
+)
+def test_parallel_precedence(monkeypatch, override, env, total_bytes, expected):
+    if env is None:
+        monkeypatch.delenv("GVL_FORCE_PARALLEL", raising=False)
+    else:
+        monkeypatch.setenv("GVL_FORCE_PARALLEL", env)
+    with th.parallel_policy(override):
+        assert th.should_parallelize(total_bytes) is expected
+
+
+def test_parallel_policy_restores_on_exit(monkeypatch):
+    monkeypatch.delenv("GVL_FORCE_PARALLEL", raising=False)
+    with th.parallel_policy(False):
+        assert th.should_parallelize(1 << 30) is False
+    # must not leak into the next read
+    assert th.should_parallelize(1 << 30) is True
+
+
+def test_parallel_policy_restores_on_exception(monkeypatch):
+    monkeypatch.delenv("GVL_FORCE_PARALLEL", raising=False)
+    with pytest.raises(RuntimeError):
+        with th.parallel_policy(False):
+            raise RuntimeError("boom")
+    assert th.should_parallelize(1 << 30) is True
+
+
+def test_parallel_policy_nests(monkeypatch):
+    monkeypatch.delenv("GVL_FORCE_PARALLEL", raising=False)
+    with th.parallel_policy(False):
+        with th.parallel_policy(True):
+            assert th.should_parallelize(0) is True
+        assert th.should_parallelize(1 << 30) is False
+
+
+def test_parallel_policy_rejects_garbage():
+    """Invalid states unrepresentable at the boundary: fail fast, not silently."""
+    with pytest.raises(ValueError, match="parallel"):
+        with th.parallel_policy("sometimes"):  # pyrefly: ignore
+            pass
+
+
+def test_explicit_setting_skips_the_env_read(monkeypatch):
+    """An explicit policy must not consult the environment at all.
+
+    Not just an optimisation -- it is what makes the precedence real. If the
+    env were still read, a truthy GVL_FORCE_PARALLEL would leak into a
+    `parallel=False` read.
+    """
+    calls = []
+    monkeypatch.setattr(th, "_force_parallel", lambda: calls.append(1) or True)
+    with th.parallel_policy(False):
+        assert th.should_parallelize(0) is False
+    with th.parallel_policy(True):
+        assert th.should_parallelize(0) is True
+    assert calls == [], "explicit policy consulted the environment"


### PR DESCRIPTION
Refs #352.

Parallelism was configurable only through the environment, so a script's behavior could not be determined by reading it — `GVL_FORCE_PARALLEL` set in a shell profile, a Dockerfile, or a SLURM template silently changed how it ran. And there was no way to force parallelism **off** at all: `GVL_FORCE_PARALLEL` is one-way, and `GVL_NUM_THREADS=1` shrinks the whole rayon pool rather than bypassing the size gate.

```python
ds = ds.with_settings(parallel=False)   # True | False | "auto"
```

## Precedence: explicit > environment > size gate

| `Dataset.parallel` | `GVL_FORCE_PARALLEL` | result |
|---|---|---|
| `True` | anything | parallel |
| `False` | anything | serial |
| `"auto"` (default) | truthy | parallel |
| `"auto"` | unset | size gate (≥ 1 MiB) |

**Nothing existing changes.** Every current program sits in the `"auto"` rows, where the environment behaves exactly as it does today. And since no in-code setting existed until now, nothing can have been relying on the environment to override one — code-wins costs no migration.

This is the same call #263 already made one level down: `cap_threads` overwrites an inherited `RAYON_NUM_THREADS` precisely so a value baked into a base image cannot defeat the cgroup-aware cap. Same trap, same answer, one level up.

## Why a ContextVar rather than an argument

Six of the thirteen `should_parallelize` call sites are **free functions with no `Dataset` in scope** (`_genotypes`, `_intervals`, `_reference`, `_reconstruct`). Threading the value would have meant ~6 signatures plus ~15 call sites — and any future call site that forgot to pass it would silently fall back to environment-only behavior, reintroducing exactly the bug class being removed here. A `ContextVar` consulted inside `should_parallelize` cannot be forgotten, restores exactly on scope exit even if the read raises, and is per-thread, so concurrent reads of differently-configured datasets can't clobber each other.

`Dataset.__getitem__` establishes the scope at **read** time, not when the setting is chosen. That is what carries the policy into dataloader worker processes: the dataset is pickled to the worker and re-enters `__getitem__` there, whereas a `ContextVar` set in the parent would never survive a spawn.

The user-facing knob stays fully visible — `ds.with_settings(parallel=False)`, sitting in the script. The ContextVar is internal plumbing, not a second configuration surface.

## Cost

Measured before committing to the approach, because "cheap" was the condition for choosing it:

| | ns/call | |
|---|---|---|
| `ContextVar.get()` | 217 | added |
| `os.environ.get()` | 3,179 | already paid by the gate on every call |
| full `should_parallelize()` today | 4,206 | |

An explicit policy short-circuits the env read, so it makes the gate **cheaper**, not slower. The default `"auto"` skips the scope entirely in `__getitem__`, leaving the hot path byte-for-byte as it was. Worst case is ~13 gate calls per batch = 0.006% of an 80 ms batch.

Absolute numbers are inflated by node load; ratios are same-process back-to-back. Self-check: the env lookup is 3,179 of the gate's 4,206 ns, which is consistent.

## Tests

- `tests/unit/test_threads.py` — the full precedence matrix (11 cases), scope restore on normal exit **and** on exception, nesting, invalid-value rejection, and a test that an explicit policy never touches the environment (which is what makes the precedence real, not just an optimisation).
- `tests/unit/dataset/test_parallel_setting.py` — end-to-end: the policy reaches every kernel through a real read with `GVL_FORCE_PARALLEL=1` set against it; `"auto"` still defers to the environment; no leak past the read; per-dataset not global; identical output either way.

The integration spy patches `should_parallelize` in all six importing modules, not just `_threads` — patching only the definition site is invisible to callers that imported the name by value, which is a trap worth pinning in a test.

## Scope

`parallel` only. Thread **count** cannot be per-dataset without building scoped rayon pools, since rayon reads `RAYON_NUM_THREADS` at global-pool init — called out in #352 and deliberately left alone.

Docs: `docs/source/faq.md` gains a section on setting parallelism in code; `skills/genvarloader/SKILL.md` updated per the public-API rule in CLAUDE.md; `api.md` verified in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
