### PR TITLE
perf(write): replace O(S^2) svar2 sample_cols with a hash lookup

### DIFF
--- a/docs/source/write.md
+++ b/docs/source/write.md
@@ -109,6 +109,19 @@ Both formats store a back-reference in the dataset's `metadata.json` instead of 
 
 `.svar2` additionally produces a write-time cache under `<path>/genotypes/svar2_ranges/` and reads back through an all-Rust, read-bound path with no interval-search-tree build and no dense-union rebuild per read — see [the FAQ](faq.md) for the read-path and on-disk-size tradeoffs, and [the format reference](format.md) for the on-disk layout, including the size formula. This cache is **not small at cohort scale**. `gvl.write` honours `max_mem` when writing `.svar2` genotype ranges, bounding the RAM used while producing the cache; the permanent range cache itself is governed by disk space, not `max_mem` (see the format reference). `.svar2` currently has a Phase-1 scope: a handful of output combinations (`annotated` haplotypes, `min_af`/`max_af`, spliced variant-window/track outputs, etc.) aren't wired yet and raise `NotImplementedError` — see the `genvarloader` skill or the format reference for the full list. Haplotype and `variants` output support splicing and `var_filter="exonic"`.
 
+## Sample order
+
+Whether you pass `samples=` or leave it `None`, `gvl.write` stores the selection in
+**lexicographic** order, and [`Dataset.samples`](api.md#genvarloader.Dataset.samples) reports
+that same order.
+
+```{warning}
+Lexicographic order is not numeric order. A cohort with integer-like IDs of mixed digit
+counts sorts as `"1000" < "999"`, whereas the phenotype table you want to join against is
+usually in numeric order. Align external tables to `Dataset.samples` **by name**, never by
+position.
+```
+
 ## Reusing a variant index across cohorts
 
 If several cohorts are sample subsets of one parent PGEN, do **not** pre-split the

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -1009,7 +1009,12 @@ class Dataset:
 
     @property
     def samples(self) -> list[str]:
-        """The samples in the dataset."""
+        """The samples in the dataset, sorted lexicographically.
+
+        Lexicographic order is not the numeric order a phenotype table usually
+        carries (``"1000"`` sorts before ``"999"``), so align external tables to
+        this list by name rather than by position.
+        """
         return self._idxer.samples
 
     @property

--- a/python/genvarloader/_dataset/_write.py
+++ b/python/genvarloader/_dataset/_write.py
@@ -26,6 +26,7 @@ from genoray._svar2_batch import MAX_END_SHIFT
 from genoray._types import V_IDX_TYPE
 from genoray._contigs import ContigNormalizer
 from genoray._utils import format_memory, parse_memory
+from hirola import HashTable
 from joblib import Parallel, delayed
 from loguru import logger
 from natsort import natsorted
@@ -41,6 +42,7 @@ from .._fasta_cache import Fingerprint
 from .._ragged import INTERVAL_DTYPE  # noqa: F401  # kept for the migration reader import
 from .._utils import lengths_to_offsets, normalize_contig_name
 from .._variants._utils import path_is_pgen, path_is_vcf
+from ._indexing import s2i
 from ._svar2_link import Svar2Link
 from ._svar_link import SvarLink
 from ._utils import bed_to_regions, regions_to_bed
@@ -138,7 +140,12 @@ def write(
             DataFrame/LazyFrame interpreted as a BED-like interval table (columns ``chrom``,
             ``chromStart``, ``chromEnd``, ``score``). Table/DataFrame sources are served by
             the Rust COITrees overlap backend. Written to ``<path>/annot_intervals/<name>/``.
-        samples: Samples to include in the dataset
+        samples: Samples to include in the dataset. Defaults to every sample available
+            across all variant file(s) and tracks. Either way the dataset's sample order
+            is the **lexicographic** sort of the selection, which is not the numeric sort
+            a phenotype table usually carries (``"1000"`` sorts before ``"999"``). Align
+            downstream tables to :attr:`Dataset.samples <genvarloader.Dataset.samples>`
+            by name, never by position.
         max_jitter: Maximum jitter to add to the regions
         overwrite: Whether to overwrite an existing dataset
         max_mem: Approximate maximum total memory to use, including the genoray variant
@@ -152,7 +159,11 @@ def write(
             a small amount.
             For a ``.svar2`` variant source this also bounds the genotype
             range-cache write: ranges are produced in per-sample chunks sized to
-            fit the budget rather than a whole contig at once.
+            fit the budget rather than a whole contig at once. The cache itself is
+            **outside** this budget: it is two ``(n_regions, n_samples, ploidy, 2)``
+            int64 memmaps on disk, which reaches tens of GiB at cohort scale (60.7 GiB
+            for 1,901 regions x 535,662 diploid samples). :func:`write` logs the
+            projected size and warns when the filesystem reports too little free space.
         extend_to_length: Whether to continue reading/writing variants until all haplotypes have a length at least as long as the intervals in `bed`.
             Otherwise, deletions can cause the length of haplotypes to be less than the intervals in `bed`. This can be disabled if having
             haplotypes shorter than the intervals is acceptable, in which case they will be padded with reference bases when appropriate.
@@ -1159,10 +1170,31 @@ def _write_from_svar2(
         out_dir / "dense_indel_range.npy", np.int64, "w+", shape=(R, 2)
     )
     # sample_cols: selected slot -> original sample index (same for every contig).
-    sample_cols = np.asarray(
-        [svar2.available_samples.index(s) for s in samples], np.int64
+    # Hash lookup, not `list.index` per sample: the latter is O(S^2) and cost ~1 h
+    # at S = 535k before a single genotype was read (#351).
+    avail = np.array(svar2.available_samples)
+    avail_s2i = HashTable(
+        max=len(avail) * 2,  # type: ignore[bad-argument-type]  # hirola HashTable.max typed as numpy.Number but accepts int
+        dtype=avail.dtype,
     )
+    avail_s2i.add(avail)
+    if len(avail_s2i.keys) != len(avail):
+        # `add` compacts to unique keys, so a duplicate name shifts every column
+        # after it. `list.index` instead pointed two slots at one column. Both are
+        # silently wrong datasets; refuse rather than pick one.
+        raise ValueError(
+            "The .svar2 store has duplicate sample names, so genotype columns"
+            " cannot be assigned unambiguously."
+        )
+    sample_cols = np.asarray(s2i(np.asarray(samples), avail_s2i), np.int64)
     np.save(out_dir / "sample_cols.npy", sample_cols)
+
+    # genoray resolves `samples` by name with its own O(S^2) scan, once per contig
+    # (d-laub/genoray#168). `None` means "every sample in store order", which is
+    # exactly this selection when the two lists already agree, so skip the scan.
+    # `samples` is sorted lexicographically by `write`, so this only fires for a
+    # store whose own order is sorted.
+    sel: list[str] | None = None if samples == avail.tolist() else samples
 
     with open(out_dir / "svar2_meta.json", "w") as f:
         json.dump(
@@ -1192,7 +1224,7 @@ def _write_from_svar2(
         # extend_to_length is validated at function entry (False raises); the
         # read-bound kernel sizes haplotype output at read time.
         stream = svar2._find_ranges_chunked(
-            c, starts, ends, samples=samples, max_mem=max_mem
+            c, starts, ends, samples=sel, max_mem=max_mem
         )
         dense_snp[lo:hi] = np.asarray(stream.dense_snp_range, np.int64).reshape(rc, 2)
         dense_indel[lo:hi] = np.asarray(stream.dense_indel_range, np.int64).reshape(

--- a/skills/genvarloader/SKILL.md
+++ b/skills/genvarloader/SKILL.md
@@ -127,6 +127,7 @@ Notable:
 - `annot_tracks`: `dict[str, str | Path | pl.DataFrame | pl.LazyFrame] | None` — sample-independent annotation tracks, written to `<path>/annot_intervals/<name>/`. Each value is either a path to an interval table/bigWig file, or a polars DataFrame/LazyFrame with BED-like columns (`chrom`, `chromStart`, `chromEnd`, `score`). Annotation tracks are sample-independent and can be read without a per-sample variant source.
 - `max_jitter`: max read-time jitter; pads stored data on both sides of every region by this many bases so `Dataset.with_settings(jitter=j)` works for any `j <= max_jitter`.
 - `extend_to_length=True` keeps reading past the BED end until every haplotype is ≥ the region length (matters when deletions would shorten output); set `False` for faster writes if shorter haps are acceptable. **Not supported for a `.svar2` variant source** — `extend_to_length=False` raises `NotImplementedError` there; only BCF/PGEN/`.svar` sources may disable it.
+- `samples`: which samples to include; `None` (default) takes every sample available across `variants` and all `tracks`. Either way the dataset's sample order is the **lexicographic** sort of that selection, which is not the numeric order a phenotype table usually carries (`"1000"` sorts before `"999"`). Align external tables to `Dataset.samples` by name, never by position.
 - Inner-joins samples across `variants` and all `tracks`.
 
 **Parallelism:** `gvl.write` now parallelizes over write categories. Variants are processed first (serially). Then per-sample `tracks` and `annot_tracks` run concurrently (joblib loky backend). The `max_mem` budget is divided across the concurrently-running categories.
@@ -505,6 +506,7 @@ See `docs/source/format.md` for the full schema, versioning, and SVAR-link detai
   `genotypes/svar2_ranges/`. That is ~98 GiB for ~4,000 regions over 414,830
   diploid samples. `max_mem` bounds RAM during the write; it does not bound this
   on-disk cache.
+- **`Dataset.samples` is sorted lexicographically, not numerically.** Cohorts with integer-like IDs of mixed digit counts come out in an order that differs from the numeric sort a phenotype table typically has (`"1000" < "999"` as strings). A positional join between the two is silently wrong; join on the sample name.
 - **`gvl.concat` requires one shared variant source and at least two inputs.** Mismatched variant
   sources (checked by fingerprint, not just backend type), `axis="regions"` with differing sample
   sets/order, or `axis="samples"` with differing regions or overlapping samples all raise

--- a/tests/dataset/test_write_svar2.py
+++ b/tests/dataset/test_write_svar2.py
@@ -455,3 +455,96 @@ def test_svar2_preflight_warns_when_disk_is_short(tmp_path, monkeypatch):
 
     assert n == _write._svar2_ranges_cache_bytes(3964, 414830, 2)
     assert any("free" in m for m in msgs), msgs
+
+
+@pytest.fixture(scope="module")
+def svar2_store_unsorted(vcf_and_ref, tmp_path_factory) -> Path:
+    """A store whose own sample order is NOT the lexicographic order gvl writes.
+
+    `write` sorts the selection, so this is the case where `sample_cols` is a real
+    permutation and the `samples=None` fast path in `_write_from_svar2` must NOT fire.
+    """
+    bcf, ref = vcf_and_ref
+    from genoray import _core
+
+    out = tmp_path_factory.mktemp("svar2_write_unsorted") / "store.svar2"
+    _core.run_conversion_pipeline(
+        str(bcf),
+        str(ref),
+        ["chr1"],
+        str(out),
+        ["S1", "S0"],  # reversed vs. the lexicographic order gvl.write emits
+        25_000,
+        2,
+        1,
+        8 * 1024 * 1024,
+    )
+    assert (out / "meta.json").exists(), "conversion did not finish"
+    return out
+
+
+def test_write_svar2_sample_cols_permutes_unsorted_store(
+    svar2_store_unsorted: Path, tmp_path: Path
+):
+    """sample_cols must map sorted slot -> store column, not slot -> slot.
+
+    Guards the `list.index` -> hirola swap (#351): `HashTable.add` returns the rank
+    in its deduped key array, which equals the store position only because sample
+    names are unique. A store that is already sorted cannot tell the two apart, so
+    use a reversed one.
+    """
+    from genoray import SparseVar2
+
+    svar2 = SparseVar2(svar2_store_unsorted)
+    assert svar2.available_samples == ["S1", "S0"], "fixture lost its store order"
+
+    bed = pl.DataFrame(
+        {"chrom": ["chr1", "chr1"], "chromStart": [0, 5], "chromEnd": [20, 15]}
+    )
+    out = tmp_path / "ds.gvl"
+    gvl.write(out, bed, variants=svar2, samples=None, overwrite=True)
+
+    rd = out / "genotypes" / "svar2_ranges"
+    sorted_samples = sorted(svar2.available_samples)  # ["S0", "S1"]
+    sample_cols = np.load(rd / "sample_cols.npy")
+    assert (
+        sample_cols.tolist()
+        == [svar2.available_samples.index(s) for s in sorted_samples]
+        == [1, 0]
+    )
+
+    # The cache must be laid out in the SORTED slot order, i.e. match a direct
+    # _find_ranges over the sorted names -- the `samples=None` fast path must not
+    # have fired and silently written the store's own order.
+    meta = json.loads((rd / "svar2_meta.json").read_text())
+    shape = tuple(meta["vk_snp_range"]["shape"])
+    vk_snp = np.array(
+        np.memmap(rd / "vk_snp_range.npy", dtype=np.int64, mode="r", shape=shape)
+    )
+    d = svar2._find_ranges(
+        "chr1",
+        bed["chromStart"].to_numpy(),
+        bed["chromEnd"].to_numpy(),
+        samples=sorted_samples,
+    )
+    np.testing.assert_array_equal(
+        vk_snp.reshape(-1, 2), np.asarray(d["vk_snp_range"], np.int64).reshape(-1, 2)
+    )
+
+
+def test_write_svar2_duplicate_store_samples_raises(
+    svar2_store: Path, tmp_path: Path, monkeypatch
+):
+    """Duplicate sample names in the store must be refused, not silently mapped.
+
+    `list.index` used to point two slots at one column and `HashTable.add` would
+    shift every column after the duplicate; both write a wrong dataset (#351).
+    """
+    from genoray import SparseVar2
+
+    svar2 = SparseVar2(svar2_store)
+    monkeypatch.setattr(svar2, "available_samples", ["S0", "S0", "S1"])
+
+    bed = pl.DataFrame({"chrom": ["chr1"], "chromStart": [0], "chromEnd": [20]})
+    with pytest.raises(ValueError, match="duplicate sample names"):
+        gvl.write(tmp_path / "ds.gvl", bed, variants=svar2, overwrite=True)


### PR DESCRIPTION
Closes #351.

## The bug

`_write_from_svar2` mapped each selected sample to its store column with a linear `list.index`:

```python
sample_cols = np.asarray(
    [svar2.available_samples.index(s) for s in samples], np.int64
)
```

and `write()` always passes the full cohort explicitly, so **every** `.svar2`-backed dataset paid O(S²). At S = 535,662 (All of Us v9) that is ~1.4×10¹¹ string comparisons on one thread — about an hour before a single genotype is read. Thanks @bschilder for the diagnosis and the `py-spy` trace.

## The fix

Use a `hirola.HashTable` via gvl's own `s2i` helper. That is already the house pattern for name→index maps (`_indexing.py`, `_splice.py`, `_reference.py`), and it is what genoray's VCF/PGEN/SVAR1 readers do through their `_s2i` tables — `SparseVar2` is simply the one reader that never got it.

Two details worth flagging for review:

**Duplicate names now raise.** `HashTable.add` compacts to unique keys, so its lookup returns the rank in the deduped key array, not the store position. With a duplicate name every column after it shifts. `list.index` had a different failure — it pointed two slots at one column. Both write a silently wrong dataset, so the store is refused outright instead:

```python
if len(avail_s2i.keys) != len(avail):
    raise ValueError(...)
```

Verified against hirola directly: `add` keeps the *first* occurrence (matching `list.index`), and lookups are safe when the selection's dtype is narrower than the store's (`<U1` query on a `<U8` table).

**genoray's half is dodged, not fixed.** genoray resolves `samples` by name with the same O(S²) scan, once per contig (d-laub/genoray#168). Passing `samples=None` means "every sample in store order", which is exactly the selection when the two lists already agree, so the scan is skipped there. `write()` sorts the selection, so this only fires for a store that is itself sorted — the general fix belongs upstream in `SparseVar2._sample_idxs`.

## Docs

Both from the same report:

- `write()`'s `max_mem` entry now says the `.svar2` range cache is **outside** that budget — two `(R, S, P, 2)` int64 memmaps, 60.7 GiB for the reporter's chromosome. This matches what `SKILL.md` already documented; the docstring was the one place that didn't say it.
- `write()`'s `samples` entry, `Dataset.samples`, `SKILL.md`, and `docs/source/write.md` now state that the sample order is a **lexicographic** sort. `"1000"` sorts before `"999"`, so a positional join against a numerically-ordered phenotype table is silently wrong — align by name. (The reporter's separate hash-seed concern was retracted; `samples.sort()` makes the order deterministic.)

## Testing

Two tests added to `tests/dataset/test_write_svar2.py`:

- `test_write_svar2_sample_cols_permutes_unsorted_store` — a store whose order is `["S1", "S0"]`, so `sample_cols` is a real permutation. A store that is already sorted cannot distinguish rank-in-key-array from store-position, hence the reversed fixture. Also pins that the `samples=None` fast path does *not* fire here.
- `test_write_svar2_duplicate_store_samples_raises` — the new guard.

Full tree on a dedicated node: **1185 passed, 54 skipped, 4 xfailed, 0 failed.** `test_rayon_stress.py` was run separately against unmodified `main` and against this branch on the same node — both pass in ~36 s; it fails only under node load (#332).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQhokUGuGHJg4P8LDgxE4x
