### PR TITLE
refactor(haps): measure variant payload through the reconstructor

### DIFF
--- a/docs/superpowers/specs/2026-09-08-haps-role-split-design.md
+++ b/docs/superpowers/specs/2026-09-08-haps-role-split-design.md
@@ -147,21 +147,29 @@ correct bug report.
 If #356 has not merged when the final layer is written, that layer deletes the
 `Ragged` placeholder instead; the end state is identical either way.
 
-## Implementation: a 4-PR stack
+## Implementation: a 5-PR stack
 
-Each layer is independently green and independently reviewable.
+Each layer is independently green and independently reviewable. (Planned as
+four; the query surface split cleanly into a cheap "read scalars off the
+reconstructor" layer and a heavier "measure the variant payload" layer, and
+splitting them kept each diff reviewable.)
 
 1. `fix/svar2-haplotype-lengths-indels` — override `_haplotype_ilens` on
    `Svar2Haps` (delegating to `_haplotype_diffs`) plus a regression test
    asserting `haplotype_lengths()` matches reconstructed lengths on an
    indel-bearing SVAR2 fixture. Small, valuable on its own, merges first.
-2. `refactor/haps-query-surface` — add the query surface listed above to `Haps`,
-   implement on both classes, switch every caller off SVAR1 internals. No
-   rename yet, so the diff is readable. The `isinstance(_, Svar2Haps)` forks
-   delete here.
-3. `refactor/haps-role-abc` — rename `Haps` -> `Svar1Haps`, hoist the ABC into
-   `Haps`, reparent `Svar2Haps` to it. Mostly mechanical.
-4. `refactor/haps-drop-placeholders` — delete the fabricated `genotypes` /
+2. `refactor/haps-query-surface` — add the cheap scalar members
+   (`stored_ploidy`, `has_ref_alleles`, `var_field_dtype`) to `Haps`,
+   implement on both classes, switch every caller off SVAR1 internals.
+   `_info_field_dtype` deletes here. No rename yet, so the diff is readable.
+3. `refactor/haps-payload-measure` — add `measure_variant_payload`,
+   `ref_allele_bytes` and `prepare_var_fields`; implement on `Haps`. The two
+   `isinstance(haps_obj, Svar2Haps)` estimate forks and the `with_var_fields`
+   fork all delete here, and `_impl.py` stops importing `Svar2Haps`.
+4. `refactor/haps-role-abc` — rename `Haps` -> `Svar1Haps`, hoist the ABC into
+   `Haps`, reparent `Svar2Haps` to it, and move the `HapsTracks.__call__`
+   dispatch onto a `realign_track_block` override. Mostly mechanical.
+5. `refactor/haps-drop-placeholders` — delete the fabricated `genotypes` /
    `_Variants` from `Svar2Haps.from_path` and `_ShapeOnlyGenotypes`.
 
 ## Testing
@@ -175,15 +183,31 @@ This is a behavior-preserving refactor except for layer 1, which fixes a bug.
 - The existing SVAR1/SVAR2 parity suite in `tests/dataset/` already pins the
   behavior that must not move.
 - New in layer 1: the `haplotype_lengths` regression test described above.
-- New in layer 4: assert `Svar2Haps` has no `genotypes`/`variants` attribute at
+- New in layer 5: assert `Svar2Haps` has no `genotypes`/`variants` attribute at
   all — replacing PR #356's two allocation-size tests, which become moot once
   there is nothing to allocate.
-- New in layer 3: round-trip `replace(haps, min_af=...)` on both subclasses, to
+- New in layer 4: round-trip `replace(haps, min_af=...)` on both subclasses, to
   pin that the settings block stays `dataclasses.replace`-able across the
   hierarchy change.
 - `tests/unit/test_slot_fit_property.py:85` and several docstrings in
   `tests/dataset/test_svar2_*.py` describe the placeholders; they need updating
   in the layer that removes what they describe.
+
+## Found while implementing layer 3
+
+`Haps.measure_variant_payload` returns the *raw* on-disk variant count while
+returning post-AF-filter spans and byte sums beside it. That asymmetry is not a
+design choice — it reproduces the accounting `_output_bytes_per_instance` has
+always used, because the raw count's over-charge under AF filtering is
+currently the only thing covering a constant per-offsets-array deficit
+elsewhere in the estimate.
+
+Every offsets array `write_chunk` serializes has `n_groups + 1` entries; the
+estimate charges `n_groups`, losing `OFF` bytes per array. Filed as **#362**,
+with the arithmetic and a reproduction. Tightening the count before that lands
+turns three `tests/unit/dataset/test_output_bytes_dummy_variant.py` cases red
+(`estimated=7696 < actual=7728`, deficit 32 = 4 x 8). Fixing #362 first, then
+tightening, is the correct order; both are out of scope for this stack.
 
 ## Non-goals
 

--- a/python/genvarloader/_dataset/_haps.py
+++ b/python/genvarloader/_dataset/_haps.py
@@ -831,9 +831,27 @@ class Haps(Reconstructor[_H]):
         Returns shape (len(idx) * ploidy,) of int64. O(|selected variants|);
         does not touch allele payload bytes — only the RaggedAlleles offsets.
         """
+        v_idxs, group_offsets = self._selected_groups(idx)
+        offsets = getattr(self.variants, kind).offsets  # int-typed, length n_variants+1
+        v_lens = (offsets[v_idxs + 1] - offsets[v_idxs]).astype(np.int64)
+        return self._segment_sum(v_lens, group_offsets)
+
+    def _selected_groups(
+        self, idx: NDArray[np.integer]
+    ) -> tuple[NDArray[np.integer], NDArray[np.int64]]:
+        """The AF-filtered variant indices and per-group offsets for ``idx``.
+
+        Args:
+            idx: Flat ``(region, sample)`` query indices for the block.
+
+        Returns:
+            ``(v_idxs, group_offsets)``: the selected variant indices, packed
+            group-major, and their ``b * ploidy + 1`` group offsets.
+        """
         r, s = np.unravel_index(idx, self.genotypes.shape[:2])  # type: ignore[no-matching-overload]
         genos = cast(Ragged[V_IDX_TYPE], self.genotypes[r, s]).to_packed()
         v_idxs = genos.data
+        group_offsets = np.asarray(genos.offsets, np.int64)
 
         if self.min_af is not None or self.max_af is not None:
             geno_afs = self.variants.info["AF"][v_idxs]
@@ -842,27 +860,159 @@ class Haps(Reconstructor[_H]):
                 keep &= geno_afs >= self.min_af
             if self.max_af is not None:
                 keep &= geno_afs <= self.max_af
-            # Filter variants per group using the flat boolean mask.
-            # Build new offsets via cumsum-indexing (handles empty groups correctly).
-            filtered_data = genos.data[keep]
-            keep_int = keep.astype(np.int64)
-            csum = np.concatenate([[np.int64(0)], np.cumsum(keep_int, dtype=np.int64)])
-            new_offsets = csum[np.asarray(genos.offsets, np.int64)]
-            genos = Ragged.from_offsets(
-                filtered_data, genos.shape, new_offsets
-            ).to_packed()
-            v_idxs = genos.data
+            keep_csum = np.concatenate(
+                [[np.int64(0)], np.cumsum(keep.astype(np.int64), dtype=np.int64)]
+            )
+            group_offsets = keep_csum[group_offsets]
+            v_idxs = v_idxs[keep]
 
-        offsets = getattr(self.variants, kind).offsets  # int-typed, length n_variants+1
-        v_lens = (offsets[v_idxs + 1] - offsets[v_idxs]).astype(np.int64)
-        # genos.offsets has length b*p + 1 (one offset per (instance, ploid)
-        # group). Segment-sum v_lens per group via a cumulative sum: this
-        # handles empty groups correctly (np.add.reduceat would index
-        # out-of-bounds / mishandle zero-length groups when a group's start
-        # offset equals len(v_lens)).
-        group_offsets = np.asarray(genos.offsets, dtype=np.int64)
-        csum = np.concatenate([[0], np.cumsum(v_lens, dtype=np.int64)])
+        return v_idxs, group_offsets
+
+    @staticmethod
+    def _segment_sum(
+        per_variant: NDArray[np.int64], group_offsets: NDArray[np.int64]
+    ) -> NDArray[np.int64]:
+        """Sum ``per_variant`` within each group delimited by ``group_offsets``.
+
+        Uses cumsum-indexing rather than :func:`np.add.reduceat`, which
+        mishandles zero-length groups and indexes out of bounds when a group
+        starts at ``len(per_variant)``.
+
+        Args:
+            per_variant: One value per selected variant.
+            group_offsets: Group boundaries, length ``n_groups + 1``.
+
+        Returns:
+            One sum per group, shape ``(n_groups,)`` int64.
+        """
+        csum = np.concatenate([[np.int64(0)], np.cumsum(per_variant, dtype=np.int64)])
         return csum[group_offsets[1:]] - csum[group_offsets[:-1]]
+
+    def measure_variant_payload(
+        self, idx: NDArray[np.integer], regions: NDArray[np.integer]
+    ) -> tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.int64]]:
+        """Per-instance variant count, ref-window span, and ALT-allele byte sum.
+
+        The single counting entry point behind
+        ``Dataset._output_bytes_per_instance``'s ``"variants"`` and
+        ``"variant-windows"`` branches, so those branches never have to know
+        which backend they are sizing. See :class:`Svar2Haps` for the read-bound
+        sibling implementation.
+
+        ``ref_span_sum`` and ``alt_bytes_sum`` are taken *after* the
+        ``min_af``/``max_af`` filter; ``n_vars_total`` is the *raw* on-disk
+        count, matching :meth:`Dataset.n_variants`. That asymmetry is
+        deliberate -- it reproduces the accounting
+        ``_output_bytes_per_instance`` has always used. Under AF filtering the
+        raw count over-charges the scalar fields, and that over-charge is
+        currently the only thing covering a constant per-offsets-array deficit
+        elsewhere in the estimate (see #362); tightening it here turns
+        ``tests/unit/dataset/test_output_bytes_dummy_variant.py`` red.
+
+        Args:
+            idx: Flat ``(region, sample)`` query indices for the block.
+            regions: ``(len(idx), 3)`` array of ``(contig_id, start, end)``.
+                Unused here -- SVAR1 genotypes are already stored per region --
+                and accepted only to match the role's signature.
+
+        Returns:
+            ``(n_vars_total, ref_span_sum, alt_bytes_sum)``, each shape
+            ``(len(idx),)`` int64:
+
+            - ``n_vars_total``: raw on-disk variant count per instance, summed
+              over ploidy. Under ``unphased_union`` that naive sum *is* the
+              union count contract (no dedup), so no separate fold is needed.
+            - ``ref_span_sum``: sum of ``1 + max(-ilen, 0)`` (the ``ref="window"``
+              per-variant span) over the instance's variants.
+            - ``alt_bytes_sum``: sum of bare ALT-allele byte lengths over the
+              instance's variants.
+        """
+        del regions  # SVAR1 genotypes are already grouped by region
+        ploidy = self.stored_ploidy
+        b = len(idx)
+        v_idxs, group_offsets = self._selected_groups(idx)
+
+        r, s_ = np.unravel_index(idx, self.genotypes.shape[:2])  # type: ignore[no-matching-overload]
+        n_vars_total = self.n_variants[r, s_].astype(np.int64).sum(-1)
+
+        ilen_sel = np.asarray(self.variants.ilen)[v_idxs].astype(np.int64)
+        ref_span_sum = (
+            self._segment_sum(1 + np.maximum(-ilen_sel, 0), group_offsets)
+            .reshape(b, ploidy)
+            .sum(-1)
+        )
+
+        alt_offsets = self.variants.alt.offsets
+        alt_lens = (alt_offsets[v_idxs + 1] - alt_offsets[v_idxs]).astype(np.int64)
+        alt_bytes_sum = (
+            self._segment_sum(alt_lens, group_offsets).reshape(b, ploidy).sum(-1)
+        )
+
+        return n_vars_total, ref_span_sum, alt_bytes_sum
+
+    def ref_allele_bytes(
+        self, idx: NDArray[np.integer], regions: NDArray[np.integer]
+    ) -> NDArray[np.int64]:
+        """Per-instance sum of bare REF allele byte lengths.
+
+        Distinct from :meth:`measure_variant_payload`'s ``ref_span_sum``, which
+        measures the ``ref="window"`` reference-genome span. Only callable when
+        :attr:`has_ref_alleles` is true; callers must gate on it.
+
+        Args:
+            idx: Flat ``(region, sample)`` query indices for the block.
+            regions: ``(len(idx), 3)`` array of ``(contig_id, start, end)``.
+                Unused here; accepted to match the role's signature.
+
+        Returns:
+            Shape ``(len(idx),)`` int64, summed over ploidy.
+        """
+        del regions  # SVAR1 genotypes are already grouped by region
+        return (
+            self._allele_bytes_sum(idx, "ref").reshape(-1, self.stored_ploidy).sum(-1)
+        )
+
+    def prepare_var_fields(self, var_fields: list[str]) -> "Haps[_H]":
+        """Record ``var_fields``, loading whatever storage they need.
+
+        SVAR1 keeps its INFO columns, dosages and custom FORMAT fields in
+        separate on-disk arrays that are memmapped on demand, so a field
+        requested after open time has to be loaded before it can be read.
+        Callers validate membership in ``available_var_fields`` first.
+
+        Args:
+            var_fields: The variant fields the dataset should emit.
+
+        Returns:
+            A new reconstructor with ``var_fields`` set and its backing
+            storage loaded.
+        """
+        # Discover custom FORMAT fields so we don't try to load them as INFO.
+        custom_fmt = _svar_format_fields(self.variants.path.parent)
+        # Lazily load any newly-requested info columns into the existing
+        # _Variants struct (mutates self.variants.info in place).
+        builtin = {"alt", "ilen", "start", "ref", "dosage"}
+        new_info_fields = [
+            f
+            for f in var_fields
+            if f not in builtin and f not in self.variants.info and f not in custom_fmt
+        ]
+        if new_info_fields:
+            self.variants.load_info(new_info_fields)
+
+        haps = self
+        # Lazily memmap dosages if newly requested.
+        if "dosage" in var_fields and haps.dosages is None:
+            haps = _lazy_load_dosages(haps)
+        # Lazily memmap custom FORMAT fields if newly requested.
+        new_custom_fields = {
+            f: custom_fmt[f]
+            for f in var_fields
+            if f in custom_fmt and f not in haps.var_field_data
+        }
+        if new_custom_fields:
+            haps = _lazy_load_custom_fields(haps, new_custom_fields)
+        return replace(haps, var_fields=var_fields)
 
     def _reconstruct_haplotypes(
         self,
@@ -1166,3 +1316,103 @@ class Haps(Reconstructor[_H]):
             keep_perm,
             keep_offsets_perm,
         )
+
+
+def _lazy_load_dosages(haps: Haps) -> Haps:
+    """Open the dosages memmap for a Haps that didn't request them at open time.
+
+    Reuses the same path-resolution logic that ``Haps.from_path`` used. Returns
+    a new ``Haps`` with ``dosages`` populated (does NOT mutate the input).
+    """
+    import json as _json
+
+    from genoray._types import DOSAGE_TYPE
+
+    from ._svar_link import _resolve_svar
+    from ._write import Metadata
+
+    path = haps.path
+    svar_meta_path = path / "genotypes" / "svar_meta.json"
+    if not svar_meta_path.exists():
+        raise ValueError(
+            "Dosage requested but this dataset is not SVAR-backed; no dosages.npy possible."
+        )
+
+    with open(svar_meta_path) as f:
+        svar_meta = _json.load(f)
+    shape = tuple(svar_meta["shape"])
+    dtype = np.dtype(svar_meta["dtype"])
+
+    offset_path = path / "genotypes" / "offsets.npy"
+
+    # Resolve the SVAR directory the same way Haps.from_path did. Dataset does
+    # not retain Metadata, so re-read metadata.json from disk.
+    meta = Metadata.model_validate_json((path / "metadata.json").read_text())
+    svar_link = meta.svar_link
+    if svar_link is not None:
+        svar_path = _resolve_svar(path, svar_link, None)
+    else:
+        legacy_link = path / "genotypes" / "link.svar"
+        svar_path = legacy_link.resolve()
+
+    dosage_path = svar_path / "dosages.npy"
+    if not dosage_path.exists():
+        raise ValueError(
+            f"Dosage requested but {dosage_path} does not exist. "
+            f"Check the SVAR was built with dosages."
+        )
+
+    offsets = np.memmap(offset_path, shape=shape, dtype=dtype, mode="r")
+    dosages_mm = np.memmap(dosage_path, dtype=DOSAGE_TYPE, mode="r")
+    rag_shape = (*shape[1:], None)
+    dosages = Ragged.from_offsets(dosages_mm, rag_shape, offsets.reshape(2, -1))
+    return replace(haps, dosages=dosages)
+
+
+def _lazy_load_custom_fields(
+    haps: Haps,
+    new_fields: dict[str, np.dtype],
+) -> Haps:
+    """Memmap custom FORMAT fields (Number=G, stored as <name>.npy) into ``haps.var_field_data`` for fields that were not loaded at open time.
+
+    ``new_fields`` maps field name → numpy dtype (already confirmed present in
+    the SVAR metadata). Returns a new ``Haps`` with updated ``var_field_data``.
+    """
+    import json as _json
+
+    path = haps.path
+    svar_meta_path = path / "genotypes" / "svar_meta.json"
+    if not svar_meta_path.exists():
+        raise ValueError(
+            "Custom FORMAT fields requested but this dataset is not SVAR-backed."
+        )
+
+    with open(svar_meta_path) as f:
+        svar_meta = _json.load(f)
+    shape = tuple(svar_meta["shape"])
+    dtype = np.dtype(svar_meta["dtype"])
+
+    offset_path = path / "genotypes" / "offsets.npy"
+
+    # The resolved SVAR directory is already embedded in haps.variants.path
+    # (which was set to <svar_path>/index.arrow by Haps.from_path, respecting any
+    # svar_override). Using .parent avoids re-resolving from metadata and correctly
+    # handles the svar_override case that the legacy link.svar branch would miss.
+    svar_path = haps.variants.path.parent
+
+    offsets = np.memmap(offset_path, shape=shape, dtype=dtype, mode="r")
+    rag_shape = (*shape[1:], None)
+
+    updated_var_field_data = dict(haps.var_field_data)
+    for name, ftype in new_fields.items():
+        field_path = svar_path / f"{name}.npy"
+        if not field_path.exists():
+            raise ValueError(
+                f"Custom FORMAT field '{name}' registered in SVAR metadata but "
+                f"{field_path} does not exist."
+            )
+        field_mm = np.memmap(field_path, dtype=ftype, mode="r")
+        updated_var_field_data[name] = Ragged.from_offsets(
+            field_mm, rag_shape, offsets.reshape(2, -1)
+        )
+    return replace(haps, var_field_data=updated_var_field_data)

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -25,7 +25,6 @@ from ._flat_variants import DummyVariant
 from ._indexing import DatasetIndexer, SpliceIndexer, is_str_arr
 from ._insertion_fill import InsertionFill
 from ._rag_variants import RaggedVariants
-from ._haps import _svar_format_fields
 from ._reconstruct import (
     Haps,
     HapsTracks,
@@ -335,46 +334,11 @@ class Dataset:
             if missing or not isinstance(self._seqs, Haps):
                 raise ValueError(f"Missing variant fields: {missing}")
 
-            from ._svar2_haps import Svar2Haps
-
-            if isinstance(self._seqs, Svar2Haps):
-                # SVAR2 field values are read on demand by the decode kernel
-                # (decode_variants_from_svar2_readbound); there is no SVAR1 variants
-                # table to lazily load INFO/dosage/custom-FORMAT columns from — this
-                # reconstructor's `variants` is a dummy placeholder.
-                haps = replace(
-                    to_evolve.get("_seqs", self._seqs), var_fields=var_fields
-                )
-                to_evolve["_seqs"] = haps
-            else:
-                haps = to_evolve.get("_seqs", self._seqs)
-                # Discover custom FORMAT fields so we don't try to load them as INFO.
-                custom_fmt = _svar_format_fields(haps.variants.path.parent)
-                # Lazily load any newly-requested info columns into the existing
-                # _Variants struct (mutates haps.variants.info in place).
-                builtin = {"alt", "ilen", "start", "ref", "dosage"}
-                new_info_fields = [
-                    f
-                    for f in var_fields
-                    if f not in builtin
-                    and f not in haps.variants.info
-                    and f not in custom_fmt
-                ]
-                if new_info_fields:
-                    haps.variants.load_info(new_info_fields)
-                # Lazily memmap dosages if newly requested.
-                if "dosage" in var_fields and haps.dosages is None:
-                    haps = _lazy_load_dosages(self, haps)
-                # Lazily memmap custom FORMAT fields if newly requested.
-                new_custom_fields = {
-                    f: custom_fmt[f]
-                    for f in var_fields
-                    if f in custom_fmt and f not in haps.var_field_data
-                }
-                if new_custom_fields:
-                    haps = _lazy_load_custom_fields(self, haps, new_custom_fields)
-                haps = replace(haps, var_fields=var_fields)
-                to_evolve["_seqs"] = haps
+            # Each backend knows how (and whether) to make the requested
+            # fields readable: SVAR1 lazily memmaps the columns, SVAR2 reads
+            # them on demand in the decode kernel and only has to record them.
+            haps = to_evolve.get("_seqs", self._seqs)
+            to_evolve["_seqs"] = haps.prepare_var_fields(var_fields)
 
         if splice_info is not None:
             if splice_info is False:
@@ -1443,45 +1407,25 @@ class Dataset:
                 raise AssertionError("variants mode requires Haps")
             haps_obj = self._seqs
             var_fields = haps_obj.var_fields
-            n_vars = self.n_variants(regions, samples)  # (n_inst, ploidy)
-            n_vars_flat = n_vars.reshape(-1, n_vars.shape[-1]).astype(np.int64)
-            n_vars_total = n_vars_flat.sum(-1)  # over ploidy → (n_inst,)
-            ploidy = n_vars.shape[-1]
-            # Real (on-disk) ploidy, NOT `ploidy` above: under unphased_union,
-            # `ploidy` is folded to 1 (see Dataset.n_variants), but
-            # _allele_bytes_sum groups by the STORED genotypes shape (always
-            # the real ploidy, unphased_union-agnostic). Reshaping its
-            # (len(ds_idx) * real_ploidy,) result with the folded `ploidy`
-            # mis-groups it (wrong element count -> ValueError) instead of
-            # summing every real haplotype's contribution into one
-            # per-instance total, which is what unphased_union's un-deduped
-            # union semantics require either way.
-            real_ploidy = haps_obj.stored_ploidy
+            # `ploidy` here is the OUTPUT ploidy axis (folded to 1 under
+            # unphased_union; see Dataset.n_variants), used only for the
+            # per-group offset and dummy-fill accounting below. The payload
+            # measures come from the reconstructor, already summed over the
+            # stored ploidy.
+            ploidy = self.n_variants(regions, samples).shape[-1]
 
-            # Svar2Haps: self.n_variants (-> self.genotypes.lengths) and
-            # _allele_bytes_sum (-> self.genotypes[...]/self.variants.alt) both
-            # read permanently-empty SVAR1-shaped placeholders for this
-            # reconstructor (see Svar2Haps.from_path) -- they are never
-            # populated because svar2 reconstructs read-bound straight from the
-            # on-disk store. Re-derive n_vars_total (and, below, the alt byte
-            # sum) from the SAME per-instance decode
-            # measure_variant_payload/_reconstruct_variants use, instead of
-            # those placeholders (issue #315).
-            from ._svar2_haps import Svar2Haps
-
-            svar2_alt_bytes: NDArray[np.int64] | None = None
-            if isinstance(haps_obj, Svar2Haps):
-                # NB: unlike the reference/track branches, we do NOT widen
-                # regions_arr by self.jitter here. The Svar2Haps read-bound
-                # decode guards jitter>0 (raises NotImplementedError, "right-
-                # clip"; see _svar2_haps.py and its jitter_guard tests), so this
-                # branch only ever runs at jitter=0 and the raw region is the
-                # exact decode window. If that guard is ever lifted (right-clip
-                # added), widen by self.jitter here to keep est an upper bound.
-                regions_arr = self._full_regions[r_idx]
-                n_vars_total, _svar2_ref_span_unused, svar2_alt_bytes = (
-                    haps_obj.measure_variant_payload(ds_idx, regions_arr)
-                )
+            # NB: regions_arr is NOT widened by self.jitter (unlike the
+            # reference/track branches). The SVAR1 measure ignores it outright
+            # -- its genotypes are already grouped by region -- and the
+            # Svar2Haps read-bound decode guards jitter>0 (raises
+            # NotImplementedError, "right-clip"; see _svar2_haps.py and its
+            # jitter_guard tests), so it only ever runs at jitter=0, where the
+            # raw region is the exact decode window. If that guard is lifted,
+            # widen by self.jitter here to keep est an upper bound.
+            regions_arr = self._full_regions[r_idx]
+            n_vars_total, _ref_span_unused, alt_bytes = (
+                haps_obj.measure_variant_payload(ds_idx, regions_arr)
+            )
 
             # "start" is unconditionally emitted by the flat/ragged variant
             # builders regardless of var_fields (see get_variants_flat's
@@ -1499,18 +1443,13 @@ class Dataset:
                         continue
                     dosage_dtype = haps_obj.var_field_dtype("dosage")
                     total += n_vars_total * dosage_dtype.itemsize
-                elif f in ("alt", "ref"):
-                    if svar2_alt_bytes is not None:
-                        # Svar2Haps: "ref" is never in available_var_fields (its
-                        # .variants.ref is always None), so this is always "alt".
-                        assert f == "alt", (
-                            "Svar2Haps does not support the bare 'ref' var_field"
-                        )
-                        total += svar2_alt_bytes
-                    else:
-                        # Allele scan: _allele_bytes_sum returns (len(ds_idx) * real_ploidy,).
-                        per_ploid = haps_obj._allele_bytes_sum(ds_idx, f)
-                        total += per_ploid.reshape(-1, real_ploidy).sum(-1)
+                elif f == "alt":
+                    total += alt_bytes
+                elif f == "ref":
+                    # Bare REF allele bytes -- distinct from the ref="window"
+                    # genome span. Only reachable on a backend that stores REF;
+                    # with_seqs/with_var_fields rejects "ref" otherwise.
+                    total += haps_obj.ref_allele_bytes(ds_idx, regions_arr)
                 else:
                     # INFO column: numeric, known dtype -- from the on-disk
                     # schema on SVAR1, from the store manifest on SVAR2.
@@ -1541,14 +1480,10 @@ class Dataset:
             # dummy-variant fill: a (region, sample, ploid) group with 0
             # *post-filter* variants still emits one dummy row when
             # dummy_variant is active (see Haps.dummy_variant /
-            # _FlatVariants.fill_empty_groups). n_vars_total/n_vars_flat above
-            # are *raw on-disk* counts (self.n_variants()), not post-AF-filter
-            # counts -- min_af/max_af can zero out a group that had real
-            # on-disk variants, so "raw count == 0" is NOT a safe test for
-            # "the flat builder will dummy-fill this group". Rather than
-            # re-deriving the exact post-filter empty-group count here (a
-            # second AF-filter pass duplicating the one in
-            # Haps._allele_bytes_sum / the ref="window" span above),
+            # _FlatVariants.fill_empty_groups). n_vars_total above is a
+            # per-instance total already summed over the stored ploidy, so it
+            # cannot say WHICH of an instance's groups came out empty.
+            # Rather than re-deriving the per-group post-filter counts here,
             # conservatively charge the dummy row's cost for *every*
             # (region, sample, ploid) group -- there are exactly `ploidy` such
             # groups per instance. This only ever over-counts (each instance
@@ -1609,111 +1544,25 @@ class Dataset:
             assert opt is not None, "variant-windows requires a VarWindowOpt"
             L = int(opt.flank_length)
             tok_itemsize = np.dtype(haps_obj.token_lut.dtype).itemsize
-            n_vars = self.n_variants(regions, samples)  # (n_inst, ploidy)
-            n_vars_flat = n_vars.reshape(-1, n_vars.shape[-1]).astype(np.int64)
-            n_vars_total = n_vars_flat.sum(-1)
-            ploidy = n_vars.shape[-1]
-            # Real (on-disk) ploidy, NOT `ploidy` above: under unphased_union,
-            # `ploidy` is folded to 1 (see Dataset.n_variants), but
-            # _allele_bytes_sum/genotypes group by the STORED genotypes shape
-            # (always the real ploidy, unphased_union-agnostic). Reshaping
-            # with the folded `ploidy` mis-groups those results (wrong
-            # element count -> ValueError) instead of summing every real
-            # haplotype's contribution into one per-instance total, which is
-            # what unphased_union's un-deduped union semantics require either
-            # way (see the "variants" branch above for the same fix).
-            real_ploidy = haps_obj.stored_ploidy
+            # `ploidy` here is the OUTPUT ploidy axis (folded to 1 under
+            # unphased_union; see Dataset.n_variants), used only for the
+            # per-group offset and dummy-fill accounting below. The payload
+            # measures come from the reconstructor, already summed over the
+            # stored ploidy.
+            ploidy = self.n_variants(regions, samples).shape[-1]
 
-            # Svar2Haps: self.n_variants/self.genotypes/self.variants are
-            # permanently-empty SVAR1-shaped placeholders for this
-            # reconstructor (see Svar2Haps.from_path) -- svar2 reconstructs
-            # read-bound straight from the on-disk store, never populating
-            # them. Re-derive n_vars_total/ref_span/alt_alleles from the SAME
-            # per-instance decode _reconstruct_variant_windows uses, instead of
-            # those placeholders (issue #315). ref="allele" is unreachable
-            # here for Svar2Haps -- with_seqs already rejects it (its
-            # .variants.ref is always None) -- so ref="window" (the ilen-span
-            # branch below) is the only case that needs covering.
-            from ._svar2_haps import Svar2Haps
-
-            if isinstance(haps_obj, Svar2Haps):
-                # NB: not widened by self.jitter (unlike the reference/track
-                # branches) -- the Svar2Haps read-bound decode guards jitter>0
-                # (raises NotImplementedError, "right-clip"; see _svar2_haps.py
-                # and its jitter_guard tests), so this branch only runs at
-                # jitter=0 and the raw region is the exact decode window. If that
-                # guard is lifted, widen by self.jitter here to keep est an
-                # upper bound.
-                regions_arr = self._full_regions[r_idx]
-                n_vars_total, ref_span, alt_alleles = haps_obj.measure_variant_payload(
-                    ds_idx, regions_arr
-                )
-            elif opt.ref == "allele":
-                # alt bytes are always stored on disk (unlike ref); exact sum
-                # reused by both alt="window" (flank5 . alt . flank3) and
-                # alt="allele" (bare alt), same primitive the "variants" branch
-                # uses for alt/ref.
-                alt_alleles = (
-                    haps_obj._allele_bytes_sum(ds_idx, "alt")
-                    .reshape(-1, real_ploidy)
-                    .sum(-1)
-                )
-                # bare REF allele bytes. with_seqs('variant-windows', ...)
-                # already rejects ref="allele" when self.variants.ref is
-                # None, so _allele_bytes_sum is safe to call here.
-                ref_span = (
-                    haps_obj._allele_bytes_sum(ds_idx, "ref")
-                    .reshape(-1, real_ploidy)
-                    .sum(-1)
-                )
-            else:
-                # alt bytes are always stored on disk (unlike ref); exact sum
-                # reused by both alt="window" (flank5 . alt . flank3) and
-                # alt="allele" (bare alt), same primitive the "variants" branch
-                # uses for alt/ref.
-                alt_alleles = (
-                    haps_obj._allele_bytes_sum(ds_idx, "alt")
-                    .reshape(-1, real_ploidy)
-                    .sum(-1)
-                )
-                # ref="window" reads [start-L, end+L) from the *reference
-                # genome*, not the stored REF allele -- which may not even be
-                # present (e.g. an ALT-only Haps, like get_dummy_dataset()).
-                # Its span is derivable exactly from ilen alone: for
-                # normalized bi-allelic records len(REF) - len(ALT) == -ilen,
-                # i.e. span = 1 + max(-ilen, 0), so this doesn't need REF
-                # storage at all.
-                r_idx_grp, s_idx_grp = np.unravel_index(
-                    ds_idx, haps_obj.genotypes.shape[:2]
-                )
-                genos = haps_obj.genotypes[r_idx_grp, s_idx_grp].to_packed()
-                v_idxs = genos.data
-                grp_offsets = np.asarray(genos.offsets, np.int64)
-                if haps_obj.min_af is not None or haps_obj.max_af is not None:
-                    geno_afs = haps_obj.variants.info["AF"][v_idxs]
-                    keep = np.full(len(v_idxs), True, np.bool_)
-                    if haps_obj.min_af is not None:
-                        keep &= geno_afs >= haps_obj.min_af
-                    if haps_obj.max_af is not None:
-                        keep &= geno_afs <= haps_obj.max_af
-                    v_idxs = v_idxs[keep]
-                    keep_csum = np.concatenate(
-                        [
-                            [np.int64(0)],
-                            np.cumsum(keep.astype(np.int64), dtype=np.int64),
-                        ]
-                    )
-                    grp_offsets = keep_csum[grp_offsets]
-                ilen_sel = np.asarray(haps_obj.variants.ilen)[v_idxs].astype(np.int64)
-                span = 1 + np.maximum(-ilen_sel, 0)
-                span_csum = np.concatenate(
-                    [[np.int64(0)], np.cumsum(span, dtype=np.int64)]
-                )
-                ref_span = (
-                    (span_csum[grp_offsets[1:]] - span_csum[grp_offsets[:-1]])
-                    .reshape(-1, real_ploidy)
-                    .sum(-1)
-                )
+            # NB: regions_arr is NOT widened by self.jitter -- see the
+            # "variants" branch above for why.
+            regions_arr = self._full_regions[r_idx]
+            n_vars_total, ref_span, alt_alleles = haps_obj.measure_variant_payload(
+                ds_idx, regions_arr
+            )
+            if opt.ref == "allele":
+                # ref="allele" emits the bare stored REF allele, not the
+                # ref="window" reference-genome span measure_variant_payload
+                # returns. with_seqs('variant-windows', ...) already rejects
+                # ref="allele" on a backend without REF bytes, so this is safe.
+                ref_span = haps_obj.ref_allele_bytes(ds_idx, regions_arr)
             # token count per present window slot: window slots add 2L flank
             # tokens per variant; bare allele slots do not.
             ref_tokens = (
@@ -1765,12 +1614,12 @@ class Dataset:
             # dummy-variant fill (see the "variants" branch above for the
             # full rationale): a group with 0 *post-filter* variants still
             # gets one dummy window/allele entry per window slot when
-            # dummy_variant is active. n_vars_flat is a *raw on-disk* count,
-            # not post-AF-filter, so it cannot safely identify which groups
-            # the flat builder will actually dummy-fill under min_af/max_af.
-            # Conservatively charge every one of the `ploidy` groups/instance
-            # instead of only the raw-empty ones -- a provable upper bound
-            # under any AF-filter config, at the cost of a modest over-count
+            # dummy_variant is active. n_vars_total is summed over the stored
+            # ploidy, so it cannot identify which groups the flat builder will
+            # actually dummy-fill. Conservatively charge every one of the
+            # `ploidy` groups/instance instead of only the empty ones -- a
+            # provable upper bound under any config, at the cost of a modest
+            # over-count
             # (only incurred when dummy_variant is opted in). Window slots
             # (opt.*="window") get a full 2L-flanked dummy window;
             # bare-allele slots (opt.*="allele") get just the dummy allele's
@@ -2138,107 +1987,6 @@ class Dataset:
         # would not survive a spawn.
         with parallel_policy(self.parallel):
             return getitem(view, idx)
-
-
-def _lazy_load_dosages(dataset: Dataset, haps: Haps) -> Haps:
-    """Open the dosages memmap for a Haps that didn't request them at open time.
-
-    Reuses the same path-resolution logic that ``Haps.from_path`` used. Returns
-    a new ``Haps`` with ``dosages`` populated (does NOT mutate the input).
-    """
-    import json as _json
-
-    from genoray._types import DOSAGE_TYPE
-
-    from ._svar_link import _resolve_svar
-    from ._write import Metadata
-
-    path = haps.path
-    svar_meta_path = path / "genotypes" / "svar_meta.json"
-    if not svar_meta_path.exists():
-        raise ValueError(
-            "Dosage requested but this dataset is not SVAR-backed; no dosages.npy possible."
-        )
-
-    with open(svar_meta_path) as f:
-        svar_meta = _json.load(f)
-    shape = tuple(svar_meta["shape"])
-    dtype = np.dtype(svar_meta["dtype"])
-
-    offset_path = path / "genotypes" / "offsets.npy"
-
-    # Resolve the SVAR directory the same way Haps.from_path did. Dataset does
-    # not retain Metadata, so re-read metadata.json from disk.
-    meta = Metadata.model_validate_json((path / "metadata.json").read_text())
-    svar_link = meta.svar_link
-    if svar_link is not None:
-        svar_path = _resolve_svar(path, svar_link, None)
-    else:
-        legacy_link = path / "genotypes" / "link.svar"
-        svar_path = legacy_link.resolve()
-
-    dosage_path = svar_path / "dosages.npy"
-    if not dosage_path.exists():
-        raise ValueError(
-            f"Dosage requested but {dosage_path} does not exist. "
-            f"Check the SVAR was built with dosages."
-        )
-
-    offsets = np.memmap(offset_path, shape=shape, dtype=dtype, mode="r")
-    dosages_mm = np.memmap(dosage_path, dtype=DOSAGE_TYPE, mode="r")
-    rag_shape = (*shape[1:], None)
-    dosages = Ragged.from_offsets(dosages_mm, rag_shape, offsets.reshape(2, -1))
-    return replace(haps, dosages=dosages)
-
-
-def _lazy_load_custom_fields(
-    dataset: Dataset,
-    haps: Haps,
-    new_fields: dict[str, np.dtype],
-) -> Haps:
-    """Memmap custom FORMAT fields (Number=G, stored as <name>.npy) into ``haps.var_field_data`` for fields that were not loaded at open time.
-
-    ``new_fields`` maps field name → numpy dtype (already confirmed present in
-    the SVAR metadata). Returns a new ``Haps`` with updated ``var_field_data``.
-    """
-    import json as _json
-
-    path = haps.path
-    svar_meta_path = path / "genotypes" / "svar_meta.json"
-    if not svar_meta_path.exists():
-        raise ValueError(
-            "Custom FORMAT fields requested but this dataset is not SVAR-backed."
-        )
-
-    with open(svar_meta_path) as f:
-        svar_meta = _json.load(f)
-    shape = tuple(svar_meta["shape"])
-    dtype = np.dtype(svar_meta["dtype"])
-
-    offset_path = path / "genotypes" / "offsets.npy"
-
-    # The resolved SVAR directory is already embedded in haps.variants.path
-    # (which was set to <svar_path>/index.arrow by Haps.from_path, respecting any
-    # svar_override). Using .parent avoids re-resolving from metadata and correctly
-    # handles the svar_override case that the legacy link.svar branch would miss.
-    svar_path = haps.variants.path.parent
-
-    offsets = np.memmap(offset_path, shape=shape, dtype=dtype, mode="r")
-    rag_shape = (*shape[1:], None)
-
-    updated_var_field_data = dict(haps.var_field_data)
-    for name, ftype in new_fields.items():
-        field_path = svar_path / f"{name}.npy"
-        if not field_path.exists():
-            raise ValueError(
-                f"Custom FORMAT field '{name}' registered in SVAR metadata but "
-                f"{field_path} does not exist."
-            )
-        field_mm = np.memmap(field_path, dtype=ftype, mode="r")
-        updated_var_field_data[name] = Ragged.from_offsets(
-            field_mm, rag_shape, offsets.reshape(2, -1)
-        )
-    return replace(haps, var_field_data=updated_var_field_data)
 
 
 SEQ = TypeVar("SEQ", NDArray[np.bytes_], AnnotatedHaps, RaggedVariants)

--- a/python/genvarloader/_dataset/_svar2_haps.py
+++ b/python/genvarloader/_dataset/_svar2_haps.py
@@ -26,7 +26,7 @@ annotated haps, and exonic filtering for non-haplotype outputs.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
@@ -1010,6 +1010,42 @@ class Svar2Haps(Haps[_H]):
                 alt_bytes_sum[qsel] = row_bytes.reshape(len(qsel), P).sum(-1)
 
         return n_vars_total, ref_span_sum, alt_bytes_sum
+
+    def ref_allele_bytes(
+        self, idx: NDArray[np.integer], regions: NDArray[np.integer]
+    ) -> NDArray[np.int64]:
+        """Unsupported: the ``.svar2`` store carries no REF allele bytes.
+
+        The read-bound decode is ALT-only, so there is nothing to measure.
+        :attr:`has_ref_alleles` is ``False`` and callers must gate on it;
+        reaching here means a caller did not.
+
+        Args:
+            idx: Unused.
+            regions: Unused.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError(
+            "the .svar2 store carries no REF allele bytes (has_ref_alleles is False)"
+        )
+
+    def prepare_var_fields(self, var_fields: list[str]) -> "Svar2Haps":
+        """Record ``var_fields``; SVAR2 has no storage to pre-load.
+
+        Field values are read on demand by the decode kernel
+        (``decode_variants_from_svar2_readbound``) straight from the ``.svar2``
+        store, so unlike SVAR1 there are no INFO/dosage/custom-FORMAT columns
+        to memmap ahead of time.
+
+        Args:
+            var_fields: The variant fields the dataset should emit.
+
+        Returns:
+            A new reconstructor with ``var_fields`` set.
+        """
+        return replace(self, var_fields=var_fields)
 
     def _reconstruct_variants(
         self, idx: NDArray[np.integer], regions: NDArray[np.integer]

--- a/tests/unit/test_slot_fit_property.py
+++ b/tests/unit/test_slot_fit_property.py
@@ -81,18 +81,18 @@ def test_slot_fit_svar2_backend(phased_svar2_gvl, svar2_slot_reference):
     for view in _views(ds):
         _assert_upper_bound(view)
 
-    # SCOPE ADD-ON: the sibling "variants" (non-window) output branch reads
-    # the same permanently-empty Svar2Haps.genotypes/.variants placeholders
-    # (n_vars_total via self.n_variants(), alt bytes via _allele_bytes_sum),
-    # so it under-counts identically (see "What Task 3 must change" in the
-    # Phase-0 findings doc). This is also RED before the fix -- confirmed by
-    # running it in isolation -- because `phased_svar2_gvl` replicates the
-    # variant window 80x (see its docstring): "variants" mode's real payload
-    # for a handful of variants sits under slot_overhead_bytes' 4096-byte
-    # floor at low instance counts, masking the defect there even though it
-    # applies; enough instances make the (buggy, ~flat) estimate fall behind
-    # the (correctly variant-count-scaling) real payload. Locks the sibling
-    # defect so Task 3's shared fix must cover it too.
+    # SCOPE ADD-ON: the sibling "variants" (non-window) output branch used to
+    # under-count identically, because it sized itself from the same
+    # permanently-empty Svar2Haps placeholders (n_vars_total via
+    # self.n_variants(), alt bytes via _allele_bytes_sum). Both branches now
+    # size themselves from Haps.measure_variant_payload, which every backend
+    # implements against its own storage. This case was RED before that fix
+    # -- confirmed by running it in isolation -- and only at enough instances:
+    # `phased_svar2_gvl` replicates the variant window 80x (see its
+    # docstring), so "variants" mode's real payload for a handful of variants
+    # sits under slot_overhead_bytes' 4096-byte floor at low instance counts,
+    # masking the defect there even though it applied. Keep both branches
+    # covered so a future backend cannot regress one without the other.
     for uu in (True, False):
         variants_view = (
             ds.with_tracks(False)


### PR DESCRIPTION
**Layer 3 of 5** in the `Haps` role/implementation split. Stacked on #365.

---

`Dataset._output_bytes_per_instance`'s "variants" and "variant-windows"
branches each carried an `isinstance(haps_obj, Svar2Haps)` fork: the
SVAR1 arm open-coded an AF-filtered scan over `haps.genotypes` /
`haps.variants.ilen` / `haps.variants.alt.offsets`, while the SVAR2 arm
called `Svar2Haps.measure_variant_payload`, which exists precisely
because those fields are fabricated placeholders on that reconstructor.
`Dataset.with_var_fields` forked the same way, to skip a lazy column
load SVAR2 has no use for.

Give `Haps` the measures the estimate actually needs —
`measure_variant_payload(idx, regions) -> (n_vars, ref_span, alt_bytes)`
and `ref_allele_bytes(idx, regions)` — plus `prepare_var_fields`, and
implement them on the SVAR1 side. All three forks collapse into
unconditional calls; `_impl.py` loses ~220 lines net and no longer
imports `Svar2Haps` at all.

Supporting changes:

- `Haps._selected_groups` / `Haps._segment_sum` factor out the
  AF-filter-then-segment-sum that `_allele_bytes_sum` and the two
  open-coded estimate scans each had their own copy of.
  `_allele_bytes_sum` now uses them, dropping a redundant
  `Ragged.from_offsets` round-trip.
- The SVAR1 lazy column loaders (`_lazy_load_dosages`,
  `_lazy_load_custom_fields`) move from `_impl.py` to `_haps.py` behind
  `prepare_var_fields`. Their `dataset: Dataset` parameters were dead —
  both read `haps.path` — and are dropped.
- `Svar2Haps.ref_allele_bytes` raises: the read-bound decode is ALT-only
  and `has_ref_alleles` is already False, so a caller reaching it did
  not gate.

Behavior-preserving.

## A deliberate asymmetry, and #362

`measure_variant_payload` returns the *raw* on-disk variant count alongside
post-AF-filter spans and byte sums, reproducing the existing accounting rather
than tidying it: the raw count's over-charge under AF filtering is currently the
only thing covering a constant per-offsets-array deficit in the estimate.
Returning the post-filter count instead turns three
`tests/unit/dataset/test_output_bytes_dummy_variant.py` cases red
(`estimated=7696 < actual=7728`; the 32-byte deficit is 4 offsets arrays x 8
bytes, because an offsets array has `n_groups + 1` entries and the estimate
charges `n_groups`). Filed as #362 with the arithmetic; the docstrings point
there. Fixing it inside a behavior-preserving refactor layer would have hidden a
real bug behind a rename.

## Testing

`pytest tests/dataset tests/unit tests/parity` at the top of the stack:
**944 passed, 36 skipped, 2 xfailed, 0 failed** (Slurm job 1049099). This layer is
contained in that run.

The earlier per-layer numbers quoted here were wrong, not merely stale: the Slurm
helper passed *relative* test paths while overriding `PYTHONPATH` to the
worktree's package, so it collected the main checkout's tests against the
branch's code. That is a false-green generator. The helper now resolves test
paths against the worktree, and the count above is from a corrected run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Romp6JJHU4g1M7UyPyCSJH

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

