### PR TITLE
refactor(haps): dispatch track realignment through the reconstructor

### DIFF
--- a/docs/superpowers/specs/2026-09-08-haps-role-split-design.md
+++ b/docs/superpowers/specs/2026-09-08-haps-role-split-design.md
@@ -89,7 +89,7 @@ today by reaching into SVAR1 storage. Nothing is added speculatively.
 | `measure_variant_payload` | the `_allele_bytes_sum` + `variants.start.dtype` open-coding in both estimate branches | new wrapper over existing `_allele_bytes_sum` | **already exists** (`_svar2_haps.py:851`) |
 | `var_field_dtype` | `variants.info[f].dtype` + the `Svar2Haps` fork in `_info_field_dtype` | `variants.info[f].dtype` | `store_fields[f].dtype` |
 | `has_ref_alleles` | `variants.ref is not None` (`_impl.py:759`) | `variants.ref is not None` | `False` |
-| `realign_track_block` | `isinstance(self.haps, Svar2Haps)` in `HapsTracks.__call__` | the current SVAR1 fused body | the current `_call_svar2` body |
+| `check_track_realign_support` + `track_realigner` | `isinstance(self.haps, Svar2Haps)` in `HapsTracks.__call__` | the guards + fused kernel call from the current SVAR1 body | the guards from `_call_svar2` + its existing `realign_track_block` |
 
 `measure_variant_payload` is the keystone: `Svar2Haps` already implements it
 precisely because the estimate branches could not trust the placeholders. Making
@@ -107,9 +107,9 @@ both `isinstance` forks into one unconditional call.
 
 ### What stays
 
-- `HapsTracks._call_svar2`'s body — a genuine kernel-dispatch difference. It
-  moves from an `isinstance` in `HapsTracks` to a `realign_track_block`
-  override on each subclass.
+- The kernel-dispatch difference `HapsTracks._call_svar2` existed for. It moves
+  from an `isinstance` in `HapsTracks` onto per-class `track_realigner`
+  overrides; the duplicated orchestration around it does not survive.
 - Every `NotImplementedError` guard in `Svar2Haps` (`min_af`/`max_af`,
   annotated haps, splicing, jitter). Those are real capability gaps, not
   artifacts of the class shape.
@@ -147,12 +147,13 @@ correct bug report.
 If #356 has not merged when the final layer is written, that layer deletes the
 `Ragged` placeholder instead; the end state is identical either way.
 
-## Implementation: a 5-PR stack
+## Implementation: a 6-PR stack
 
 Each layer is independently green and independently reviewable. (Planned as
-four; the query surface split cleanly into a cheap "read scalars off the
+four. The query surface split cleanly into a cheap "read scalars off the
 reconstructor" layer and a heavier "measure the variant payload" layer, and
-splitting them kept each diff reviewable.)
+splitting them kept each diff reviewable. Then the track dispatch had to move
+*below* the ABC hoist rather than into it -- see layer 4.)
 
 1. `fix/svar2-haplotype-lengths-indels` — override `_haplotype_ilens` on
    `Svar2Haps` (delegating to `_haplotype_diffs`) plus a regression test
@@ -166,10 +167,17 @@ splitting them kept each diff reviewable.)
    `ref_allele_bytes` and `prepare_var_fields`; implement on `Haps`. The two
    `isinstance(haps_obj, Svar2Haps)` estimate forks and the `with_var_fields`
    fork all delete here, and `_impl.py` stops importing `Svar2Haps`.
-4. `refactor/haps-role-abc` — rename `Haps` -> `Svar1Haps`, hoist the ABC into
-   `Haps`, reparent `Svar2Haps` to it, and move the `HapsTracks.__call__`
-   dispatch onto a `realign_track_block` override. Mostly mechanical.
-5. `refactor/haps-drop-placeholders` — delete the fabricated `genotypes` /
+4. `refactor/haps-track-dispatch` — collapse `HapsTracks.__call__`'s two arms
+   into one body that reaches the backend only through
+   `Haps.check_track_realign_support` and `Haps.track_realigner` (returning a
+   per-batch `TrackRealigner`). `_call_svar2` and the last
+   `isinstance(self.haps, Svar2Haps)` delete here, and `_reconstruct.py` stops
+   importing `Svar2Haps`. `has_dosages` joins the query surface, retiring the
+   last `_impl.py` reach into SVAR1 storage.
+5. `refactor/haps-role-abc` — rename `Haps` -> `Svar1Haps`, hoist the ABC into
+   `Haps`, reparent `Svar2Haps` to it. Mechanical, because after layer 4
+   nothing outside `_haps.py` / `_flat_variants.py` touches SVAR1 storage.
+6. `refactor/haps-drop-placeholders` — delete the fabricated `genotypes` /
    `_Variants` from `Svar2Haps.from_path` and `_ShapeOnlyGenotypes`.
 
 ## Testing
@@ -208,6 +216,35 @@ with the arithmetic and a reproduction. Tightening the count before that lands
 turns three `tests/unit/dataset/test_output_bytes_dummy_variant.py` cases red
 (`estimated=7696 < actual=7728`, deficit 32 = 4 x 8). Fixing #362 first, then
 tightening, is the correct order; both are out of scope for this stack.
+
+## Found while implementing layer 4
+
+Two things in the layer-4 plan above were wrong, and reordering the stack was
+the fix.
+
+**`realign_track_block` was already taken.** The design named the new
+track-dispatch override after a method that already exists on `Svar2Haps`
+(`_svar2_haps.py`) as a *lower-level kernel helper* — the thing `_call_svar2`
+called inside its per-track loop. The role-level member is now
+`Haps.track_realigner`, returning a per-batch `TrackRealigner`; the SVAR2
+kernel helper keeps its name.
+
+**The dispatch had to move below the ABC hoist, not into it.** After layer 3,
+`_reconstruct.py` still read `haps.genotypes` and `haps.ffi_static` inside
+`HapsTracks.__call__`'s SVAR1 arm, and `_impl.py` still read `haps_obj.dosages`.
+Hoisting the ABC first would have left those as type errors against the role,
+to be papered over with `cast`/`assert isinstance` and then unpicked again one
+layer later. Doing the dispatch first means the hoist touches only class
+headers and field placement.
+
+**Why a `TrackRealigner` object rather than a per-track hook.** The obvious
+shape — one abstract "fill this track's block" method — would have re-run
+`_as_starts_stops(self.genotypes.offsets)` once per track. That array is
+`(2, regions*samples*ploidy)`, and the old code deliberately hoisted it out of
+the loop. Caching it on the reconstructor instead would pin a per-sample-scale
+allocation for the dataset's lifetime. Splitting the hook into "prepare once
+per batch" + "fill once per track" preserves the hoist by construction, and
+gives the per-batch state a name and a type.
 
 ## Non-goals
 

--- a/python/genvarloader/_dataset/_haps.py
+++ b/python/genvarloader/_dataset/_haps.py
@@ -31,11 +31,15 @@ from seqpro.rag import OFFSET_TYPE, Ragged
 from typing_extensions import assert_never
 
 from .._flat import _Flat, _FlatAnnotatedHaps
-from .._ragged import RaggedAnnotatedHaps, RaggedSeqs
+from .._ragged import RaggedAnnotatedHaps, RaggedIntervals, RaggedSeqs
 from ._flat_variants import _FlatVariantWindows, VarWindowOpt
 from .._utils import lengths_to_offsets
 from .._variants._records import RaggedAlleles
+
+# Fused tracks entry: intervals -> scratch -> realign, one FFI crossing.
+# Imported at module level so the spy in test_fused_tracks_parity can monkeypatch it.
 from ..genvarloader import (
+    intervals_and_realign_track_fused as intervals_and_realign_track_fused,
     reconstruct_annotated_haplotypes_fused as reconstruct_annotated_haplotypes_fused,
     reconstruct_annotated_haplotypes_spliced_fused as reconstruct_annotated_haplotypes_spliced_fused,
     reconstruct_haplotypes_fused as reconstruct_haplotypes_fused,
@@ -48,7 +52,7 @@ from ._genotypes import (
 )
 from .._threads import should_parallelize
 from ._utils import _ffi_array
-from ._protocol import Reconstructor
+from ._protocol import Reconstructor, TrackRealigner
 from ._rag_variants import RaggedVariants
 from ._reference import Reference
 from ._splice import SplicePlan
@@ -348,6 +352,16 @@ class Haps(Reconstructor[_H]):
     def has_ref_alleles(self) -> bool:
         """Whether REF allele bytes are available (needed by ``ref='allele'``)."""
         return self.variants.ref is not None
+
+    @property
+    def has_dosages(self) -> bool:
+        """Whether per-call dosages can be emitted for ``var_fields=['dosage']``.
+
+        SVAR1 memmaps ``dosages`` only when the dataset was written with them, so
+        this is a storage question the memory estimate has to ask before charging
+        for a dosage column.
+        """
+        return self.dosages is not None
 
     def var_field_dtype(self, field: str) -> np.dtype:
         """The numpy dtype of per-variant *scalar* field ``field``.
@@ -1014,6 +1028,95 @@ class Haps(Reconstructor[_H]):
             haps = _lazy_load_custom_fields(haps, new_custom_fields)
         return replace(haps, var_fields=var_fields)
 
+    # ---- haplotype-realigned tracks ----
+    #
+    # ``HapsTracks.__call__`` runs one body for every backend and reaches the
+    # backend only through these two members. See
+    # docs/superpowers/specs/2026-09-08-haps-role-split-design.md.
+
+    def check_track_realign_support(
+        self,
+        output_length: Literal["ragged", "variable"] | int,
+        splice_plan: SplicePlan | None,
+        to_rc: NDArray[np.bool_] | None,
+        ragged_tracks: bool,
+    ) -> None:
+        """Reject request shapes this backend cannot realign tracks for.
+
+        Args:
+            output_length: The requested output length.
+            splice_plan: The requested splice plan, if any.
+            to_rc: Per-query reverse-complement mask, if any.
+            ragged_tracks: Whether the tracks are being realigned at all
+                (False means the caller returns stored intervals untouched, so
+                realign-only limits do not apply).
+
+        Raises:
+            NotImplementedError: If this backend cannot serve the request.
+        """
+        del output_length, to_rc, ragged_tracks
+        if splice_plan is not None:
+            raise NotImplementedError(
+                "Splicing of haplotypes + tracks (shape (b, t, p, ~l)) is not "
+                "supported."
+            )
+
+    def track_realigner(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.int32],
+        shifts: NDArray[np.int32],
+        geno_idx: NDArray[np.integer],
+        track_lengths: NDArray[np.integer],
+        out_offsets: NDArray[np.integer],
+        keep: NDArray[np.bool_] | None,
+        keep_offsets: NDArray[np.integer] | None,
+        to_rc: NDArray[np.bool_] | None,
+        base_seed: int,
+    ) -> TrackRealigner:
+        """Prepare the per-batch state for filling realigned track blocks.
+
+        Args:
+            idx: Flat ``(region, sample)`` dataset indices for the batch.
+            regions: ``(b, 3)`` contig/start/end of each query.
+            shifts: ``(b, p)`` per-haplotype jitter shifts.
+            geno_idx: ``(b, p)`` indices into the sparse genotype offsets.
+            track_lengths: ``(b,)`` reference span each track block is read over.
+            out_offsets: ``(b*p+1,)`` per-haplotype offsets into one track's block.
+            keep: Optional per-variant keep mask (``filter='exonic'``).
+            keep_offsets: Offsets into ``keep``.
+            to_rc: Per-query reverse-complement mask, if any.
+            base_seed: Seed for seed-dependent insertion fills.
+
+        Returns:
+            A realigner whose ``fill`` writes one track at a time.
+        """
+        del idx  # SVAR1 addresses each track by ``o_idx`` alone
+        return _Svar1TrackRealigner(
+            haps=self,
+            regions=np.ascontiguousarray(regions, np.int32),
+            shifts=np.ascontiguousarray(shifts, np.int32),
+            geno_offset_idx=np.ascontiguousarray(geno_idx, np.int64),
+            # Materialized once per batch rather than once per track: it is
+            # (2, regions*samples*ploidy). Dataset-scoped in principle, but
+            # caching it on the reconstructor would pin a per-sample-scale
+            # array for the dataset's lifetime.
+            geno_offsets=_as_starts_stops(self.genotypes.offsets),
+            out_offsets=np.ascontiguousarray(out_offsets, np.int64),
+            track_offsets=np.ascontiguousarray(
+                lengths_to_offsets(track_lengths), np.int64
+            ),
+            keep=None if keep is None else np.ascontiguousarray(keep, np.bool_),
+            keep_offsets=None
+            if keep_offsets is None
+            else np.ascontiguousarray(keep_offsets, np.int64),
+            # Expand per-query to_rc to per-(query, hap) for the track kernel.
+            to_rc=None
+            if to_rc is None
+            else np.ascontiguousarray(np.repeat(to_rc, geno_idx.shape[-1]), np.bool_),
+            base_seed=base_seed,
+        )
+
     def _reconstruct_haplotypes(
         self,
         req: ReconstructionRequest,
@@ -1315,6 +1418,70 @@ class Haps(Reconstructor[_H]):
             permuted_regions,
             keep_perm,
             keep_offsets_perm,
+        )
+
+
+@dataclass(slots=True)
+class _Svar1TrackRealigner:
+    """SVAR1 :class:`TrackRealigner`: one fused FFI crossing per track.
+
+    Every array here is FFI-ready, so the per-track :meth:`fill` does no
+    conversion work that does not depend on the track. ``geno_offsets`` in
+    particular is ``(2, regions*samples*ploidy)``; materializing it once per
+    track instead of once per batch was measurably wasteful.
+    """
+
+    haps: "Haps"
+    regions: NDArray[np.int32]
+    shifts: NDArray[np.int32]
+    geno_offset_idx: NDArray[np.int64]
+    geno_offsets: NDArray[np.int64]
+    out_offsets: NDArray[np.int64]
+    track_offsets: NDArray[np.int64]
+    keep: NDArray[np.bool_] | None
+    keep_offsets: NDArray[np.int64] | None
+    to_rc: NDArray[np.bool_] | None
+    base_seed: int
+
+    def fill(
+        self,
+        out: NDArray[np.float32],
+        o_idx: NDArray[np.integer],
+        intervals: RaggedIntervals,
+        params: NDArray[np.float64],
+        strategy_id: int,
+    ) -> None:
+        """Fill one track's block via the fused intervals->realign kernel.
+
+        Replaces the unfused ``np.empty`` scratch + ``intervals_to_tracks`` +
+        ``shift_and_realign_tracks_sparse`` sequence with a single FFI crossing
+        that writes in place into ``out`` (a contiguous slice of the caller's
+        pre-allocated buffer, so no ``ascontiguousarray`` is needed for it).
+        """
+        stat = self.haps.ffi_static
+        intervals_and_realign_track_fused(
+            out=out,
+            out_offsets=self.out_offsets,
+            regions=self.regions,
+            shifts=self.shifts,
+            geno_offset_idx=self.geno_offset_idx,
+            geno_v_idxs=_ffi_array(self.haps.genotypes.data, np.int32, "geno_v_idxs"),
+            geno_offsets=self.geno_offsets,
+            v_starts=stat.v_starts,
+            ilens=stat.ilens,
+            offset_idxs=np.ascontiguousarray(o_idx, np.int64),
+            itv_starts=_ffi_array(intervals.starts.data, np.int32, "itv_starts"),
+            itv_ends=_ffi_array(intervals.ends.data, np.int32, "itv_ends"),
+            itv_values=_ffi_array(intervals.values.data, np.float32, "itv_values"),
+            itv_offsets=_ffi_array(intervals.starts.offsets, np.int64, "itv_offsets"),
+            track_offsets=self.track_offsets,
+            params=np.ascontiguousarray(params, np.float64),
+            strategy_id=int(strategy_id),
+            base_seed=int(self.base_seed),
+            keep=self.keep,
+            keep_offsets=self.keep_offsets,
+            to_rc=self.to_rc,
+            parallel=should_parallelize(int(self.out_offsets[-1]) * 4),
         )
 
 

--- a/python/genvarloader/_dataset/_impl.py
+++ b/python/genvarloader/_dataset/_impl.py
@@ -1439,7 +1439,7 @@ class Dataset:
                 elif f == "ilen":
                     total += n_vars_total * haps_obj.var_field_dtype("ilen").itemsize
                 elif f == "dosage":
-                    if haps_obj.dosages is None:
+                    if not haps_obj.has_dosages:
                         continue
                     dosage_dtype = haps_obj.var_field_dtype("dosage")
                     total += n_vars_total * dosage_dtype.itemsize
@@ -1507,7 +1507,7 @@ class Dataset:
                             n_dummy_groups * haps_obj.var_field_dtype("ilen").itemsize
                         )
                     elif f == "dosage":
-                        if haps_obj.dosages is None:
+                        if not haps_obj.has_dosages:
                             continue
                         total += (
                             n_dummy_groups * haps_obj.var_field_dtype("dosage").itemsize
@@ -1587,7 +1587,7 @@ class Dataset:
                 if f == "ilen":
                     total += n_vars_total * haps_obj.var_field_dtype("ilen").itemsize
                 elif f == "dosage":
-                    if haps_obj.dosages is None:
+                    if not haps_obj.has_dosages:
                         continue
                     total += n_vars_total * haps_obj.var_field_dtype("dosage").itemsize
                 else:
@@ -1646,7 +1646,7 @@ class Dataset:
                             n_dummy_groups * haps_obj.var_field_dtype("ilen").itemsize
                         )
                     elif f == "dosage":
-                        if haps_obj.dosages is None:
+                        if not haps_obj.has_dosages:
                             continue
                         total += (
                             n_dummy_groups * haps_obj.var_field_dtype("dosage").itemsize

--- a/python/genvarloader/_dataset/_protocol.py
+++ b/python/genvarloader/_dataset/_protocol.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 if TYPE_CHECKING:
+    from .._ragged import RaggedIntervals
     from ._splice import SplicePlan
 
 T = TypeVar("T", covariant=True)
@@ -41,5 +42,39 @@ class Reconstructor(Protocol[T]):
         ``to_rc`` is a per-row boolean mask (True = reverse-complement this row).
         On the Rust backend, flat-seq kinds fold RC in-kernel; on numba the
         caller's post-pass handles it and this param is ignored by each method.
+        """
+        ...
+
+
+class TrackRealigner(Protocol):
+    """Per-batch state for filling haplotype-realigned track blocks.
+
+    ``HapsTracks.__call__`` allocates one output buffer for the whole batch and
+    then fills it one track at a time. Everything the realign kernel needs that
+    does *not* vary across tracks -- the batch's regions, shifts, haplotype
+    offsets and whatever backend-specific arrays those imply -- is prepared once
+    by :meth:`Haps.track_realigner` and carried here, so the per-track loop stays
+    backend-agnostic and per-batch work is not repeated per track.
+    """
+
+    def fill(
+        self,
+        out: NDArray[np.float32],
+        o_idx: NDArray[np.integer],
+        intervals: "RaggedIntervals",
+        params: NDArray[np.float64],
+        strategy_id: int,
+    ) -> None:
+        """Write one track's realigned haplotype block into ``out``.
+
+        Args:
+            out: The destination slice for this track, laid out on the batch's
+                per-haplotype output offsets. Written in place.
+            o_idx: Per-query row into this track's intervals -- the sample-major
+                index for :attr:`TrackType.SAMPLE` tracks, the region index
+                otherwise.
+            intervals: This track's stored intervals.
+            params: The lowered insertion-fill parameters for this track.
+            strategy_id: The lowered insertion-fill strategy for this track.
         """
         ...

--- a/python/genvarloader/_dataset/_reconstruct.py
+++ b/python/genvarloader/_dataset/_reconstruct.py
@@ -23,7 +23,6 @@ from typing_extensions import assert_never
 from .._flat import _Flat
 from .._ragged import RaggedAnnotatedHaps, RaggedIntervals, RaggedSeqs, RaggedTracks
 from .._utils import lengths_to_offsets
-from ._genotypes import _as_starts_stops
 from ._haps import _H, Haps, ReconstructionRequest, _NewH, _Variants
 from ._insertion_fill import Repeat5p
 from ._insertion_fill import lower as _lower_insertion_fills
@@ -38,14 +37,6 @@ from ._tracks import (
     TrackType,
     _NewT,
 )  # noqa: F401
-from ._utils import _ffi_array
-from .._threads import should_parallelize
-
-# Fused tracks entry: intervals → scratch → realign, one FFI crossing.
-# Imported at module level so the spy in test_fused_tracks_parity can monkeypatch it.
-from ..genvarloader import (
-    intervals_and_realign_track_fused as intervals_and_realign_track_fused,
-)
 
 
 # Re-exports for back-compat (callers historically imported these from
@@ -142,29 +133,22 @@ class HapsTracks(Reconstructor[tuple[_H, _T]]):
         flat: bool = False,
         to_rc: "NDArray[np.bool_] | None" = None,
     ) -> tuple[_H, _T]:
-        # SVAR2 read path: route to the split materialize→realign
-        # kernel. The isinstance guard keeps the SVAR1 body below byte-unchanged.
-        from ._svar2_haps import Svar2Haps
+        """Haplotypes plus their haplotype-realigned tracks, ``(b, t, p, ~l)``.
 
-        if isinstance(self.haps, Svar2Haps):
-            return self._call_svar2(
-                idx,
-                r_idx,
-                regions,
-                output_length,
-                jitter,
-                rng,
-                deterministic,
-                splice_plan,
-                flat,
-                to_rc,
-            )
+        One body for every haplotype backend. The two things that differ --
+        which request shapes a backend can serve, and how one track's realigned
+        block is produced -- are asked of the reconstructor via
+        :meth:`Haps.check_track_realign_support` and
+        :meth:`Haps.track_realigner`.
+        """
+        ragged_tracks = issubclass(self.tracks.kind, RaggedTracks)
+        self.haps.check_track_realign_support(
+            output_length=output_length,
+            splice_plan=splice_plan,
+            to_rc=to_rc,
+            ragged_tracks=ragged_tracks,
+        )
 
-        if splice_plan is not None:
-            raise NotImplementedError(
-                "Splicing of haplotypes + tracks (shape (b, t, p, ~l)) is not "
-                "supported."
-            )
         lengths = regions[:, 2] - regions[:, 1]
 
         # ragged (b p l), (b p), (b p), (b*p*v), (b*p+1), (b p)
@@ -179,7 +163,7 @@ class HapsTracks(Reconstructor[tuple[_H, _T]]):
             )
         )
 
-        if issubclass(self.tracks.kind, RaggedTracks):
+        if ragged_tracks:
             if isinstance(output_length, int):
                 # (b p)
                 out_lengths = np.full_like(hap_lengths, output_length)
@@ -192,8 +176,6 @@ class HapsTracks(Reconstructor[tuple[_H, _T]]):
 
             # (b*p+1)
             out_ofsts_per_t = lengths_to_offsets(out_lengths)
-            # (b+1)
-            track_ofsts_per_t = lengths_to_offsets(track_lengths)
             n_per_track: int = out_ofsts_per_t[-1]
             # ragged (b t p l)
             out = np.empty(len(self.tracks.active_tracks) * n_per_track, np.float32)
@@ -212,6 +194,12 @@ class HapsTracks(Reconstructor[tuple[_H, _T]]):
             # from the full idx array so different batches produce different
             # fills; same input always produces the same fill. Uses the full
             # uint64 range.
+            #
+            # Seed-dependent fills stay byte-identical across backends even
+            # though the readbound path realigns per contig group where
+            # `k / ploidy` is contig-LOCAL: that path passes the group's global
+            # row indices into the FFI and the kernel seeds with those. Fixed in
+            # issue #267.
             if deterministic:
                 base_seed = np.uint64(
                     np.bitwise_xor.reduce(idx.astype(np.uint64, copy=False))
@@ -221,223 +209,36 @@ class HapsTracks(Reconstructor[tuple[_H, _T]]):
                     rng.integers(0, np.iinfo(np.uint64).max, dtype=np.uint64)
                 )
 
-            # Pre-compute (2, n) geno_offsets once for the fused Rust path
-            # (avoids re-computing _as_starts_stops n_tracks times).
-            _geno_offsets_2d = _as_starts_stops(self.haps.genotypes.offsets)
+            # Everything the realign kernels need that does not vary per track,
+            # prepared once (see TrackRealigner).
+            realigner = self.haps.track_realigner(
+                idx=idx,
+                regions=regions,
+                shifts=shifts,
+                geno_idx=geno_idx,
+                track_lengths=track_lengths,
+                out_offsets=out_ofsts_per_t,
+                keep=keep,
+                keep_offsets=keep_offsets,
+                to_rc=to_rc,
+                base_seed=int(base_seed),
+            )
 
             for track_ofst, (name, tracktype) in enumerate(
                 self.tracks.active_tracks.items()
             ):
-                intervals = self.tracks.intervals[name]
-
                 if tracktype is TrackType.SAMPLE:
                     o_idx = idx
                 else:
                     o_idx = r_idx
 
-                _out = out[track_ofst * n_per_track : (track_ofst + 1) * n_per_track]
-
-                # Fused path (Rust): one FFI crossing, no Python-side
-                # intermediate buffer.  Replaces:
-                #   _tracks = np.empty(...)                (audit T2)
-                #   intervals_to_tracks(...)               (FFI crossing #3)
-                #   shift_and_realign_tracks_sparse(...)   (FFI crossing #4)
-                #
-                # _out is a contiguous f32 slice of the pre-allocated `out`
-                # buffer (np.empty, step=1).  No ascontiguousarray needed for
-                # `out`; the fused entry writes in-place into its buffer.
-                # Expand per-query to_rc to per-(query, hap) for the track kernel.
-                # out_ofsts_per_t is (b*p+1); ploidy = geno_idx.shape[-1].
-                _ploidy = geno_idx.shape[-1]
-                _to_rc_hap = (
-                    None
-                    if to_rc is None
-                    else np.ascontiguousarray(np.repeat(to_rc, _ploidy), np.bool_)
-                )
-                intervals_and_realign_track_fused(
-                    out=_out,
-                    out_offsets=np.ascontiguousarray(out_ofsts_per_t, np.int64),
-                    regions=np.ascontiguousarray(regions, np.int32),
-                    shifts=np.ascontiguousarray(shifts, np.int32),
-                    geno_offset_idx=np.ascontiguousarray(geno_idx, np.int64),
-                    geno_v_idxs=_ffi_array(
-                        self.haps.genotypes.data, np.int32, "geno_v_idxs"
-                    ),
-                    geno_offsets=_geno_offsets_2d,
-                    v_starts=self.haps.ffi_static.v_starts,
-                    ilens=self.haps.ffi_static.ilens,
-                    offset_idxs=np.ascontiguousarray(o_idx, np.int64),
-                    itv_starts=_ffi_array(
-                        intervals.starts.data, np.int32, "itv_starts"
-                    ),
-                    itv_ends=_ffi_array(intervals.ends.data, np.int32, "itv_ends"),
-                    itv_values=_ffi_array(
-                        intervals.values.data, np.float32, "itv_values"
-                    ),
-                    itv_offsets=_ffi_array(
-                        intervals.starts.offsets, np.int64, "itv_offsets"
-                    ),
-                    track_offsets=np.ascontiguousarray(track_ofsts_per_t, np.int64),
-                    params=np.ascontiguousarray(strat_params[track_ofst], np.float64),
-                    strategy_id=int(strat_ids[track_ofst]),
-                    base_seed=int(base_seed),
-                    keep=None if keep is None else np.ascontiguousarray(keep, np.bool_),
-                    keep_offsets=None
-                    if keep_offsets is None
-                    else np.ascontiguousarray(keep_offsets, np.int64),
-                    to_rc=_to_rc_hap,
-                    parallel=should_parallelize(int(out_ofsts_per_t[-1]) * 4),
-                )
-
-            out_shape = (
-                len(idx),
-                len(self.tracks.active_tracks),
-                self.haps.stored_ploidy,
-                None,
-            )
-
-            # flat (b t p l)
-            tracks = _Flat.from_offsets(out, out_shape, out_offsets)
-
-        else:
-            tracks = self.tracks._call_intervals(idx)
-
-        tracks = cast(_T, tracks)
-
-        return haps, tracks
-
-    def _call_svar2(
-        self,
-        idx: NDArray[np.integer],  # (b)
-        r_idx: NDArray[np.integer],  # (b)
-        regions: NDArray[np.int32],  # (b 3)
-        output_length: Literal["ragged", "variable"] | int,
-        jitter: int,
-        rng: np.random.Generator,
-        deterministic: bool,
-        splice_plan: SplicePlan | None = None,
-        flat: bool = False,
-        to_rc: "NDArray[np.bool_] | None" = None,
-    ) -> tuple[_H, _T]:
-        """SVAR2 haplotype-realigned tracks (see :class:`Svar2Haps`).
-
-        Produces the SAME ``(b, t, p, ~l)`` ``_Flat`` layout the SVAR1
-        :meth:`__call__` above produces — the per-track ``_out`` slices are filled
-        byte-identically, only the interval→realign step is SPLIT into the two
-        standalone SVAR2 kernels (``intervals_to_tracks`` +
-        ``shift_and_realign_tracks_from_svar2_readbound``) instead of the fused
-        SVAR1 kernel. Haps come from the shared ``get_haps_and_shifts`` 7-tuple.
-        """
-        from ._svar2_haps import Svar2Haps
-
-        haps_recon = cast(Svar2Haps, self.haps)
-
-        if splice_plan is not None:
-            raise NotImplementedError(
-                "Splicing of haplotypes + tracks is not supported for svar2 "
-                "datasets yet."
-            )
-        # Annotated haps are out of scope for svar2 (matches Svar2Haps.__call__).
-        # HapsTracks routes here BEFORE Svar2Haps's own annotated guard, and
-        # get_haps_and_shifts returns plain Ragged[S1] regardless of kind, so
-        # without this an annotated view would silently yield non-annotated haps.
-        if issubclass(self.haps.kind, RaggedAnnotatedHaps):
-            raise NotImplementedError(
-                "svar2 datasets do not support with_seqs('annotated') with tracks yet."
-            )
-        # The realign kernel has no in-kernel reverse-complement.
-        if to_rc is not None and bool(np.asarray(to_rc).any()):
-            raise NotImplementedError(
-                "In-kernel reverse-complement is not supported for svar2 "
-                "haplotype-realigned tracks."
-            )
-
-        lengths = regions[:, 2] - regions[:, 1]
-
-        # ragged (b p l), (b p), (b p), (b p), (b p), None, None
-        haps, _geno_idx, shifts, diffs, hap_lengths, _keep, _keep_offsets = (
-            haps_recon.get_haps_and_shifts(
-                idx=idx,
-                regions=regions,
-                output_length=output_length,
-                rng=rng,
-                deterministic=deterministic,
-                to_rc=to_rc,
-            )
-        )
-
-        if issubclass(self.tracks.kind, RaggedTracks):
-            # The readbound track kernel always sizes each hap to ref_len + diff
-            # (no output_length override), so a fixed-length request cannot be
-            # honored byte-identically. Guard rather than silently mis-size.
-            if isinstance(output_length, int):
-                raise NotImplementedError(
-                    "Fixed-length (int output_length) haplotype-realigned tracks "
-                    "are not supported for svar2 datasets yet; use ragged/variable "
-                    "output."
-                )
-            # (b p) — ragged output: hap output length == hap_lengths.
-            out_lengths = hap_lengths
-            # (b) = lengths (b) + max deletion length across ploidy (b p) -> (b)
-            track_lengths = lengths - diffs.clip(max=0).min(1)
-
-            # (b*p+1)
-            out_ofsts_per_t = lengths_to_offsets(out_lengths)
-            n_per_track: int = out_ofsts_per_t[-1]
-            # ragged (b t p l)
-            out = np.empty(len(self.tracks.active_tracks) * n_per_track, np.float32)
-            out_lens = repeat(
-                out_lengths, "b p -> b t p", t=len(self.tracks.active_tracks)
-            )
-            out_offsets = lengths_to_offsets(out_lens)
-
-            # Lower per-track strategies into numba-friendly arrays.
-            strat_list = [
-                self.tracks.insertion_fill.get(name, Repeat5p())
-                for name in self.tracks.active_tracks
-            ]
-            strat_ids, strat_params = _lower_insertion_fills(strat_list)
-
-            # Seed-dependent (FlankSample) fills stay byte-identical to the single
-            # fused SVAR1 call across a multi-contig batch: SVAR1 realigns the
-            # whole batch in ONE call, so the fill hash `hash4(base_seed, query,
-            # hap, out_idx+i)` uses the GLOBAL row `query`. `_call_svar2` calls the
-            # readbound kernel once PER CONTIG GROUP where `k / ploidy` is
-            # contig-LOCAL, so `realign_track_block` passes the group's global row
-            # indices into the FFI (`global_query`) and the kernel seeds with those
-            # instead of the local index. `base_seed` already matches (both derive
-            # from the full idx). Fixed in issue #267.
-            # Base seed identical to the SVAR1 path (idx-xor when deterministic).
-            if deterministic:
-                base_seed = np.uint64(
-                    np.bitwise_xor.reduce(idx.astype(np.uint64, copy=False))
-                )
-            else:
-                base_seed = np.uint64(
-                    rng.integers(0, np.iinfo(np.uint64).max, dtype=np.uint64)
-                )
-
-            for track_ofst, (name, tracktype) in enumerate(
-                self.tracks.active_tracks.items()
-            ):
-                intervals = self.tracks.intervals[name]
-                o_idx = idx if tracktype is TrackType.SAMPLE else r_idx
-
-                _out = out[track_ofst * n_per_track : (track_ofst + 1) * n_per_track]
-                block_data, _block_off = haps_recon.realign_track_block(
-                    idx=idx,
+                realigner.fill(
+                    out=out[track_ofst * n_per_track : (track_ofst + 1) * n_per_track],
                     o_idx=o_idx,
-                    regions=regions,
-                    shifts=shifts,
-                    track_lengths=track_lengths,
-                    intervals=intervals,
-                    params=np.ascontiguousarray(strat_params[track_ofst], np.float64),
+                    intervals=self.tracks.intervals[name],
+                    params=strat_params[track_ofst],
                     strategy_id=int(strat_ids[track_ofst]),
-                    base_seed=int(base_seed),
                 )
-                # block_data is (b, P) C-ordered with per-hap lengths == hap_lengths,
-                # so its offsets equal out_ofsts_per_t; copy into the track slice.
-                _out[:] = block_data
 
             out_shape = (
                 len(idx),
@@ -453,6 +254,7 @@ class HapsTracks(Reconstructor[tuple[_H, _T]]):
             tracks = self.tracks._call_intervals(idx)
 
         tracks = cast(_T, tracks)
+
         return cast(_H, haps), tracks
 
 

--- a/python/genvarloader/_dataset/_svar2_haps.py
+++ b/python/genvarloader/_dataset/_svar2_haps.py
@@ -37,7 +37,7 @@ from numpy.typing import NDArray
 from seqpro.rag import Ragged
 
 from .._flat import _Flat
-from .._ragged import RaggedAnnotatedHaps, _COMP
+from .._ragged import RaggedAnnotatedHaps, RaggedIntervals, _COMP
 from .._threads import should_parallelize
 from .._utils import lengths_to_offsets
 from .._variants._records import RaggedAlleles
@@ -58,6 +58,7 @@ from ._flat_variants import (
 )
 from ._intervals import intervals_to_tracks
 from ._haps import _H, Haps, _Variants
+from ._protocol import TrackRealigner
 from ._rag_variants import RaggedVariants
 from ._reference import Reference
 from ._svar2_link import Svar2Link, _resolve_svar2, _verify_svar2_fingerprint
@@ -294,6 +295,65 @@ class Svar2Haps(Haps[_H]):
     def has_ref_alleles(self) -> bool:
         """SVAR2 never carries REF allele bytes (the decode is ALT-only)."""
         return False
+
+    @property
+    def has_dosages(self) -> bool:
+        """SVAR2 never emits dosages.
+
+        ``dosage`` is a builtin name the read-bound decode kernel does not
+        produce, so it is filtered out of both :attr:`available_var_fields` and
+        :meth:`_requested_store_fields` and can never be requested.
+        """
+        return False
+
+    def check_track_realign_support(
+        self,
+        output_length: Literal["ragged", "variable"] | int,
+        splice_plan: "SplicePlan | None",
+        to_rc: NDArray[np.bool_] | None,
+        ragged_tracks: bool,
+    ) -> None:
+        """Reject the request shapes the read-bound track path cannot serve.
+
+        Args:
+            output_length: The requested output length.
+            splice_plan: The requested splice plan, if any.
+            to_rc: Per-query reverse-complement mask, if any.
+            ragged_tracks: Whether the tracks are being realigned at all.
+
+        Raises:
+            NotImplementedError: For splicing, annotated haps, a fixed output
+                length, or in-kernel reverse-complement.
+        """
+        if splice_plan is not None:
+            raise NotImplementedError(
+                "Splicing of haplotypes + tracks is not supported for svar2 "
+                "datasets yet."
+            )
+        # Annotated haps are out of scope for svar2 (matches Svar2Haps.__call__).
+        # HapsTracks checks support BEFORE reaching Svar2Haps's own annotated
+        # guard, and get_haps_and_shifts returns plain Ragged[S1] regardless of
+        # kind, so without this an annotated view would silently yield
+        # non-annotated haps.
+        if issubclass(self.kind, RaggedAnnotatedHaps):
+            raise NotImplementedError(
+                "svar2 datasets do not support with_seqs('annotated') with tracks yet."
+            )
+        # The realign kernel has no in-kernel reverse-complement.
+        if to_rc is not None and bool(np.asarray(to_rc).any()):
+            raise NotImplementedError(
+                "In-kernel reverse-complement is not supported for svar2 "
+                "haplotype-realigned tracks."
+            )
+        # The readbound track kernel always sizes each hap to ref_len + diff
+        # (no output_length override), so a fixed-length request cannot be
+        # honored byte-identically. Guard rather than silently mis-size.
+        if ragged_tracks and isinstance(output_length, int):
+            raise NotImplementedError(
+                "Fixed-length (int output_length) haplotype-realigned tracks "
+                "are not supported for svar2 datasets yet; use ragged/variable "
+                "output."
+            )
 
     def var_field_dtype(self, field: str) -> np.dtype:
         """The dtype of a scalar variant field, from the store manifest.
@@ -768,6 +828,52 @@ class Svar2Haps(Haps[_H]):
         return out, geno_offset_idx, shifts, diffs, hap_lengths, None, None
 
     # ---- tracks ----
+
+    def track_realigner(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.int32],
+        shifts: NDArray[np.int32],
+        geno_idx: NDArray[np.integer],
+        track_lengths: NDArray[np.integer],
+        out_offsets: NDArray[np.integer],
+        keep: NDArray[np.bool_] | None,
+        keep_offsets: NDArray[np.integer] | None,
+        to_rc: NDArray[np.bool_] | None,
+        base_seed: int,
+    ) -> TrackRealigner:
+        """Prepare the per-batch state for the read-bound track path.
+
+        ``geno_idx``/``keep``/``keep_offsets``/``to_rc`` describe the SVAR1
+        sparse-genotype layout and the exonic filter, neither of which the
+        read-bound decode uses: the kernel re-derives its own per-contig ranges
+        from the store, and :meth:`check_track_realign_support` has already
+        rejected the reverse-complement and exonic cases.
+
+        Args:
+            idx: Flat ``(region, sample)`` dataset indices for the batch.
+            regions: ``(b, 3)`` contig/start/end of each query.
+            shifts: ``(b, p)`` per-haplotype jitter shifts.
+            geno_idx: Unused; see above.
+            track_lengths: ``(b,)`` reference span each track block is read over.
+            out_offsets: Unused; the kernel sizes each hap natively.
+            keep: Unused; see above.
+            keep_offsets: Unused; see above.
+            to_rc: Unused; see above.
+            base_seed: Seed for seed-dependent insertion fills.
+
+        Returns:
+            A realigner whose ``fill`` writes one track at a time.
+        """
+        del geno_idx, out_offsets, keep, keep_offsets, to_rc
+        return _Svar2TrackRealigner(
+            haps=self,
+            idx=idx,
+            regions=regions,
+            shifts=shifts,
+            track_lengths=track_lengths,
+            base_seed=base_seed,
+        )
 
     def realign_track_block(
         self,
@@ -1552,3 +1658,44 @@ class Svar2Haps(Haps[_H]):
             "Ragged[np.bytes_]",
             _Flat.from_offsets(out_data, (b, P, None), out_off).view("S1"),
         )
+
+
+@dataclass(slots=True)
+class _Svar2TrackRealigner:
+    """SVAR2 :class:`TrackRealigner`: two standalone kernels per track.
+
+    Thin per-batch holder around :meth:`Svar2Haps.realign_track_block`, which
+    does its own per-contig cache slicing and therefore has no batch-scoped
+    arrays worth precomputing here.
+    """
+
+    haps: "Svar2Haps"
+    idx: NDArray[np.integer]
+    regions: NDArray[np.int32]
+    shifts: NDArray[np.int32]
+    track_lengths: NDArray[np.integer]
+    base_seed: int
+
+    def fill(
+        self,
+        out: NDArray[np.float32],
+        o_idx: NDArray[np.integer],
+        intervals: RaggedIntervals,
+        params: NDArray[np.float64],
+        strategy_id: int,
+    ) -> None:
+        """Fill one track's block from the read-bound realign kernels."""
+        block_data, _block_off = self.haps.realign_track_block(
+            idx=self.idx,
+            o_idx=o_idx,
+            regions=self.regions,
+            shifts=self.shifts,
+            track_lengths=self.track_lengths,
+            intervals=intervals,
+            params=np.ascontiguousarray(params, np.float64),
+            strategy_id=int(strategy_id),
+            base_seed=int(self.base_seed),
+        )
+        # block_data is (b, P) C-ordered with per-hap lengths == hap_lengths, so
+        # its offsets equal the caller's per-track offsets; copy into the slice.
+        out[:] = block_data

--- a/tests/dataset/test_svar2_dataset.py
+++ b/tests/dataset/test_svar2_dataset.py
@@ -367,7 +367,7 @@ def test_svar2_tracks_match_svar1(
 
     Both datasets are written from the SAME VCF + SAME BigWig track; at read the
     SVAR1 backend realigns via the fused kernel and the SVAR2 backend
-    (``Svar2Haps`` + ``HapsTracks._call_svar2``) realigns via the split
+    (``Svar2Haps.realign_track_block``) realigns via the split
     ``intervals_to_tracks`` + ``shift_and_realign_tracks_from_svar2_readbound``
     path. deterministic=True + max_jitter=0 => shifts=0, so parity is exact.
     """
@@ -413,7 +413,7 @@ def test_svar2_tracks_match_svar1_multicontig(
     tmp_path, svar_fixture2, svar2_fixture2, _src2
 ):
     """Realigned tracks byte-identical to SVAR1 across a TWO-contig, out-of-order
-    bed -- exercises ``_call_svar2``'s contig-group split + inverse row-perm
+    bed -- exercises ``realign_track_block``'s contig-group split + inverse row-perm
     stitching for the track path (single-contig fast path bypassed)."""
     import pyBigWig
 
@@ -482,7 +482,7 @@ def test_svar2_flanksample_multicontig_matches_svar1(
 ):
     """FlankSample (seed-dependent fill) + MULTI-contig is byte-identical to SVAR1.
 
-    ``_call_svar2`` realigns per contig group, so ``k / ploidy`` is a contig-LOCAL
+    ``realign_track_block`` realigns per contig group, so ``k / ploidy`` is a contig-LOCAL
     query index; SVAR1 realigns the whole batch in one fused call and seeds the
     FlankSample fill hash with the GLOBAL row. Issue #267 makes the read-bound
     path pass each group's global row indices (``global_query``) into the FFI so

--- a/tests/parity/test_dataset_parity.py
+++ b/tests/parity/test_dataset_parity.py
@@ -207,7 +207,7 @@ def test_tracks_realign_getitem_identical_across_backends(
     The spy targets this entry.
     """
     import genvarloader as gvl
-    import genvarloader._dataset._reconstruct as _recon_mod
+    import genvarloader._dataset._haps as _haps_mod
     from genvarloader._dataset._insertion_fill import (
         Constant,
         FlankSample,
@@ -221,10 +221,10 @@ def test_tracks_realign_getitem_identical_across_backends(
     ds_base = gvl.Dataset.open(ds_dir, reference=ref)
     ds_base = ds_base.with_seqs("haplotypes").with_tracks("signal")
 
-    orig_fused = getattr(_recon_mod, "intervals_and_realign_track_fused", None)
+    orig_fused = getattr(_haps_mod, "intervals_and_realign_track_fused", None)
     assert orig_fused is not None, (
-        "intervals_and_realign_track_fused not found on _recon_mod — "
-        "ensure it is imported at module level in _reconstruct.py"
+        "intervals_and_realign_track_fused not found on _haps_mod — "
+        "ensure it is imported at module level in _haps.py"
     )
 
     calls: dict[str, int] = {"n": 0}
@@ -245,7 +245,7 @@ def test_tracks_realign_getitem_identical_across_backends(
         strategy_name = type(strategy).__name__
         ds = ds_base.with_insertion_fill(strategy)
 
-        monkeypatch.setattr(_recon_mod, "intervals_and_realign_track_fused", _spy_fused)
+        monkeypatch.setattr(_haps_mod, "intervals_and_realign_track_fused", _spy_fused)
         calls["n"] = 0  # reset per-strategy counter
 
         # --- read (default rust backend, spy active) ---
@@ -255,7 +255,7 @@ def test_tracks_realign_getitem_identical_across_backends(
         assert calls["n"] > 0, (
             f"[{strategy_name}] intervals_and_realign_track_fused was NEVER "
             f"invoked during the read (calls={calls['n']}) — "
-            "the backstop is vacuous. Inspect HapsTracks.__call__ to "
+            "the backstop is vacuous. Inspect _Svar1TrackRealigner.fill to "
             "confirm intervals_and_realign_track_fused is called on the Rust path."
         )
 
@@ -277,7 +277,7 @@ def test_tracks_realign_getitem_identical_across_backends(
         _golden.assert_output_matches_golden(out, _golden.load_flat_golden(golden_name))
 
         # Restore original between strategies.
-        monkeypatch.setattr(_recon_mod, "intervals_and_realign_track_fused", orig_fused)
+        monkeypatch.setattr(_haps_mod, "intervals_and_realign_track_fused", orig_fused)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/parity/test_fused_tracks_parity.py
+++ b/tests/parity/test_fused_tracks_parity.py
@@ -32,11 +32,11 @@ def test_fused_tracks_dataset_parity(synthetic_case, tmp_path, monkeypatch):
     directly from HapsTracks.__call__ on the rust path) must produce the same
     float32 bytes as the frozen golden.
 
-    Spy guard: we monkeypatch ``_reconstruct_mod.intervals_and_realign_track_fused``
+    Spy guard: we monkeypatch ``_haps_mod.intervals_and_realign_track_fused``
     to count calls. The spy must fire at least once during the read.
     """
     import genvarloader as gvl
-    import genvarloader._dataset._reconstruct as _reconstruct_mod
+    import genvarloader._dataset._haps as _haps_mod
     from genvarloader._dataset._insertion_fill import (
         Constant,
         FlankSample,
@@ -51,10 +51,10 @@ def test_fused_tracks_dataset_parity(synthetic_case, tmp_path, monkeypatch):
     ds_base = gvl.Dataset.open(ds_dir, reference=ref)
     ds_base = ds_base.with_seqs("haplotypes").with_tracks("signal")
 
-    orig_fused = getattr(_reconstruct_mod, "intervals_and_realign_track_fused", None)
+    orig_fused = getattr(_haps_mod, "intervals_and_realign_track_fused", None)
     assert orig_fused is not None, (
-        "intervals_and_realign_track_fused not found on _reconstruct_mod — "
-        "ensure it is imported at module level in _reconstruct.py"
+        "intervals_and_realign_track_fused not found on _haps_mod — "
+        "ensure it is imported at module level in _haps.py"
     )
 
     fill_strategies = [
@@ -80,9 +80,7 @@ def test_fused_tracks_dataset_parity(synthetic_case, tmp_path, monkeypatch):
             return spy
 
         spy_fn = _make_spy(orig_fused)
-        monkeypatch.setattr(
-            _reconstruct_mod, "intervals_and_realign_track_fused", spy_fn
-        )
+        monkeypatch.setattr(_haps_mod, "intervals_and_realign_track_fused", spy_fn)
 
         calls["n"] = 0  # reset per-strategy
 
@@ -93,7 +91,7 @@ def test_fused_tracks_dataset_parity(synthetic_case, tmp_path, monkeypatch):
         assert calls["n"] > 0, (
             f"[{strategy_name}] intervals_and_realign_track_fused was NEVER invoked "
             f"during the read (calls={calls['n']}) — the backstop is "
-            "vacuous. Ensure HapsTracks.__call__ calls intervals_and_realign_track_fused "
+            "vacuous. Ensure _Svar1TrackRealigner.fill calls intervals_and_realign_track_fused "
             "on the Rust path."
         )
 
@@ -117,6 +115,4 @@ def test_fused_tracks_dataset_parity(synthetic_case, tmp_path, monkeypatch):
         _golden.assert_output_matches_golden(out, _golden.load_flat_golden(golden_name))
 
         # Restore original between strategies.
-        monkeypatch.setattr(
-            _reconstruct_mod, "intervals_and_realign_track_fused", orig_fused
-        )
+        monkeypatch.setattr(_haps_mod, "intervals_and_realign_track_fused", orig_fused)


### PR DESCRIPTION
**Layer 4 of 5** in the `Haps` role/implementation split. Stacked on #366.

---

`HapsTracks.__call__` opened with `isinstance(self.haps, Svar2Haps)` and routed
to a 145-line `_call_svar2` that reproduced the SVAR1 body almost line for line
— same guards, same `get_haps_and_shifts` call, same output sizing, same
per-track loop. The two differed in exactly two places: which request shapes the
backend can serve, and how one track's realigned block is produced. Everything
else was duplicated, and the SVAR1 arm additionally read `haps.genotypes` /
`haps.ffi_static` straight off the reconstructor.

Ask the reconstructor those two things instead:

- `Haps.check_track_realign_support(output_length, splice_plan, to_rc,
  ragged_tracks)` raises for the combinations a backend cannot realign. Each
  existing `NotImplementedError` moves here verbatim.
- `Haps.track_realigner(...) -> TrackRealigner` prepares the per-batch state and
  hands back an object whose `fill(out, o_idx, intervals, params, strategy_id)`
  writes one track's block.

`_call_svar2` and the last `isinstance(self.haps, Svar2Haps)` delete;
`_reconstruct.py` no longer imports `Svar2Haps` at all, and `__call__` loses
~200 lines.

## Why a `TrackRealigner` object

The obvious shape — one abstract "fill this track's block" method — would re-run
`_as_starts_stops(genotypes.offsets)` once per track. That array is
`(2, regions*samples*ploidy)`, and the old code deliberately hoisted it out of
the per-track loop. Caching it on the reconstructor instead would pin a
per-sample-scale allocation for the dataset's lifetime, which is the failure
mode #315's neighbours are made of. Splitting the hook into "prepare once per
batch" + "fill once per track" preserves the hoist by construction rather than
by comment, and gives the per-batch state a name and a type.

## Also: `has_dosages`

`_output_bytes_per_instance` asked `haps_obj.dosages is None` in four places —
the last spot where `_impl.py` reached into SVAR1 storage. SVAR2 answers `False`,
which is what the placeholder answered too: `dosage` is a builtin name the
read-bound decode does not produce, so it is filtered out of
`available_var_fields` and can never be requested.

## Behavior

Behavior-preserving, with one deliberate shift: SVAR2 rejected a fixed `int`
`output_length` from inside the ragged-tracks branch, i.e. after
`get_haps_and_shifts` had already run. The guard now fires before it. Same
exception, same message, raised earlier.

The fused-kernel import moves to `_haps.py` with the call site, so the two
parity spies (`test_dataset_parity`, `test_fused_tracks_parity`) patch `_haps`
rather than `_reconstruct`.

## A correction to the design doc

The design bundled this dispatch into the ABC hoist and named it after
`realign_track_block` — a name already taken by the lower-level SVAR2 kernel
helper. It is its own layer, *below* the hoist, because the hoist is only
mechanical once nothing outside `_haps.py` touches SVAR1 storage. The doc is
updated here with both corrections.

## Testing

`pytest tests/dataset tests/unit tests/parity` at the top of the stack:
**944 passed, 36 skipped, 2 xfailed, 0 failed** (Slurm job 1049099). Every layer
below is contained in that run.

Note on the evidence: the earlier per-layer runs used a Slurm helper that passed
*relative* test paths while overriding `PYTHONPATH` to the worktree's package —
so it collected the main checkout's tests against the branch's code. That is a
false-green generator (it also produced two nonsense failures here, where the
stale spies patched a symbol this branch moved). The helper now resolves test
paths against the worktree; the number above is from the corrected run, and the
+1 in the collected count versus the stale run is #364's regression test finally
being collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Romp6JJHU4g1M7UyPyCSJH

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
