### PR TITLE
fix(svar2): account for indels in haplotype_lengths

### DIFF
--- a/python/genvarloader/_dataset/_svar2_haps.py
+++ b/python/genvarloader/_dataset/_svar2_haps.py
@@ -585,6 +585,36 @@ class Svar2Haps(Haps[_H]):
             diffs[qsel] = np.asarray(d, np.int32).reshape(len(qsel), ploidy)
         return diffs
 
+    def _haplotype_ilens(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.integer],
+        deterministic: bool,
+        keep: NDArray[np.bool_] | None = None,
+        keep_offsets: NDArray[np.integer] | None = None,
+    ) -> NDArray[np.int32]:
+        """SVAR2 per-haplotype length deltas. Backs ``Dataset.haplotype_lengths``.
+
+        Must be overridden: the base :class:`Haps` implementation reads
+        ``self.genotypes``/``self.variants``, which are permanently-empty
+        SVAR1-shaped placeholders for this reconstructor, so inheriting it
+        silently yields all-zero deltas -- i.e. ``haplotype_lengths()`` reporting
+        the unadjusted reference span, and ``_output_bytes_per_instance``
+        under-sizing the ``"haplotypes"``/``"annotated"`` slots (the sibling of
+        the ``"variants"``/``"variant-windows"`` defect in #315).
+
+        ``keep``/``keep_offsets`` carry the SVAR1 exonic *pre*-filter's output.
+        The read-bound kernel applies the exonic filter itself (it is handed
+        ``self.filter == "exonic"``), so a caller-supplied mask has no meaning
+        here; reject it rather than ignore it.
+        """
+        if keep is not None or keep_offsets is not None:
+            raise NotImplementedError(
+                "Svar2Haps._haplotype_ilens does not accept a caller-supplied keep"
+                " mask: the read-bound kernel applies the exonic filter itself."
+            )
+        return self._haplotype_diffs(idx, np.asarray(regions, np.int32))
+
     def get_haps_and_shifts(
         self,
         idx: NDArray[np.integer],

--- a/tests/dataset/test_svar2_dataset.py
+++ b/tests/dataset/test_svar2_dataset.py
@@ -166,6 +166,44 @@ def test_svar2_haplotypes_match_svar1(tmp_path, bed, svar_fixture, svar2_fixture
     assert np.array_equal(a.data.view("u1"), b.data.view("u1"))
 
 
+def test_svar2_haplotype_lengths_match_svar1(
+    tmp_path, bed, svar_fixture, svar2_fixture, _src
+):
+    """``Dataset.haplotype_lengths()`` must account for indels on the SVAR2 path.
+
+    Regression: ``Svar2Haps`` implements ``_haplotype_diffs`` but did not override
+    ``_haplotype_ilens``, which is what ``Dataset.haplotype_lengths`` calls
+    (``_impl.py``). The call therefore fell through to the SVAR1 base
+    implementation, which read the permanently-empty placeholder ``genotypes``,
+    found every ``(region, sample, ploid)`` group empty, and returned all-zero
+    length deltas -- so ``haplotype_lengths()`` reported the unadjusted reference
+    span. ``Dataset._output_bytes_per_instance`` consumes this for the
+    ``"haplotypes"``/``"annotated"`` slot-size estimate, making it the sibling of
+    the ``"variants"``/``"variant-windows"`` defect tracked in #315.
+    """
+    _bcf, ref = _src
+    ds1, ds2 = _open_pair(tmp_path, bed, svar_fixture, svar2_fixture, ref)
+    ds1 = ds1.with_settings(deterministic=True).with_seqs("haplotypes")
+    ds2 = ds2.with_settings(deterministic=True).with_seqs("haplotypes")
+
+    hl1 = ds1.haplotype_lengths()
+    hl2 = ds2.haplotype_lengths()
+    assert hl1 is not None and hl2 is not None
+
+    # Guard against a vacuous pass: the fixture's het indels must make the two
+    # haplotypes of some (region, sample) differ in length. If they never do,
+    # an all-zero delta would be indistinguishable from the correct answer.
+    assert (hl1[..., 0] != hl1[..., 1]).any(), (
+        "fixture exercises no length-changing het variant; test would be vacuous"
+    )
+
+    np.testing.assert_array_equal(hl2, hl1)
+
+    # ...and the prediction must match what reconstruction actually produces.
+    actual = np.asarray(ds2[:, :].lengths)
+    np.testing.assert_array_equal(hl2, actual)
+
+
 def test_svar2_spliced_minus_strand_haplotypes_match_svar1(
     tmp_path, svar_fixture, svar2_fixture, _src
 ):


### PR DESCRIPTION
**Layer 1 of 5** in the `Haps` role/implementation split — see the design doc
`docs/superpowers/specs/2026-09-08-haps-role-split-design.md` (added by #365).
This layer is a standalone bug fix and does not depend on the rest of the stack.

---

`Svar2Haps` implements `_haplotype_diffs` but never overrode
`_haplotype_ilens`, which is what `Dataset.haplotype_lengths` calls. The
call fell through to the SVAR1 base implementation, which reads
`self.genotypes` / `self.variants` — permanently-empty SVAR1-shaped
placeholders on this reconstructor — found every (region, sample, ploid)
group empty, and returned all-zero length deltas. `haplotype_lengths()`
therefore reported the unadjusted reference span on any SVAR2 dataset.

On the existing 4-region x 2-sample fixture (a C>CAT insertion and a
GTA>G deletion), SVAR1 returns `[[38, 40], [42, 40]]` where SVAR2 returned
`[[40, 40], [40, 40]]`; 6 of 16 elements differ.

`Dataset._output_bytes_per_instance` consumes those lengths for the
"haplotypes" / "annotated" slot-size estimate, so the same zeros reach
the double-buffered slot sizing — the sibling of the "variants" /
"variant-windows" defect tracked in #315.

Override `_haplotype_ilens` to delegate to the existing
`_haplotype_diffs`, and reject a caller-supplied keep mask rather than
ignore it: the read-bound kernel applies the exonic filter itself.

Closes #361.

## Testing

`pytest tests/dataset tests/unit tests/parity` at the top of the stack:
**944 passed, 36 skipped, 2 xfailed, 0 failed** (Slurm job 1049099). This layer is
contained in that run.

The earlier per-layer numbers quoted here were wrong, not merely stale: the Slurm
helper passed *relative* test paths while overriding `PYTHONPATH` to the
worktree's package, so it collected the main checkout's tests against the
branch's code. That is a false-green generator. The helper now resolves test
paths against the worktree, and the count above is from a corrected run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Romp6JJHU4g1M7UyPyCSJH

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

