### PR TITLE
refactor(haps): query the reconstructor, not SVAR1 storage

### DIFF
--- a/docs/superpowers/specs/2026-09-08-haps-role-split-design.md
+++ b/docs/superpowers/specs/2026-09-08-haps-role-split-design.md
@@ -1,0 +1,196 @@
+# Splitting the `Haps` role from the SVAR1 implementation
+
+Status: approved 2026-09-08. Supersedes the placeholder-shrinking workaround in
+PR #356 (which stays as a hotfix; see "Relationship to PR #356").
+
+## Problem
+
+`Haps` fuses three unrelated jobs into one class. Only two of them are shared
+across variant backends.
+
+| # | Job | Consumers | Where it lives today |
+|---|-----|-----------|----------------------|
+| 1 | **Role marker** — "these seqs are variant-aware" | ~30 `isinstance(self._seqs, Haps)` / `case Haps()` sites across `_impl.py`, `_open.py`, `_reconstruct.py`, `_double_buffered_loader.py` | the class identity |
+| 2 | **View settings** — `kind`, `filter`, `min_af`/`max_af`, `var_fields`, `flank_length`, `token_lut`/`token_dtype`/`token_alphabet`/`unknown_token`, `window_opt`, `unphased_union`, `dummy_variant` | `Dataset.with_*`, via `dataclasses.replace` | base-class fields |
+| 3 | **SVAR1 storage** — `variants: _Variants`, `genotypes: Ragged`, `dosages`, `var_field_data`, `_ffi_static` | the SVAR1 kernels only | base-class fields |
+
+`Svar2Haps` needs jobs 1 and 2. It inherits job 3, so `Svar2Haps.from_path` must
+fabricate an empty `_Variants` and a fake `genotypes` `Ragged` purely to satisfy
+a data model it never reads. Its own module docstring says so outright: it
+"subclasses `Haps` only so the many `isinstance(_, Haps)` / `case Haps()` checks
+throughout the dataset machinery keep working; every read method is overridden."
+
+The fabrication is not inert. It leaks into callers, which must then be taught
+that the base class's own fields are lies:
+
+1. `_info_field_dtype` (`_impl.py:53-76`) special-cases `Svar2Haps` because
+   `variants.info` is permanently empty.
+2. The two memory-estimate branches in `Dataset._output_bytes_per_instance`
+   (`_impl.py:1437-1830`, "variants" and "variant-windows") each carry an
+   `isinstance(haps_obj, Svar2Haps)` fork plus ~10 comment blocks explaining
+   which base fields must not be trusted.
+3. `Dataset.ploidy`, `Dataset.haplotype_lengths`, and
+   `_output_bytes_per_instance` read `genotypes.shape[-2]` — a *storage* detail
+   standing in for a *dataset* property.
+4. `HapsTracks.__call__` routes on `isinstance(self.haps, Svar2Haps)`
+   (`_reconstruct.py:147-162`) before its SVAR1 body.
+5. `Dataset.with_var_fields` forks on `Svar2Haps` (`_impl.py:361-403`).
+6. `get_variants_flat` (`_flat_variants.py:883`) reads `haps.genotypes`
+   directly; it is only ever reached from the SVAR1 `__call__`, but its
+   signature claims any `Haps`.
+
+The failure mode this shape invites is silent, not loud: a base method that
+`Svar2Haps` forgets to override does not raise — it reads zeros out of the
+placeholder and returns a plausible wrong answer. See "Bug found while
+designing this" below for a live instance.
+
+PR #356 makes the fake `genotypes` cheap (`_ShapeOnlyGenotypes`, a zero-stride
+`broadcast_to` view) rather than removing the need for a fake. That is the right
+hotfix and the wrong end state.
+
+## Design
+
+`Haps` becomes an abstract base holding only jobs 1 and 2. Today's `Haps` body
+becomes `Svar1Haps`. `Svar2Haps` becomes its sibling rather than its subclass.
+
+```
+Haps[_H]  (ABC, Reconstructor[_H])      <- the ~30 isinstance sites keep working verbatim
+|-- settings fields (job 2, unchanged, so replace() keeps working)
+|-- abstract: __call__, to_kind
+|-- abstract query surface (job 1):
+|     ploidy                                     -> int
+|     n_variants                                 -> NDArray[int32], shape (R, S, P)
+|     _haplotype_ilens(idx, regions, deterministic, keep=None, keep_offsets=None)
+|     haplotype_lengths_for_plan(idx, regions)
+|     measure_variant_payload(idx, regions)      -> (n_vars, ref_span, alt_bytes)
+|     var_field_dtype(field)                     -> np.dtype
+|     has_ref_alleles                            -> bool
+|     available_var_fields                       -> list[str]
+|     realign_track_block(...)
+|
+|-- Svar1Haps(Haps[_H])   owns variants / genotypes / dosages / var_field_data / _ffi_static
+`-- Svar2Haps(Haps[_H])   owns store / cache; no placeholders at all
+```
+
+`Haps` is **not** in `genvarloader.__all__`, so the rename is internal: no public
+API change, and no `skills/genvarloader/SKILL.md` or `docs/source/api.md` update
+is required by the CLAUDE.md public-API gate.
+
+### The abstract query surface, derived from actual callers
+
+Each member exists because a caller in `_impl.py`/`_reconstruct.py` asks for it
+today by reaching into SVAR1 storage. Nothing is added speculatively.
+
+| Member | Replaces | SVAR1 impl | SVAR2 impl |
+|---|---|---|---|
+| `ploidy` | `genotypes.shape[-2]` (`_impl.py:1061`, `:1318`, `:1485`, `:1648`) | `genotypes.shape[-2]` | stored `P` from the svar2 cache meta |
+| `n_variants` | `genotypes.lengths` set in `__post_init__` | unchanged | real per-(r,s,p) counts, or an explicit documented zero contract |
+| `_haplotype_ilens` | already abstract in spirit | unchanged | delegates to existing `_haplotype_diffs` |
+| `measure_variant_payload` | the `_allele_bytes_sum` + `variants.start.dtype` open-coding in both estimate branches | new wrapper over existing `_allele_bytes_sum` | **already exists** (`_svar2_haps.py:851`) |
+| `var_field_dtype` | `variants.info[f].dtype` + the `Svar2Haps` fork in `_info_field_dtype` | `variants.info[f].dtype` | `store_fields[f].dtype` |
+| `has_ref_alleles` | `variants.ref is not None` (`_impl.py:759`) | `variants.ref is not None` | `False` |
+| `realign_track_block` | `isinstance(self.haps, Svar2Haps)` in `HapsTracks.__call__` | the current SVAR1 fused body | the current `_call_svar2` body |
+
+`measure_variant_payload` is the keystone: `Svar2Haps` already implements it
+precisely because the estimate branches could not trust the placeholders. Making
+it part of the role and giving `Svar1Haps` the matching implementation collapses
+both `isinstance` forks into one unconditional call.
+
+### What deletes
+
+- `_ShapeOnlyGenotypes` and the whole PR #356 workaround.
+- Both `isinstance(haps_obj, Svar2Haps)` forks in `_output_bytes_per_instance`.
+- The `Svar2Haps` fork in `_info_field_dtype` and in `with_var_fields`.
+- The `isinstance(self.haps, Svar2Haps)` fork in `HapsTracks.__call__`.
+- The ~10 comment blocks across `_impl.py` documenting which inherited fields
+  are not to be trusted.
+
+### What stays
+
+- `HapsTracks._call_svar2`'s body — a genuine kernel-dispatch difference. It
+  moves from an `isinstance` in `HapsTracks` to a `realign_track_block`
+  override on each subclass.
+- Every `NotImplementedError` guard in `Svar2Haps` (`min_af`/`max_af`,
+  annotated haps, splicing, jitter). Those are real capability gaps, not
+  artifacts of the class shape.
+- `get_variants_flat`, narrowed from `Haps` to `Svar1Haps`.
+
+## Bug found while designing this
+
+`Svar2Haps` implements `_haplotype_diffs` but does **not** override
+`_haplotype_ilens`. `Dataset.haplotype_lengths` calls `_haplotype_ilens`
+(`_impl.py:1309`), so on an SVAR2 dataset it falls through to the SVAR1 base
+implementation, which reads the empty `genotypes` placeholder, finds every
+group empty, and returns all-zero length deltas. `haplotype_lengths()` therefore
+reports the unadjusted reference span, ignoring indels.
+
+`Dataset._output_bytes_per_instance` consumes `haplotype_lengths()` for the
+`"haplotypes"` and `"annotated"` branches, so the same zeros propagate into the
+double-buffered slot-size estimate — the sibling of the `"variants"` /
+`"variant-windows"` defect already tracked as #315.
+
+This is precisely the silent-wrong-answer failure mode the current class shape
+invites, and it is the strongest argument for the split: under an ABC, a missing
+override is an instantiation-time `TypeError`, not a plausible zero.
+
+It gets its own issue and its own bottom-of-stack PR so it can land ahead of the
+refactor.
+
+## Relationship to PR #356
+
+PR #356 (external contributor) fixes a real 64 GB open-time allocation at All of
+Us scale and unblocks their chr19 run today. Recommendation: **merge #356
+as-is**, then delete `_ShapeOnlyGenotypes` in the final layer of this stack.
+Asking the contributor to absorb this refactor would be unfair scope creep on a
+correct bug report.
+
+If #356 has not merged when the final layer is written, that layer deletes the
+`Ragged` placeholder instead; the end state is identical either way.
+
+## Implementation: a 4-PR stack
+
+Each layer is independently green and independently reviewable.
+
+1. `fix/svar2-haplotype-lengths-indels` — override `_haplotype_ilens` on
+   `Svar2Haps` (delegating to `_haplotype_diffs`) plus a regression test
+   asserting `haplotype_lengths()` matches reconstructed lengths on an
+   indel-bearing SVAR2 fixture. Small, valuable on its own, merges first.
+2. `refactor/haps-query-surface` — add the query surface listed above to `Haps`,
+   implement on both classes, switch every caller off SVAR1 internals. No
+   rename yet, so the diff is readable. The `isinstance(_, Svar2Haps)` forks
+   delete here.
+3. `refactor/haps-role-abc` — rename `Haps` -> `Svar1Haps`, hoist the ABC into
+   `Haps`, reparent `Svar2Haps` to it. Mostly mechanical.
+4. `refactor/haps-drop-placeholders` — delete the fabricated `genotypes` /
+   `_Variants` from `Svar2Haps.from_path` and `_ShapeOnlyGenotypes`.
+
+## Testing
+
+This is a behavior-preserving refactor except for layer 1, which fixes a bug.
+
+- Gate for every layer: the full tree, `pixi run -e dev pytest tests -q`. Scoped
+  runs skip `tests/unit/` (per CLAUDE.md), which is exactly where the
+  reconstructor-construction tests live (`tests/unit/dataset/test_build_reconstructor.py`,
+  `tests/unit/test_slot_fit_property.py`).
+- The existing SVAR1/SVAR2 parity suite in `tests/dataset/` already pins the
+  behavior that must not move.
+- New in layer 1: the `haplotype_lengths` regression test described above.
+- New in layer 4: assert `Svar2Haps` has no `genotypes`/`variants` attribute at
+  all — replacing PR #356's two allocation-size tests, which become moot once
+  there is nothing to allocate.
+- New in layer 3: round-trip `replace(haps, min_af=...)` on both subclasses, to
+  pin that the settings block stays `dataclasses.replace`-able across the
+  hierarchy change.
+- `tests/unit/test_slot_fit_property.py:85` and several docstrings in
+  `tests/dataset/test_svar2_*.py` describe the placeholders; they need updating
+  in the layer that removes what they describe.
+
+## Non-goals
+
+- No change to the `.svar2` on-disk format or to any Rust kernel.
+- No change to public API, `__all__`, docs, or the `genvarloader` skill.
+- Not lifting any `Svar2Haps` capability guard (`min_af`/`max_af`, annotated
+  haps, splicing, jitter). Those are separate features.
+- Not touching the `StreamingDataset` `StreamBackend` path, which is coordinated
+  through the StreamingDataset project board and targets the `streaming` branch.
+  This work targets `main`.

--- a/python/genvarloader/_dataset/_haps.py
+++ b/python/genvarloader/_dataset/_haps.py
@@ -326,6 +326,62 @@ class Haps(Reconstructor[_H]):
                 + "Doing this automatically is not yet supported."
             )
 
+    # ---- backend-agnostic query surface ----
+    #
+    # These describe the dataset, not the storage layout, so every caller in
+    # ``_impl.py`` / ``_reconstruct.py`` can ask a ``Haps`` about it without
+    # reaching into SVAR1-specific fields (``genotypes``, ``variants``). Each
+    # member exists because some caller was already doing exactly that. See
+    # docs/superpowers/specs/2026-09-08-haps-role-split-design.md.
+
+    @property
+    def stored_ploidy(self) -> int:
+        """Ploidy as laid out on disk, ignoring any ``unphased_union`` folding.
+
+        Distinct from :attr:`Dataset.ploidy`, which reports ``1`` under
+        ``unphased_union``. Grouping that is keyed on the stored layout (e.g.
+        :meth:`_allele_bytes_sum`'s result shape) must use this.
+        """
+        return int(self.genotypes.shape[-2])
+
+    @property
+    def has_ref_alleles(self) -> bool:
+        """Whether REF allele bytes are available (needed by ``ref='allele'``)."""
+        return self.variants.ref is not None
+
+    def var_field_dtype(self, field: str) -> np.dtype:
+        """The numpy dtype of per-variant *scalar* field ``field``.
+
+        Args:
+            field: A scalar variant field: ``"start"``, ``"ilen"``, ``"dosage"``,
+                or the name of a numeric INFO / per-call FORMAT field.
+
+        Returns:
+            The field's numpy dtype.
+
+        Raises:
+            KeyError: If ``field`` is unknown, or is one of the variable-length
+                allele fields ``"alt"``/``"ref"``, which have no scalar dtype --
+                callers size those from their actual byte payload instead.
+        """
+        if field in ("alt", "ref"):
+            raise KeyError(
+                f"{field!r} is a variable-length allele field with no scalar dtype;"
+                " size it from its byte payload instead."
+            )
+        if field == "start":
+            return self.variants.start.dtype
+        if field == "ilen":
+            return self.variants.ilen.dtype
+        if field == "dosage":
+            if self.dosages is None:
+                raise KeyError("this dataset has no dosages")
+            return self.dosages.data.dtype
+        try:
+            return self.variants.info[field].dtype
+        except KeyError:
+            raise KeyError(f"unknown variant field {field!r}") from None
+
     @property
     def ffi_static(self) -> _HapsFfiStatic:
         """Lazily-computed, cached FFI-ready sub-linear arrays (see _HapsFfiStatic)."""
@@ -530,7 +586,7 @@ class Haps(Reconstructor[_H]):
         )
 
         # genotypes are (r, s, p, ~v)
-        ploidy = cast(int, self.genotypes.shape[-2])
+        ploidy = self.stored_ploidy
         return hap_ilens.reshape(-1, ploidy)
 
     def haplotype_lengths_for_plan(
@@ -685,7 +741,7 @@ class Haps(Reconstructor[_H]):
         splice_plan: SplicePlan | None = None,
     ) -> ReconstructionRequest:
         """Compute the per-batch prep state for haplotype reconstruction."""
-        ploidy = cast(int, self.genotypes.shape[-2])
+        ploidy = self.stored_ploidy
         batch_size = len(idx)
         # (b)
         lengths = regions[:, 2] - regions[:, 1]

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -50,32 +50,6 @@ if TORCH_AVAILABLE:
 _py_open = open
 
 
-def _info_field_dtype(haps_obj: Haps, f: str) -> np.dtype:
-    """Dtype of variant INFO/store field ``f``, used by ``_output_bytes_per_instance``.
-
-    ``Svar2Haps.variants`` is a dummy placeholder with an empty ``info`` dict;
-    its INFO/store field dtypes live on ``store_fields`` instead. Falls back
-    to ``variants.info[f].dtype`` for other ``Haps`` implementations (e.g.
-    ``Svar1``/VCF/PGEN-backed datasets), where ``variants.info`` is the real
-    on-disk INFO table.
-
-    Args:
-        haps_obj: The ``Haps`` reconstructor whose variant field dtype is
-            being looked up.
-        f: The variant field name (must not be one of the special-cased
-            scalar fields ``start``/``ilen``/``dosage``/``alt``/``ref``,
-            which are handled separately by callers).
-
-    Returns:
-        The numpy dtype of field ``f``.
-    """
-    from ._svar2_haps import Svar2Haps
-
-    if isinstance(haps_obj, Svar2Haps) and f in haps_obj.store_fields:
-        return haps_obj.store_fields[f].dtype
-    return haps_obj.variants.info[f].dtype
-
-
 @dataclass(slots=True, frozen=True)
 class Dataset:
     """A dataset of genotypes, reference sequences, and intervals.
@@ -756,7 +730,7 @@ class Dataset:
                     " with_seqs('variant-windows', VarWindowOpt(flank_length=...,"
                     " token_alphabet=..., unknown_token=...))."
                 )
-            if window_opt.ref == "allele" and self._seqs.variants.ref is None:
+            if window_opt.ref == "allele" and not self._seqs.has_ref_alleles:
                 raise ValueError(
                     "VarWindowOpt(ref='allele') needs REF alleles, but this dataset"
                     " has none. Use ref='window', or write the dataset with REF."
@@ -1058,7 +1032,7 @@ class Dataset:
         if isinstance(self._seqs, Haps):
             if self._seqs.unphased_union:
                 return 1
-            return self._seqs.genotypes.shape[-2]
+            return self._seqs.stored_ploidy
 
     @property
     def shape(self) -> tuple[int, int]:
@@ -1315,7 +1289,7 @@ class Dataset:
         if out_reshape is not None:
             hap_lens = hap_lens.reshape(
                 *out_reshape,
-                self._seqs.genotypes.shape[-2],
+                self._seqs.stored_ploidy,
             )
 
         return hap_lens
@@ -1482,7 +1456,7 @@ class Dataset:
             # summing every real haplotype's contribution into one
             # per-instance total, which is what unphased_union's un-deduped
             # union semantics require either way.
-            real_ploidy = haps_obj.genotypes.shape[-2]
+            real_ploidy = haps_obj.stored_ploidy
 
             # Svar2Haps: self.n_variants (-> self.genotypes.lengths) and
             # _allele_bytes_sum (-> self.genotypes[...]/self.variants.alt) both
@@ -1514,16 +1488,16 @@ class Dataset:
             # "start: ALWAYS"), so charge it independent of var_fields
             # membership -- charging it only when "start" in var_fields
             # under-counts for e.g. the legal var_fields=["alt"].
-            total += n_vars_total * haps_obj.variants.start.dtype.itemsize
+            total += n_vars_total * haps_obj.var_field_dtype("start").itemsize
             for f in var_fields:
                 if f == "start":
                     continue  # charged unconditionally above
                 elif f == "ilen":
-                    total += n_vars_total * haps_obj.variants.ilen.dtype.itemsize
+                    total += n_vars_total * haps_obj.var_field_dtype("ilen").itemsize
                 elif f == "dosage":
                     if haps_obj.dosages is None:
                         continue
-                    dosage_dtype = haps_obj.dosages.data.dtype
+                    dosage_dtype = haps_obj.var_field_dtype("dosage")
                     total += n_vars_total * dosage_dtype.itemsize
                 elif f in ("alt", "ref"):
                     if svar2_alt_bytes is not None:
@@ -1538,11 +1512,10 @@ class Dataset:
                         per_ploid = haps_obj._allele_bytes_sum(ds_idx, f)
                         total += per_ploid.reshape(-1, real_ploidy).sum(-1)
                 else:
-                    # INFO column: numeric, known dtype from on-disk schema.
-                    # _info_field_dtype guards Svar2Haps, whose .variants is a
-                    # dummy placeholder (info={}) -- store fields' dtypes live
-                    # in the store manifest instead.
-                    info_dtype = _info_field_dtype(haps_obj, f)
+                    # INFO column: numeric, known dtype -- from the on-disk
+                    # schema on SVAR1, from the store manifest on SVAR2.
+                    # var_field_dtype knows which; the caller does not care.
+                    info_dtype = haps_obj.var_field_dtype(f)
                     total += n_vars_total * info_dtype.itemsize
             # ride-along flank tokens (flat output only): 2L tokens per variant.
             if getattr(haps_obj, "flank_length", 0) and haps_obj.token_lut is not None:
@@ -1590,22 +1563,26 @@ class Dataset:
                 # (including "start") for each empty group -- so charge it
                 # once here, outside the var_fields loop, mirroring the
                 # real-variant charge above.
-                total += n_dummy_groups * haps_obj.variants.start.dtype.itemsize
+                total += n_dummy_groups * haps_obj.var_field_dtype("start").itemsize
                 for f in var_fields:
                     if f == "start":
                         continue  # charged unconditionally above
                     elif f == "ilen":
-                        total += n_dummy_groups * haps_obj.variants.ilen.dtype.itemsize
+                        total += (
+                            n_dummy_groups * haps_obj.var_field_dtype("ilen").itemsize
+                        )
                     elif f == "dosage":
                         if haps_obj.dosages is None:
                             continue
-                        total += n_dummy_groups * haps_obj.dosages.data.dtype.itemsize
+                        total += (
+                            n_dummy_groups * haps_obj.var_field_dtype("dosage").itemsize
+                        )
                     elif f == "alt":
                         total += n_dummy_groups * len(dummy.alt)
                     elif f == "ref":
                         total += n_dummy_groups * len(dummy.ref)
                     else:
-                        info_dtype = _info_field_dtype(haps_obj, f)
+                        info_dtype = haps_obj.var_field_dtype(f)
                         total += n_dummy_groups * info_dtype.itemsize
                 if (
                     getattr(haps_obj, "flank_length", 0)
@@ -1645,7 +1622,7 @@ class Dataset:
             # haplotype's contribution into one per-instance total, which is
             # what unphased_union's un-deduped union semantics require either
             # way (see the "variants" branch above for the same fix).
-            real_ploidy = haps_obj.genotypes.shape[-2]
+            real_ploidy = haps_obj.stored_ploidy
 
             # Svar2Haps: self.n_variants/self.genotypes/self.variants are
             # permanently-empty SVAR1-shaped placeholders for this
@@ -1754,22 +1731,21 @@ class Dataset:
             # get_variants_flat's "start: ALWAYS"), so charge it independent of
             # var_fields membership -- charging it only when "start" in
             # var_fields under-counts for e.g. the legal var_fields=["alt"].
-            total += n_vars_total * haps_obj.variants.start.dtype.itemsize
+            total += n_vars_total * haps_obj.var_field_dtype("start").itemsize
             for f in haps_obj.var_fields:
                 if f in ("alt", "ref", "start"):
                     continue  # "start" charged unconditionally above
                 if f == "ilen":
-                    total += n_vars_total * haps_obj.variants.ilen.dtype.itemsize
+                    total += n_vars_total * haps_obj.var_field_dtype("ilen").itemsize
                 elif f == "dosage":
                     if haps_obj.dosages is None:
                         continue
-                    total += n_vars_total * haps_obj.dosages.data.dtype.itemsize
+                    total += n_vars_total * haps_obj.var_field_dtype("dosage").itemsize
                 else:
-                    # INFO column: numeric, known dtype from on-disk schema.
-                    # _info_field_dtype guards Svar2Haps, whose .variants is a
-                    # dummy placeholder (info={}) -- store fields' dtypes live
-                    # in the store manifest instead.
-                    info_dtype = _info_field_dtype(haps_obj, f)
+                    # INFO column: numeric, known dtype -- from the on-disk
+                    # schema on SVAR1, from the store manifest on SVAR2.
+                    # var_field_dtype knows which; the caller does not care.
+                    info_dtype = haps_obj.var_field_dtype(f)
                     total += n_vars_total * info_dtype.itemsize
             if include_offsets:
                 # "start" always has its own outer-offsets array (it is
@@ -1812,18 +1788,22 @@ class Dataset:
                 # "start" dummy rows are filled unconditionally too (see the
                 # "variants" branch's dummy loop above for the same rationale)
                 # -- charge it once here, outside the var_fields loop.
-                total += n_dummy_groups * haps_obj.variants.start.dtype.itemsize
+                total += n_dummy_groups * haps_obj.var_field_dtype("start").itemsize
                 for f in haps_obj.var_fields:
                     if f in ("alt", "ref", "start"):
                         continue  # "start" charged unconditionally above
                     if f == "ilen":
-                        total += n_dummy_groups * haps_obj.variants.ilen.dtype.itemsize
+                        total += (
+                            n_dummy_groups * haps_obj.var_field_dtype("ilen").itemsize
+                        )
                     elif f == "dosage":
                         if haps_obj.dosages is None:
                             continue
-                        total += n_dummy_groups * haps_obj.dosages.data.dtype.itemsize
+                        total += (
+                            n_dummy_groups * haps_obj.var_field_dtype("dosage").itemsize
+                        )
                     else:
-                        info_dtype = _info_field_dtype(haps_obj, f)
+                        info_dtype = haps_obj.var_field_dtype(f)
                         total += n_dummy_groups * info_dtype.itemsize
                 if include_offsets:
                     # Only the window slots' inner (per-variant) offsets grow

--- a/python/genvarloader/_dataset/_reconstruct.py
+++ b/python/genvarloader/_dataset/_reconstruct.py
@@ -292,7 +292,7 @@ class HapsTracks(Reconstructor[tuple[_H, _T]]):
             out_shape = (
                 len(idx),
                 len(self.tracks.active_tracks),
-                self.haps.genotypes.shape[-2],
+                self.haps.stored_ploidy,
                 None,
             )
 
@@ -442,7 +442,7 @@ class HapsTracks(Reconstructor[tuple[_H, _T]]):
             out_shape = (
                 len(idx),
                 len(self.tracks.active_tracks),
-                self.haps.genotypes.shape[-2],
+                self.haps.stored_ploidy,
                 None,
             )
 

--- a/python/genvarloader/_dataset/_svar2_haps.py
+++ b/python/genvarloader/_dataset/_svar2_haps.py
@@ -218,6 +218,13 @@ class Svar2Haps(Haps[_H]):
     """The .svar2 store's contig names (used to open the store's ContigReaders)."""
     ds_contigs: list[str] = field(default_factory=list)
     """The dataset's contig names (``regions[:, 0]`` indexes into this)."""
+    ploidy: int = 2
+    """The store's ploidy, from the svar2 range cache's ``svar2_meta.json``.
+
+    Backs :attr:`stored_ploidy`. Held directly rather than read off a
+    ``genotypes`` array: svar2 has no per-region sparse genotype store, so the
+    inherited ``genotypes`` field is a placeholder here (see the class docstring).
+    """
     max_jitter: int = 0
     """The dataset's write-time max_jitter. When > 0 the cache's per-query ranges
     were computed over a max_jitter-padded window, which over-includes variants past
@@ -275,6 +282,38 @@ class Svar2Haps(Haps[_H]):
                 f" .svar2 store, whose contigs are {self.store_contigs}."
             )
         return contig
+
+    # ---- backend-agnostic query surface (see Haps) ----
+
+    @property
+    def stored_ploidy(self) -> int:
+        """Ploidy as laid out in the .svar2 store."""
+        return self.ploidy
+
+    @property
+    def has_ref_alleles(self) -> bool:
+        """SVAR2 never carries REF allele bytes (the decode is ALT-only)."""
+        return False
+
+    def var_field_dtype(self, field: str) -> np.dtype:
+        """The dtype of a scalar variant field, from the store manifest.
+
+        The base implementation reads ``self.variants``, which is a placeholder
+        here; the .svar2 store's INFO/FORMAT dtypes live in ``store_fields``, and
+        ``start``/``ilen`` are fixed by the read-bound decode kernel's output.
+        """
+        if field in ("alt", "ref"):
+            raise KeyError(
+                f"{field!r} is a variable-length allele field with no scalar dtype;"
+                " size it from its byte payload instead."
+            )
+        if field == "start":
+            return np.dtype(POS_TYPE)
+        if field == "ilen":
+            return np.dtype(np.int32)
+        if field in self.store_fields:
+            return self.store_fields[field].dtype
+        raise KeyError(f"unknown variant field {field!r}")
 
     # ---- construction ----
 
@@ -375,6 +414,7 @@ class Svar2Haps(Haps[_H]):
             cache=cache,
             store_contigs=list(sv.contigs),
             ds_contigs=list(contigs),
+            ploidy=P,
             max_jitter=max_jitter,
             store_fields=store_fields,
             var_fields=var_fields,
@@ -484,7 +524,7 @@ class Svar2Haps(Haps[_H]):
         """
         assert self.store is not None
         regions = np.asarray(regions, np.int32)
-        P = int(self.genotypes.shape[-2])
+        P = self.stored_ploidy
         b = len(idx)
 
         perm = np.asarray(splice_plan.permutation, np.intp)
@@ -564,7 +604,7 @@ class Svar2Haps(Haps[_H]):
     ) -> NDArray[np.int32]:
         """Return ``(query, ploidy)`` SVAR2 length deltas."""
         regions = np.asarray(regions, np.int32)
-        ploidy = int(self.genotypes.shape[-2])
+        ploidy = self.stored_ploidy
         diffs = np.empty((len(idx), ploidy), np.int32)
         for ci, qsel, gi in self._gathered_groups(idx, regions, ploidy):
             d = hap_diffs_from_svar2_readbound(
@@ -647,7 +687,7 @@ class Svar2Haps(Haps[_H]):
                 "get_haps_and_shifts expects splice_plan=None."
             )
         regions = np.asarray(regions, np.int32)
-        P = int(self.genotypes.shape[-2])
+        P = self.stored_ploidy
         b = len(idx)
         lengths = (regions[:, 2] - regions[:, 1]).astype(np.int64)
 
@@ -767,7 +807,7 @@ class Svar2Haps(Haps[_H]):
             )
         assert self.store is not None
         regions = np.asarray(regions, np.int32)
-        P = int(self.genotypes.shape[-2])
+        P = self.stored_ploidy
         b = len(idx)
 
         params_c = np.ascontiguousarray(params, np.float64)
@@ -911,7 +951,7 @@ class Svar2Haps(Haps[_H]):
               instance's variants.
         """
         regions = np.asarray(regions, np.int32)
-        P = int(self.genotypes.shape[-2])
+        P = self.stored_ploidy
         b = len(idx)
 
         n_vars_total = np.zeros(b, np.int64)
@@ -985,7 +1025,7 @@ class Svar2Haps(Haps[_H]):
                 bytes, and any requested INFO/FORMAT fields).
         """
         regions = np.asarray(regions, np.int32)
-        P = int(self.genotypes.shape[-2])
+        P = self.stored_ploidy
         b = len(idx)
         p_eff = 1 if self.unphased_union else P
 
@@ -1115,7 +1155,7 @@ class Svar2Haps(Haps[_H]):
         include_ilen = "ilen" in self.var_fields
 
         regions = np.asarray(regions, np.int32)
-        P = int(self.genotypes.shape[-2])
+        P = self.stored_ploidy
         b = len(idx)
 
         p_eff = 1 if self.unphased_union else P


### PR DESCRIPTION
**Layer 2 of 5** in the `Haps` role/implementation split. Adds the design doc
`docs/superpowers/specs/2026-09-08-haps-role-split-design.md`, which motivates
the whole stack. Stacked on #364.

## Why

PR #356 fixed a symptom of an architectural problem: `Svar2Haps` inherits from
`Haps`, a class whose fields *are* the SVAR1 on-disk layout (a sparse
`Ragged` genotype array plus a `_Variants` struct). SVAR2 has neither — it
decodes read-bound from a `.svar2` store — so `Svar2Haps.from_path` fabricates
empty SVAR1-shaped placeholders to satisfy the inherited fields. Every caller
that reads those fields off the role gets a silently wrong answer instead of a
type error. #361 (fixed in #364) and #363 are two instances of that family.

The fix is to make the base class a *role* — what a haplotype reconstructor
must answer — and push the SVAR1 storage into a sibling implementation. This
stack does that in reviewable layers, each behavior-preserving except #364.

---

`Dataset` and `HapsTracks` read SVAR1 storage internals off whatever
`Haps` they were handed — `genotypes.shape[-2]` for ploidy,
`variants.ref is not None` for REF availability, `variants.start.dtype` /
`variants.ilen.dtype` / `variants.info[f].dtype` / `dosages.data.dtype`
for the memory estimates. On `Svar2Haps` those fields are fabricated
SVAR1-shaped placeholders, so each site either needed an
`isinstance(_, Svar2Haps)` fork or a comment warning that the inherited
field is a lie.

Add a small backend-agnostic query surface to the `Haps` role —
`stored_ploidy`, `has_ref_alleles`, `var_field_dtype(field)` — and
override it on `Svar2Haps` to read the `.svar2` store manifest. Switch
every caller in `_impl.py` and `_reconstruct.py` onto it. `Svar2Haps`
gains an explicit `ploidy` field carrying the store's ploidy rather than
inferring it from the placeholder's shape.

`_info_field_dtype` deletes: it existed only to fork on
`isinstance(haps_obj, Svar2Haps)`, and `var_field_dtype` subsumes it.

Behavior-preserving.

## Testing

`pytest tests/dataset tests/unit tests/parity` at the top of the stack:
**944 passed, 36 skipped, 2 xfailed, 0 failed** (Slurm job 1049099). This layer is
contained in that run.

The earlier per-layer numbers quoted here were wrong, not merely stale: the Slurm
helper passed *relative* test paths while overriding `PYTHONPATH` to the
worktree's package, so it collected the main checkout's tests against the
branch's code. That is a false-green generator. The helper now resolves test
paths against the worktree, and the count above is from a corrected run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Romp6JJHU4g1M7UyPyCSJH

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

