### PR TITLE
fix(svar2): stop allocating R×S×P placeholder arrays at dataset open

### DIFF
--- a/python/genvarloader/_dataset/_svar2_haps.py
+++ b/python/genvarloader/_dataset/_svar2_haps.py
@@ -107,6 +107,41 @@ def _field_spec(sf: "StoredField") -> tuple[str, str, str]:
     return (sf.category, sf.name, _META_DTYPE[sf.dtype])
 
 
+@dataclass(frozen=True, slots=True)
+class _ShapeOnlyGenotypes:
+    """Zero-byte stand-in for the SVAR1 per-region genotype store.
+
+    SVAR2 reconstructs read-bound straight from the on-disk store, so ``Svar2Haps``
+    has no per-(region, sample) genotype index. The base ``Haps`` machinery and
+    ``Dataset`` only ever read ``genotypes.shape`` (ploidy, ``R``, ``S``) and
+    ``genotypes.lengths`` (which becomes ``n_variants``) from it; every path that
+    reads ``.data``/``.offsets`` is either overridden by ``Svar2Haps`` or guarded
+    by ``isinstance(..., Svar2Haps)``.
+
+    Previously this was a real ``Ragged`` built from ``np.zeros(R*S*P + 1, int64)``,
+    and its ``lengths`` materialised a second ``(R, S, P)`` int64 array: 32 B per
+    (region, sample, haplotype) of zeros that were never read. At cohort scale
+    that is the dominant anonymous memory of a dataset open -- 64 GB resident for
+    3,734 regions x 535,662 samples, ~200 GB for chr19's 11,834 regions -- and
+    forced dense chromosomes to be sharded to fit a 503 GB host.
+    """
+
+    shape: tuple[int, int, int, None]
+    """``(R, S, P, None)``: regions, samples, ploidy, ragged variants axis."""
+
+    @property
+    def lengths(self) -> NDArray[np.int32]:
+        """All-zero ``(R, S, P)`` counts as a read-only, zero-stride view.
+
+        Indexes and reduces like a materialised array (``Dataset.n_variants``
+        fancy-indexes and sums it) without allocating one.
+        """
+        return np.broadcast_to(np.zeros((), np.int32), self.shape[:-1])
+
+    def __len__(self) -> int:
+        return self.shape[0]
+
+
 @dataclass(slots=True)
 class _Svar2Cache:
     """The six memmapped ``svar2_ranges/`` arrays (all int64), sliced per query.
@@ -342,12 +377,13 @@ class Svar2Haps(Haps[_H]):
             raise ValueError(f"Missing variant fields: {missing}")
 
         # Minimal base-Haps fields. genotypes carries only the (R, S, P, None)
-        # shape (so ploidy = shape[-2] and n_variants.shape are available); its
-        # data is empty (svar2 has no per-region sparse genotype store).
-        empty_geno = Ragged.from_offsets(
-            np.empty(0, V_IDX_TYPE),
-            (R, S, P, None),
-            np.zeros(R * S * P + 1, np.int64),
+        # shape (so ploidy = shape[-2] and n_variants.shape are available); svar2
+        # has no per-region sparse genotype store, so it must not cost R*S*P
+        # bytes either -- see _ShapeOnlyGenotypes.
+        # Deliberately not a Ragged (a real one costs R*S*P offsets); cast via
+        # object because only .shape/.lengths are ever read from it.
+        empty_geno = cast(
+            "Ragged[V_IDX_TYPE]", cast(object, _ShapeOnlyGenotypes((R, S, P, None)))
         )
         empty_alt = RaggedAlleles.from_offsets(
             np.empty(0, np.uint8).view("S1"), (0, None), np.zeros(1, np.int64)

--- a/tests/dataset/test_svar2_dataset.py
+++ b/tests/dataset/test_svar2_dataset.py
@@ -1112,3 +1112,69 @@ def test_svar2_variant_windows_jitter_guard(tmp_path, svar2_fixture, _src):
     ds = gvl.Dataset.open(d, reference=ref).with_output_format("flat")
     with pytest.raises(NotImplementedError, match="right-clip"):
         ds.with_seqs("variant-windows", _WIN_OPT)[:, :]
+
+
+def test_svar2_open_does_not_allocate_per_cell_placeholders(
+    tmp_path, bed, svar2_fixture, _src
+):
+    """Opening an SVAR2-backed dataset must not materialise (R, S, P)-sized arrays.
+
+    ``Svar2Haps`` carries an SVAR1-shaped ``genotypes`` placeholder purely for its
+    shape (ploidy) and for ``n_variants``. When that placeholder was a real
+    ``Ragged`` it allocated ``R*S*P+1`` int64 offsets plus a same-sized
+    ``lengths`` array: 32 B per (region, sample, haplotype), i.e. 64 GB resident
+    for 3,734 regions x 535,662 samples and ~200 GB for chr19's 11,834 regions,
+    all zeros that are never read. Both must be zero-stride views.
+    """
+    from genoray import SparseVar2
+
+    from genvarloader._dataset._svar2_haps import Svar2Haps
+
+    _bcf, ref = _src
+    out = tmp_path / "placeholder.gvl"
+    gvl.write(
+        out, bed, variants=SparseVar2(svar2_fixture), samples=None, overwrite=True
+    )
+    ds = gvl.Dataset.open(out, reference=ref).with_seqs("haplotypes")
+    seqs = ds._seqs
+    assert isinstance(seqs, Svar2Haps)
+
+    R, S, P = ds.n_regions, ds.n_samples, ds.ploidy
+    assert seqs.genotypes.shape == (R, S, P, None)
+    assert seqs.n_variants.shape == (R, S, P)
+    assert seqs.n_variants.dtype == np.int32
+    assert not seqs.n_variants.any()
+    assert seqs.n_variants.strides == (0, 0, 0), (
+        f"n_variants is a materialised array (strides {seqs.n_variants.strides}), "
+        "not a zero-stride view"
+    )
+    # The documented SVAR2 limitation (issue #315) is unchanged: counts read 0.
+    counts = ds.n_variants()
+    assert counts.shape == (R, S, P)
+    assert not counts.any()
+    assert ds.n_variants(regions=0, samples=0).shape == (P,)
+
+
+def test_svar2_placeholder_genotypes_are_free_at_cohort_scale():
+    """The stand-in stays O(1) in memory at All of Us scale (12.7e9 cells)."""
+    import tracemalloc
+
+    from genvarloader._dataset._svar2_haps import _ShapeOnlyGenotypes
+
+    R, S, P = 11_834, 535_662, 2
+    tracemalloc.start()
+    geno = _ShapeOnlyGenotypes((R, S, P, None))
+    lengths = geno.lengths
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert geno.shape == (R, S, P, None)
+    assert int(geno.shape[-2]) == P
+    assert lengths.shape == (R, S, P)
+    assert lengths.strides == (0, 0, 0)
+    assert not lengths.flags.writeable
+    assert lengths[np.array([0, R - 1]), np.array([S - 1, 0])].tolist() == [
+        [0, 0],
+        [0, 0],
+    ]
+    assert peak < 1 << 20, f"placeholder allocated {peak} bytes"


### PR DESCRIPTION
Closes #355.

## What

`Svar2Haps.from_path` built its SVAR1-shaped `genotypes` placeholder as a real `Ragged` from `np.zeros(R*S*P + 1, int64)`, and `__post_init__` materialised `genotypes.lengths` as a second `(R, S, P)` int64 array. Both are zeros that are only ever read for their shape (ploidy) and, through `Dataset.n_variants()`, as a zero-filled array — 32 B per (region, sample, haplotype) at open: 64 GB resident for AoU chr22 (3,734 × 535,662 × 2), ~200 GB for chr19, ~2× that transiently.

This replaces the `Ragged` with `_ShapeOnlyGenotypes`, a frozen dataclass carrying `(R, S, P, None)` whose `lengths` is a read-only zero-stride `np.broadcast_to` view. `n_variants` becomes the `int32` its annotation already claims.

## Why it's safe

- Every reader of `.data`/`.offsets` is either overridden by `Svar2Haps` (`__call__`, `_reconstruct_variants`, `_reconstruct_variant_windows`, `get_haps_and_shifts`, `realign_track_block`, …) or sits behind an `isinstance(haps_obj, Svar2Haps)` guard (`_impl.py` variants/variant-windows estimate branches; `_reconstruct.py` routes SVAR2 to `_call_svar2` before the fused path; `get_variants_flat` is only reached from the overridden `__call__`).
- `.shape[-2]`, `.shape[:2]`, fancy indexing and `.sum(-1, dtype=np.int32)` on `n_variants` behave exactly as before; `Dataset.n_variants()` still returns the documented zeros for SVAR2 (#315).
- `Ragged.from_offsets` copies a zero-stride view into a contiguous array (verified: 3.2 GB for a 4 × 10⁸-cell test) and `.lengths` allocates again, so passing a `broadcast_to` view into a `Ragged` would not have helped — hence the stand-in.

## Tests

- `test_svar2_open_does_not_allocate_per_cell_placeholders`: opens the SVAR2 fixture dataset and asserts the placeholder is `(R, S, P, None)`, `n_variants` is an all-zero int32 view with strides `(0, 0, 0)`, and `Dataset.n_variants()` shapes/values are unchanged. Fails on `main` (int64, real strides).
- `test_svar2_placeholder_genotypes_are_free_at_cohort_scale`: constructs the stand-in at 11,834 × 535,662 × 2 under `tracemalloc` and asserts < 1 MiB, zero strides, read-only, indexable.

Run locally against a `maturin develop` build of `main` @ 936d85e: all SVAR2 test modules pass (107 passed, 1 skipped; the 7 pre-existing errors are the missing `vcfixture` test module). Full `tests/` (minus benchmarks) has an identical failure set before and after (439 ids, all "synthetic.fa.bgz not found" fixture data absent from my checkout) — no regressions. `basedpyright` on the module: 52 errors before and after (all pre-existing); ruff-format clean on the changed hunks.

## Context

Found while building per-chromosome haplotype stores for 535,662 All of Us genomes: SLVAR/SLHAP extraction peaked at 221 GB RSS on chr22 and could not fit chr19 whole on a 503 GB VM. With this change the anonymous part should shrink to the genuine working set; I'll report the measured before/after on the next chromosome run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)