### PR TITLE
refactor(haps): split the Haps role from its SVAR1 implementation

### DIFF
--- a/docs/superpowers/specs/2026-09-08-haps-role-split-design.md
+++ b/docs/superpowers/specs/2026-09-08-haps-role-split-design.md
@@ -144,16 +144,20 @@ as-is**, then delete `_ShapeOnlyGenotypes` in the final layer of this stack.
 Asking the contributor to absorb this refactor would be unfair scope creep on a
 correct bug report.
 
-If #356 has not merged when the final layer is written, that layer deletes the
-`Ragged` placeholder instead; the end state is identical either way.
+#356 had not merged when the final layer was written, so layer 5 deletes the
+plain `Ragged` placeholder instead of `_ShapeOnlyGenotypes`. The end state is
+identical either way, and #356 can be closed unmerged once this stack lands:
+there is no longer an allocation for it to shrink.
 
-## Implementation: a 6-PR stack
+## Implementation: a 5-PR stack
 
 Each layer is independently green and independently reviewable. (Planned as
-four. The query surface split cleanly into a cheap "read scalars off the
-reconstructor" layer and a heavier "measure the variant payload" layer, and
-splitting them kept each diff reviewable. Then the track dispatch had to move
-*below* the ABC hoist rather than into it -- see layer 4.)
+four, then six, and landed as five. The query surface split cleanly into a cheap
+"read scalars off the reconstructor" layer and a heavier "measure the variant
+payload" layer, and splitting them kept each diff reviewable. Then the track
+dispatch had to move *below* the ABC hoist rather than into it -- see layer 4.
+Finally the placeholder deletion turned out to be inseparable from the hoist --
+see layer 5.)
 
 1. `fix/svar2-haplotype-lengths-indels` — override `_haplotype_ilens` on
    `Svar2Haps` (delegating to `_haplotype_diffs`) plus a regression test
@@ -175,10 +179,10 @@ splitting them kept each diff reviewable. Then the track dispatch had to move
    importing `Svar2Haps`. `has_dosages` joins the query surface, retiring the
    last `_impl.py` reach into SVAR1 storage.
 5. `refactor/haps-role-abc` — rename `Haps` -> `Svar1Haps`, hoist the ABC into
-   `Haps`, reparent `Svar2Haps` to it. Mechanical, because after layer 4
-   nothing outside `_haps.py` / `_flat_variants.py` touches SVAR1 storage.
-6. `refactor/haps-drop-placeholders` — delete the fabricated `genotypes` /
-   `_Variants` from `Svar2Haps.from_path` and `_ShapeOnlyGenotypes`.
+   `Haps`, reparent `Svar2Haps` to it, and delete the fabricated `genotypes` /
+   `_Variants` from `Svar2Haps.from_path` in the same commit. Mechanical outside
+   `_haps.py`, because after layer 4 nothing else touches SVAR1 storage except
+   `get_variants_flat`.
 
 ## Testing
 
@@ -191,12 +195,13 @@ This is a behavior-preserving refactor except for layer 1, which fixes a bug.
 - The existing SVAR1/SVAR2 parity suite in `tests/dataset/` already pins the
   behavior that must not move.
 - New in layer 1: the `haplotype_lengths` regression test described above.
-- New in layer 5: assert `Svar2Haps` has no `genotypes`/`variants` attribute at
-  all — replacing PR #356's two allocation-size tests, which become moot once
-  there is nothing to allocate.
-- New in layer 4: round-trip `replace(haps, min_af=...)` on both subclasses, to
-  pin that the settings block stays `dataclasses.replace`-able across the
-  hierarchy change.
+- New in layer 5 (`tests/unit/dataset/test_haps_role_split.py`): `Haps` is
+  abstract and uninstantiable; neither implementation is left abstract; the role
+  declares no SVAR1 storage field and `Svar2Haps` has no such *attribute* at all
+  (`slots=True` makes that stronger than a field check); and the settings block
+  stays `dataclasses.replace`-able on both sides of the hierarchy. The first two
+  replace PR #356's allocation-size tests, which become moot once there is
+  nothing to allocate.
 - `tests/unit/test_slot_fit_property.py:85` and several docstrings in
   `tests/dataset/test_svar2_*.py` describe the placeholders; they need updating
   in the layer that removes what they describe.
@@ -245,6 +250,41 @@ the loop. Caching it on the reconstructor instead would pin a per-sample-scale
 allocation for the dataset's lifetime. Splitting the hook into "prepare once
 per batch" + "fill once per track" preserves the hoist by construction, and
 gives the per-batch state a name and a type.
+
+## Found while implementing layer 5
+
+**Layers 5 and 6 are one layer.** The plan had the ABC hoist and the placeholder
+deletion as separate PRs, on the theory that the placeholders could keep
+existing for a commit after `Svar2Haps` was reparented. They cannot. Both
+classes are `slots=True` dataclasses, so reparenting `Svar2Haps` onto a role
+that does not declare `genotypes` / `variants` / `dosages` / `var_field_data`
+removes those slots outright — there is nowhere left for a fabricated value to
+be stored. Deleting them is not a follow-up to the hoist; it *is* the hoist. The
+stack is five PRs, not six.
+
+**`kw_only=True` is what makes the split possible at all.** `Svar1Haps` adds
+four required fields, and they follow the role's defaulted ones (`var_fields`,
+`dummy_variant`, the token block, ...). Without `kw_only` that is a
+`TypeError` at class creation, and the workaround — giving every storage field a
+meaningless default — is exactly the shape that let the placeholders exist. It
+costs nothing here because every construction site was already all-keyword.
+
+It also pays for itself immediately on the other side: `Svar2Haps.store` and
+`.cache` were `X | None = None` purely to satisfy the same ordering rule, with
+three `assert ... is not None` lines apologising for it downstream. Keyword-only
+fields let both become required, and the asserts delete.
+
+**`Svar2Haps` needs `n_regions` / `n_samples` of its own.** They were the last
+thing the placeholder `genotypes` was really carrying: `_gathered_groups`
+unravels a flat dataset index against `genotypes.shape[:2]`. `from_path` already
+computed both from the range cache and threw them away. They are now fields.
+
+**`n_variants` stays, and stays zero.** It is on the role rather than the SVAR1
+side because `_impl.py` reads `.n_variants.shape[-1]` for ploidy on any `Haps`.
+`Svar2Haps.__post_init__` now sets it explicitly to a documented
+`zeros((R, S, P))` rather than inheriting zeros as a side effect of an empty
+placeholder — same value, but no longer an accident. #363 tracks making it
+correct.
 
 ## Non-goals
 

--- a/python/genvarloader/_dataset/_flat_variants.py
+++ b/python/genvarloader/_dataset/_flat_variants.py
@@ -33,7 +33,7 @@ from ..genvarloader import rc_alleles as _rc_alleles_rust_kernel
 from ._genotypes import _as_starts_stops
 
 if TYPE_CHECKING:
-    from ._haps import Haps
+    from ._haps import Svar1Haps
 
 
 @dataclass(frozen=True)
@@ -867,9 +867,9 @@ def _rc_alleles_rust(byte_data, seq_offsets, var_offsets, to_rc_row):
 
 
 def get_variants_flat(
-    haps: "Haps", idx: NDArray[np.integer], regions=None
+    haps: "Svar1Haps", idx: NDArray[np.integer], regions=None
 ) -> "_FlatVariants | _FlatVariantWindows":
-    """Flat-buffer analog of :meth:`Haps._get_variants`: builds a :class:`_FlatVariants` on the pure-numpy hot path.
+    """Flat-buffer analog of :meth:`Svar1Haps._get_variants`: builds a :class:`_FlatVariants` on the pure-numpy hot path.
 
     Re-wrapping the result via :meth:`_FlatVariants.to_ragged` is byte-identical
     to the :class:`RaggedVariants` produced by ``_get_variants``.

--- a/python/genvarloader/_dataset/_haps.py
+++ b/python/genvarloader/_dataset/_haps.py
@@ -1,18 +1,23 @@
-"""Haplotype reconstructor + supporting value objects.
+"""Haplotype reconstructor role + the SVAR1 implementation of it.
 
 Houses:
 
-- :class:`_Variants` — internal variant-storage struct.
+- :class:`Haps` — the haplotype-reconstructor *role*: what every backend must
+  answer, and nothing about how any of them stores genotypes.
+- :class:`Svar1Haps` — the SVAR1 implementation: reconstructs haplotype bytes
+  (and optionally per-nucleotide annotations or :class:`RaggedVariants`) from
+  sparse per-region genotypes plus an in-memory variant table. The read-bound
+  sibling is :class:`Svar2Haps` in ``_svar2_haps.py``.
+- :class:`_Variants` — internal variant-storage struct, SVAR1-only.
 - :class:`ReconstructionRequest` — per-batch prep state passed to the kernel-
-  facing reconstruction methods on :class:`Haps`.
-- :class:`Haps` — reconstructs haplotype bytes (and optionally per-nucleotide
-  annotations or :class:`RaggedVariants`) from sparse genotypes.
+  facing reconstruction methods on :class:`Svar1Haps`.
 """
 
 from __future__ import annotations
 
 import json
 import warnings
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeVar, cast
@@ -66,14 +71,14 @@ class ReconstructionRequest:
     Describes *what* to reconstruct: which variants apply for each
     ``(region, sample, ploid)`` triple, what shifts to apply, where to write,
     and (optionally) how to splice the output. Produced by
-    :meth:`Haps._prepare_request`; consumed by
-    :meth:`Haps._reconstruct_haplotypes` and
-    :meth:`Haps._reconstruct_annotated_haplotypes`.
+    :meth:`Svar1Haps._prepare_request`; consumed by
+    :meth:`Svar1Haps._reconstruct_haplotypes` and
+    :meth:`Svar1Haps._reconstruct_annotated_haplotypes`.
 
     Decoupled from region-major iteration: a caller (e.g. a future
     variant-major reconstructor) can build a :class:`ReconstructionRequest`
     directly and invoke the kernel-facing methods without going through
-    :meth:`Haps.get_haps_and_shifts`.
+    :meth:`Svar1Haps.get_haps_and_shifts`.
     """
 
     geno_offset_idx: NDArray[np.intp]
@@ -239,7 +244,7 @@ class _HapsFfiStatic:
     """FFI-ready, contiguous, correctly-typed sub-linear arrays consumed by the fused kernels.
 
     Grows only with the variant/reference count (sub-linear in
-    samples), so it is cached for the lifetime of the Haps reconstructor.
+    samples), so it is cached for the lifetime of the Svar1Haps reconstructor.
     """
 
     v_starts: NDArray[np.int32]
@@ -250,32 +255,49 @@ class _HapsFfiStatic:
     ref_offsets: "NDArray[np.int64] | None"
 
 
-@dataclass(slots=True)
-class Haps(Reconstructor[_H]):
+@dataclass(kw_only=True, slots=True)
+class Haps(Reconstructor[_H], ABC):
+    """The haplotype-reconstructor *role*: what every backend must answer.
+
+    Holds only what is true of any haplotype reconstructor -- where the dataset
+    lives, what it is being asked to produce, and which settings shape the
+    output. How the genotypes are stored, and how a haplotype is decoded from
+    them, belongs to the implementations: :class:`Svar1Haps` reads a sparse
+    per-region genotype array plus an in-memory variant table, while
+    :class:`Svar2Haps` decodes read-bound from a ``.svar2`` store and has
+    neither.
+
+    Splitting the two is what keeps a caller from reading storage internals off
+    whatever reconstructor it was handed and silently getting the wrong answer
+    on the other backend (see
+    docs/superpowers/specs/2026-09-08-haps-role-split-design.md). Everything a
+    caller outside this module needs is declared abstract below; anything it
+    cannot get from this class it is not entitled to.
+
+    Fields are keyword-only so implementations can add required fields of their
+    own without having to give them defaults just to follow the role's
+    defaulted ones.
+    """
+
     path: Path
     """The path to the GVL dataset."""
     reference: Reference | None
     """The reference genome. This is kept in memory."""
-    variants: _Variants
-    """The variant sites in the dataset. This is kept in memory."""
-    genotypes: Ragged[V_IDX_TYPE]
-    """Shape: (regions, samples, ploidy). The genotypes in the dataset. This is memory mapped."""
-    dosages: Ragged[DOSAGE_TYPE] | None
     kind: type[_H]
+    """What to reconstruct: sequences, annotated haplotypes, or variants."""
     filter: Literal["exonic"] | None
-    n_variants: NDArray[np.int32] = field(init=False)
-    """Shape: (regions, samples, ploidy). The number of variants in the dataset."""
+    """Restrict applied variants to those overlapping the query's exons."""
     min_af: float | None
     """The minimum allele frequency to keep."""
     max_af: float | None
     """The maximum allele frequency to keep."""
-    var_fields: list[str] = field(default_factory=lambda: ["alt", "ilen", "start"])
-    var_field_data: dict[str, Ragged] = field(default_factory=dict)
-    """Custom per-call (Number=G) FORMAT fields requested via ``var_fields``,
-    memmapped on the genotype offsets. Parallel to ``dosages``. See issue #231."""
-    dummy_variant: "DummyVariant | None" = None
+    n_variants: NDArray[np.int32] = field(init=False)
+    """Shape: (regions, samples, ploidy). The number of variants in the dataset."""
     available_var_fields: list[str] = field(init=False)
-    _ffi_static: "_HapsFfiStatic | None" = field(default=None, init=False)
+    """Every variant field this dataset could serve, whether or not it is loaded."""
+    var_fields: list[str] = field(default_factory=lambda: ["alt", "ilen", "start"])
+    """The variant fields to emit for ``kind=RaggedVariants``."""
+    dummy_variant: "DummyVariant | None" = None
     flank_length: int | None = None
     """Number of reference flank bases on each side for flank/window tokenization. ``0``/``None`` disables."""
     token_lut: NDArray | None = None
@@ -297,6 +319,259 @@ class Haps(Reconstructor[_H]):
     (union of called ALTs per region/sample) for variant/variant-windows output. Phase is
     discarded; suited to unphased somatic calls. Set via ``with_settings(unphased_union=True)``.
     See issue #222."""
+
+    # ---- backend-agnostic query surface ----
+    #
+    # These describe the dataset, not the storage layout, so every caller in
+    # ``_impl.py`` / ``_reconstruct.py`` can ask a ``Haps`` about it without
+    # reaching into one backend's fields. Each member exists because some
+    # caller was already doing exactly that.
+
+    @property
+    @abstractmethod
+    def stored_ploidy(self) -> int:
+        """Ploidy as laid out on disk, ignoring any ``unphased_union`` folding.
+
+        Distinct from :attr:`Dataset.ploidy`, which reports ``1`` under
+        ``unphased_union``. Grouping that is keyed on the stored layout must use
+        this.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def has_ref_alleles(self) -> bool:
+        """Whether REF allele bytes are available (needed by ``ref='allele'``)."""
+        ...
+
+    @property
+    @abstractmethod
+    def has_dosages(self) -> bool:
+        """Whether per-call dosages can be emitted for ``var_fields=['dosage']``."""
+        ...
+
+    @abstractmethod
+    def var_field_dtype(self, field: str) -> np.dtype:
+        """The numpy dtype of per-variant *scalar* field ``field``.
+
+        Args:
+            field: A scalar variant field: ``"start"``, ``"ilen"``, ``"dosage"``,
+                or the name of a numeric INFO / per-call FORMAT field.
+
+        Returns:
+            The field's numpy dtype.
+
+        Raises:
+            KeyError: If ``field`` is unknown, or is one of the variable-length
+                allele fields ``"alt"``/``"ref"``, which have no scalar dtype --
+                callers size those from their actual byte payload instead.
+        """
+        ...
+
+    @abstractmethod
+    def measure_variant_payload(
+        self, idx: NDArray[np.integer], regions: NDArray[np.integer]
+    ) -> tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.int64]]:
+        """Per-instance variant count, ref-window span, and ALT-allele byte sum.
+
+        The single counting entry point behind
+        ``Dataset._output_bytes_per_instance``'s ``"variants"`` and
+        ``"variant-windows"`` branches, so those branches never have to know
+        which backend they are sizing.
+
+        Args:
+            idx: Flat ``(region, sample)`` query indices for the block.
+            regions: ``(len(idx), 3)`` array of ``(contig_id, start, end)``.
+
+        Returns:
+            ``(n_vars_total, ref_span_sum, alt_bytes_sum)``, each shape
+            ``(len(idx),)`` int64 and summed over ploidy.
+        """
+        ...
+
+    @abstractmethod
+    def ref_allele_bytes(
+        self, idx: NDArray[np.integer], regions: NDArray[np.integer]
+    ) -> NDArray[np.int64]:
+        """Per-instance sum of bare REF allele byte lengths.
+
+        Distinct from :meth:`measure_variant_payload`'s ``ref_span_sum``, which
+        measures the ``ref="window"`` reference-genome span. Only callable when
+        :attr:`has_ref_alleles` is true; callers must gate on it.
+
+        Args:
+            idx: Flat ``(region, sample)`` query indices for the block.
+            regions: ``(len(idx), 3)`` array of ``(contig_id, start, end)``.
+
+        Returns:
+            Shape ``(len(idx),)`` int64, summed over ploidy.
+        """
+        ...
+
+    @abstractmethod
+    def prepare_var_fields(self, var_fields: list[str]) -> "Haps[_H]":
+        """Record ``var_fields``, loading whatever storage they need.
+
+        Callers validate membership in ``available_var_fields`` first.
+
+        Args:
+            var_fields: The variant fields the dataset should emit.
+
+        Returns:
+            A new reconstructor with ``var_fields`` set and its backing storage
+            loaded.
+        """
+        ...
+
+    @abstractmethod
+    def _haplotype_ilens(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.integer],
+        deterministic: bool,
+        keep: NDArray[np.bool_] | None = None,
+        keep_offsets: NDArray[np.integer] | None = None,
+    ) -> NDArray[np.int32]:
+        """``(B, P)`` per-haplotype length deltas vs the reference. ``idx`` must be 1D."""
+        ...
+
+    @abstractmethod
+    def haplotype_lengths_for_plan(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.int32],
+    ) -> NDArray[np.int32]:
+        """``(B, P)`` per-query haplotype lengths, without running the full reconstruction.
+
+        Used by the spliced path to size buffers and build a ``SplicePlan``
+        before the kernel is invoked.
+        """
+        ...
+
+    @abstractmethod
+    def get_haps_and_shifts(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.integer],
+        output_length: Literal["ragged", "variable"] | int,
+        rng: np.random.Generator,
+        deterministic: bool,
+        splice_plan: SplicePlan | None = None,
+        to_rc: "NDArray[np.bool_] | None" = None,
+    ) -> tuple[
+        _H,
+        NDArray[np.intp],
+        NDArray[np.int32],
+        NDArray[np.int32],
+        NDArray[np.int32],
+        NDArray[np.bool_] | None,
+        NDArray[np.int64] | None,
+    ]:
+        """Reconstruct the batch and return it with the per-batch state tracks need.
+
+        Returns:
+            ``(out, geno_offset_idx, shifts, diffs, hap_lengths, keep,
+            keep_offsets)``.
+        """
+        ...
+
+    # ---- haplotype-realigned tracks ----
+    #
+    # ``HapsTracks.__call__`` runs one body for every backend and reaches the
+    # backend only through these two members.
+
+    def check_track_realign_support(
+        self,
+        output_length: Literal["ragged", "variable"] | int,
+        splice_plan: SplicePlan | None,
+        to_rc: NDArray[np.bool_] | None,
+        ragged_tracks: bool,
+    ) -> None:
+        """Reject request shapes this backend cannot realign tracks for.
+
+        The base implementation rejects only what no backend can serve;
+        override to add further limits.
+
+        Args:
+            output_length: The requested output length.
+            splice_plan: The requested splice plan, if any.
+            to_rc: Per-query reverse-complement mask, if any.
+            ragged_tracks: Whether the tracks are being realigned at all
+                (False means the caller returns stored intervals untouched, so
+                realign-only limits do not apply).
+
+        Raises:
+            NotImplementedError: If this backend cannot serve the request.
+        """
+        del output_length, to_rc, ragged_tracks
+        if splice_plan is not None:
+            raise NotImplementedError(
+                "Splicing of haplotypes + tracks (shape (b, t, p, ~l)) is not "
+                "supported."
+            )
+
+    @abstractmethod
+    def track_realigner(
+        self,
+        idx: NDArray[np.integer],
+        regions: NDArray[np.int32],
+        shifts: NDArray[np.int32],
+        geno_idx: NDArray[np.integer],
+        track_lengths: NDArray[np.integer],
+        out_offsets: NDArray[np.integer],
+        keep: NDArray[np.bool_] | None,
+        keep_offsets: NDArray[np.integer] | None,
+        to_rc: NDArray[np.bool_] | None,
+        base_seed: int,
+    ) -> TrackRealigner:
+        """Prepare the per-batch state for filling realigned track blocks.
+
+        Args:
+            idx: Flat ``(region, sample)`` dataset indices for the batch.
+            regions: ``(b, 3)`` contig/start/end of each query.
+            shifts: ``(b, p)`` per-haplotype jitter shifts.
+            geno_idx: ``(b, p)`` indices into the sparse genotype offsets.
+            track_lengths: ``(b,)`` reference span each track block is read over.
+            out_offsets: ``(b*p+1,)`` per-haplotype offsets into one track's block.
+            keep: Optional per-variant keep mask (``filter='exonic'``).
+            keep_offsets: Offsets into ``keep``.
+            to_rc: Per-query reverse-complement mask, if any.
+            base_seed: Seed for seed-dependent insertion fills.
+
+        Returns:
+            A realigner whose ``fill`` writes one track at a time.
+        """
+        ...
+
+    def to_kind(self, kind: type[_NewH]) -> Haps[_NewH]:
+        """A copy of this reconstructor producing ``kind`` instead."""
+        if kind != RaggedVariants and self.reference is None:
+            raise ValueError(
+                f"Cannot return {kind.__name__}: no reference genome was provided."
+            )
+        return cast(Haps[_NewH], replace(self, kind=kind))
+
+
+@dataclass(kw_only=True, slots=True)
+class Svar1Haps(Haps[_H]):
+    """The SVAR1 haplotype reconstructor: sparse per-region genotypes + a variant table.
+
+    Genotypes are stored once per ``(region, sample, ploid)`` as a ragged array
+    of variant indices into an in-memory :class:`_Variants` table, so every
+    query is a gather over arrays that are already grouped the way the query
+    asks for them. :class:`Svar2Haps` is the read-bound sibling; the role they
+    share is :class:`Haps`.
+    """
+
+    variants: _Variants
+    """The variant sites in the dataset. This is kept in memory."""
+    genotypes: Ragged[V_IDX_TYPE]
+    """Shape: (regions, samples, ploidy). The genotypes in the dataset. This is memory mapped."""
+    dosages: Ragged[DOSAGE_TYPE] | None
+    var_field_data: dict[str, Ragged] = field(default_factory=dict)
+    """Custom per-call (Number=G) FORMAT fields requested via ``var_fields``,
+    memmapped on the genotype offsets. Parallel to ``dosages``. See issue #231."""
+    _ffi_static: "_HapsFfiStatic | None" = field(default=None, init=False)
 
     def __post_init__(self):
         self.n_variants = self.genotypes.lengths
@@ -330,13 +605,7 @@ class Haps(Reconstructor[_H]):
                 + "Doing this automatically is not yet supported."
             )
 
-    # ---- backend-agnostic query surface ----
-    #
-    # These describe the dataset, not the storage layout, so every caller in
-    # ``_impl.py`` / ``_reconstruct.py`` can ask a ``Haps`` about it without
-    # reaching into SVAR1-specific fields (``genotypes``, ``variants``). Each
-    # member exists because some caller was already doing exactly that. See
-    # docs/superpowers/specs/2026-09-08-haps-role-split-design.md.
+    # ---- backend-agnostic query surface (see Haps) ----
 
     @property
     def stored_ploidy(self) -> int:
@@ -434,7 +703,7 @@ class Haps(Reconstructor[_H]):
 
     @classmethod
     def from_path(
-        cls: type[Haps[RaggedVariants]],
+        cls: type[Svar1Haps[RaggedVariants]],
         path: Path,
         reference: Reference | None,
         regions: NDArray[np.int32],
@@ -447,7 +716,7 @@ class Haps(Reconstructor[_H]):
         max_af: float | None = None,
         filter: Literal["exonic"] | None = None,
         var_fields: list[str] | None = None,
-    ) -> Haps[RaggedVariants]:
+    ) -> Svar1Haps[RaggedVariants]:
         # Default var_fields for loading. var_fields=None means "use the default
         # set" — we resolve it here so we know exactly which info columns to load.
         if var_fields is None:
@@ -637,13 +906,6 @@ class Haps(Reconstructor[_H]):
         )
         hap_lengths = lengths[:, None] + diffs
         return hap_lengths.astype(np.int32, copy=False)
-
-    def to_kind(self, kind: type[_NewH]) -> Haps[_NewH]:
-        if kind != RaggedVariants and self.reference is None:
-            raise ValueError(
-                f"Cannot return {kind.__name__}: no reference genome was provided."
-            )
-        return cast(Haps[_NewH], replace(self, kind=kind))
 
     def __call__(
         self,
@@ -986,7 +1248,7 @@ class Haps(Reconstructor[_H]):
             self._allele_bytes_sum(idx, "ref").reshape(-1, self.stored_ploidy).sum(-1)
         )
 
-    def prepare_var_fields(self, var_fields: list[str]) -> "Haps[_H]":
+    def prepare_var_fields(self, var_fields: list[str]) -> "Svar1Haps[_H]":
         """Record ``var_fields``, loading whatever storage they need.
 
         SVAR1 keeps its INFO columns, dosages and custom FORMAT fields in
@@ -1029,37 +1291,6 @@ class Haps(Reconstructor[_H]):
         return replace(haps, var_fields=var_fields)
 
     # ---- haplotype-realigned tracks ----
-    #
-    # ``HapsTracks.__call__`` runs one body for every backend and reaches the
-    # backend only through these two members. See
-    # docs/superpowers/specs/2026-09-08-haps-role-split-design.md.
-
-    def check_track_realign_support(
-        self,
-        output_length: Literal["ragged", "variable"] | int,
-        splice_plan: SplicePlan | None,
-        to_rc: NDArray[np.bool_] | None,
-        ragged_tracks: bool,
-    ) -> None:
-        """Reject request shapes this backend cannot realign tracks for.
-
-        Args:
-            output_length: The requested output length.
-            splice_plan: The requested splice plan, if any.
-            to_rc: Per-query reverse-complement mask, if any.
-            ragged_tracks: Whether the tracks are being realigned at all
-                (False means the caller returns stored intervals untouched, so
-                realign-only limits do not apply).
-
-        Raises:
-            NotImplementedError: If this backend cannot serve the request.
-        """
-        del output_length, to_rc, ragged_tracks
-        if splice_plan is not None:
-            raise NotImplementedError(
-                "Splicing of haplotypes + tracks (shape (b, t, p, ~l)) is not "
-                "supported."
-            )
 
     def track_realigner(
         self,
@@ -1431,7 +1662,7 @@ class _Svar1TrackRealigner:
     track instead of once per batch was measurably wasteful.
     """
 
-    haps: "Haps"
+    haps: "Svar1Haps"
     regions: NDArray[np.int32]
     shifts: NDArray[np.int32]
     geno_offset_idx: NDArray[np.int64]
@@ -1485,11 +1716,11 @@ class _Svar1TrackRealigner:
         )
 
 
-def _lazy_load_dosages(haps: Haps) -> Haps:
-    """Open the dosages memmap for a Haps that didn't request them at open time.
+def _lazy_load_dosages(haps: Svar1Haps) -> Svar1Haps:
+    """Open the dosages memmap for a Svar1Haps that didn't request them at open time.
 
-    Reuses the same path-resolution logic that ``Haps.from_path`` used. Returns
-    a new ``Haps`` with ``dosages`` populated (does NOT mutate the input).
+    Reuses the same path-resolution logic that ``Svar1Haps.from_path`` used. Returns
+    a new ``Svar1Haps`` with ``dosages`` populated (does NOT mutate the input).
     """
     import json as _json
 
@@ -1512,7 +1743,7 @@ def _lazy_load_dosages(haps: Haps) -> Haps:
 
     offset_path = path / "genotypes" / "offsets.npy"
 
-    # Resolve the SVAR directory the same way Haps.from_path did. Dataset does
+    # Resolve the SVAR directory the same way Svar1Haps.from_path did. Dataset does
     # not retain Metadata, so re-read metadata.json from disk.
     meta = Metadata.model_validate_json((path / "metadata.json").read_text())
     svar_link = meta.svar_link
@@ -1537,13 +1768,13 @@ def _lazy_load_dosages(haps: Haps) -> Haps:
 
 
 def _lazy_load_custom_fields(
-    haps: Haps,
+    haps: Svar1Haps,
     new_fields: dict[str, np.dtype],
-) -> Haps:
+) -> Svar1Haps:
     """Memmap custom FORMAT fields (Number=G, stored as <name>.npy) into ``haps.var_field_data`` for fields that were not loaded at open time.
 
     ``new_fields`` maps field name → numpy dtype (already confirmed present in
-    the SVAR metadata). Returns a new ``Haps`` with updated ``var_field_data``.
+    the SVAR metadata). Returns a new ``Svar1Haps`` with updated ``var_field_data``.
     """
     import json as _json
 
@@ -1562,7 +1793,7 @@ def _lazy_load_custom_fields(
     offset_path = path / "genotypes" / "offsets.npy"
 
     # The resolved SVAR directory is already embedded in haps.variants.path
-    # (which was set to <svar_path>/index.arrow by Haps.from_path, respecting any
+    # (which was set to <svar_path>/index.arrow by Svar1Haps.from_path, respecting any
     # svar_override). Using .parent avoids re-resolving from metadata and correctly
     # handles the svar_override case that the legacy link.svar branch would miss.
     svar_path = haps.variants.path.parent

--- a/python/genvarloader/_dataset/_open.py
+++ b/python/genvarloader/_dataset/_open.py
@@ -20,7 +20,7 @@ from loguru import logger
 from numpy.typing import NDArray
 
 from ._indexing import DatasetIndexer
-from ._reconstruct import Haps, Ref, Tracks, _build_reconstructor
+from ._reconstruct import Haps, Ref, Svar1Haps, Tracks, _build_reconstructor
 from ._reference import Reference
 from ._utils import bed_to_regions
 from ._validate import validate_dataset
@@ -204,7 +204,7 @@ class OpenRequest:
                     var_fields=self.var_fields,
                 )
             else:
-                seqs = Haps.from_path(
+                seqs = Svar1Haps.from_path(
                     path=self.path,
                     reference=reference,
                     regions=regions,

--- a/python/genvarloader/_dataset/_reconstruct.py
+++ b/python/genvarloader/_dataset/_reconstruct.py
@@ -4,10 +4,10 @@ Houses the *compound* reconstructors (:class:`SeqsTracks`, :class:`HapsTracks`)
 that combine a sequence source with tracks, plus the
 :func:`_build_reconstructor` factory.
 
-Re-exports the leaf reconstructors (:class:`Ref`, :class:`Haps`,
-:class:`Tracks`) and supporting types (``Reconstructor``,
-``ReconstructionRequest``, ``_Variants``, ``TrackType``) from their split
-modules for backward-compatible import paths.
+Re-exports the leaf reconstructors (:class:`Ref`, the :class:`Haps` role and
+its :class:`Svar1Haps` implementation, :class:`Tracks`) and supporting types
+(``Reconstructor``, ``ReconstructionRequest``, ``_Variants``, ``TrackType``)
+from their split modules for backward-compatible import paths.
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ from typing_extensions import assert_never
 from .._flat import _Flat
 from .._ragged import RaggedAnnotatedHaps, RaggedIntervals, RaggedSeqs, RaggedTracks
 from .._utils import lengths_to_offsets
-from ._haps import _H, Haps, ReconstructionRequest, _NewH, _Variants
+from ._haps import _H, Haps, ReconstructionRequest, Svar1Haps, _NewH, _Variants
 from ._insertion_fill import Repeat5p
 from ._insertion_fill import lower as _lower_insertion_fills
 from ._flat_variants import _FlatVariantWindows
@@ -43,6 +43,7 @@ from ._tracks import (
 # ``_reconstruct``):
 __all__ = [
     "Haps",
+    "Svar1Haps",
     "HapsTracks",
     "ReconstructionRequest",
     "Reconstructor",

--- a/python/genvarloader/_dataset/_svar2_haps.py
+++ b/python/genvarloader/_dataset/_svar2_haps.py
@@ -1,9 +1,10 @@
 """SVAR2-backed haplotype/variant reconstructor (dataset read dispatch).
 
-``Svar2Haps`` is a *separate* reconstructor from the SVAR1 :class:`Haps` — the
-SVAR1 path is left byte-unchanged. It subclasses :class:`Haps` only so the many
-``isinstance(_, Haps)`` / ``case Haps()`` checks throughout the dataset
-machinery keep working; every read method is overridden.
+``Svar2Haps`` is the read-bound sibling of :class:`Svar1Haps`; the two share
+only the :class:`Haps` role (see ``_haps.py``), which declares what a
+haplotype reconstructor must answer and says nothing about how genotypes are
+stored. There is no per-region sparse genotype array and no in-memory variant
+table here -- everything is decoded from the ``.svar2`` store at read time.
 
 For a query block of ``n_q`` rows, each row ``q = (region r_q, sample slot si_q)``
 with post-jitter bounds ``[start_q, end_q)``, the cache (written by
@@ -32,7 +33,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
 import numpy as np
 from genoray._contigs import ContigNormalizer
-from genoray._types import POS_TYPE, V_IDX_TYPE
+from genoray._types import POS_TYPE
 from numpy.typing import NDArray
 from seqpro.rag import Ragged
 
@@ -40,7 +41,6 @@ from .._flat import _Flat
 from .._ragged import RaggedAnnotatedHaps, RaggedIntervals, _COMP
 from .._threads import should_parallelize
 from .._utils import lengths_to_offsets
-from .._variants._records import RaggedAlleles
 from ..genvarloader import (
     Svar2Store,
     decode_variants_from_svar2_readbound,
@@ -57,7 +57,7 @@ from ._flat_variants import (
     _assemble_variant_buffers_rust,
 )
 from ._intervals import intervals_to_tracks
-from ._haps import _H, Haps, _Variants
+from ._haps import _H, Haps
 from ._protocol import TrackRealigner
 from ._rag_variants import RaggedVariants
 from ._reference import Reference
@@ -208,35 +208,43 @@ def _ragged_arange_gather_2level(
     return data[src], new_var_off, new_str_off
 
 
-@dataclass(slots=True)
+@dataclass(kw_only=True, slots=True)
 class Svar2Haps(Haps[_H]):
     """Read-bound SVAR2 reconstructor. See module docstring."""
 
-    # New fields must default (they follow base Haps' defaulted fields).
-    store: "Svar2Store | None" = None
-    cache: "_Svar2Cache | None" = None
-    store_contigs: list[str] = field(default_factory=list)
+    store: "Svar2Store"
+    """The query-only handle on the ``.svar2`` store."""
+    cache: "_Svar2Cache"
+    """The per-query variant ranges written at ``genotypes/svar2_ranges/``."""
+    store_contigs: list[str]
     """The .svar2 store's contig names (used to open the store's ContigReaders)."""
-    ds_contigs: list[str] = field(default_factory=list)
+    ds_contigs: list[str]
     """The dataset's contig names (``regions[:, 0]`` indexes into this)."""
-    ploidy: int = 2
+    n_regions: int
+    """The dataset's region count, from the range cache's ``dense_snp_range`` shape."""
+    n_samples: int
+    """The dataset's sample count, from the range cache's ``vk_snp_range`` shape.
+
+    Together with :attr:`n_regions` this is the ``(R, S)`` grid a flat dataset
+    index unravels into. SVAR1 reads the same two numbers off its ``genotypes``
+    array's leading shape; there is no such array here.
+    """
+    ploidy: int
     """The store's ploidy, from the svar2 range cache's ``svar2_meta.json``.
 
-    Backs :attr:`stored_ploidy`. Held directly rather than read off a
-    ``genotypes`` array: svar2 has no per-region sparse genotype store, so the
-    inherited ``genotypes`` field is a placeholder here (see the class docstring).
+    Backs :attr:`stored_ploidy`.
+    """
+    store_fields: dict[str, "StoredField"]
+    """The .svar2 store's INFO/FORMAT field manifest, keyed by field key.
+
+    Populated from ``SparseVar2.available_fields``. These keys are additionally
+    advertised in ``available_var_fields`` so users can request them via ``var_fields``.
     """
     max_jitter: int = 0
     """The dataset's write-time max_jitter. When > 0 the cache's per-query ranges
     were computed over a max_jitter-padded window, which over-includes variants past
     the (unpadded) read window in variants mode (the decode kernel has no right-clip);
     guarded below."""
-    store_fields: dict[str, "StoredField"] = field(default_factory=dict)
-    """The .svar2 store's INFO/FORMAT field manifest, keyed by field key.
-
-    Populated from ``SparseVar2.available_fields``. These keys are additionally
-    advertised in ``available_var_fields`` so users can request them via ``var_fields``.
-    """
     _gather_memo: (
         tuple[int, NDArray[np.intp], NDArray[np.int32], list[_GatheredGroup]] | None
     ) = field(init=False, repr=False)
@@ -258,10 +266,17 @@ class Svar2Haps(Haps[_H]):
     """
 
     def __post_init__(self):
-        # Deliberately does NOT call Haps.__post_init__ (that reads an SVAR1
-        # variants table / AF cache which svar2 has no analogue for). Set only
-        # the init=False fields the base machinery reads.
-        self.n_variants = self.genotypes.lengths
+        # Deliberately does NOT call any SVAR1 setup (there is no variants table
+        # or AF cache to read). Set only the role's init=False fields.
+        #
+        # n_variants is all zeros, and wrong: the read-bound decode never counts
+        # a query's variants without also decoding them, so there is nothing to
+        # fill this with at open time. Tracked as #363 -- Dataset.n_variants()
+        # reports zeros on SVAR2. Kept zero-valued rather than absent because the
+        # shape (R, S, P) is what callers read it for.
+        self.n_variants = np.zeros(
+            (self.n_regions, self.n_samples, self.ploidy), np.int32
+        )
         self.available_var_fields = ["alt", "ilen", "start"] + [
             k for k in self.store_fields if k not in _BUILTIN_VAR_FIELDS
         ]
@@ -358,9 +373,9 @@ class Svar2Haps(Haps[_H]):
     def var_field_dtype(self, field: str) -> np.dtype:
         """The dtype of a scalar variant field, from the store manifest.
 
-        The base implementation reads ``self.variants``, which is a placeholder
-        here; the .svar2 store's INFO/FORMAT dtypes live in ``store_fields``, and
-        ``start``/``ilen`` are fixed by the read-bound decode kernel's output.
+        There is no in-memory variant table here: the .svar2 store's INFO/FORMAT
+        dtypes live in ``store_fields``, and ``start``/``ilen`` are fixed by the
+        read-bound decode kernel's output.
         """
         if field in ("alt", "ref"):
             raise KeyError(
@@ -440,32 +455,9 @@ class Svar2Haps(Haps[_H]):
         if missing := [f for f in var_fields if f not in allowed]:
             raise ValueError(f"Missing variant fields: {missing}")
 
-        # Minimal base-Haps fields. genotypes carries only the (R, S, P, None)
-        # shape (so ploidy = shape[-2] and n_variants.shape are available); its
-        # data is empty (svar2 has no per-region sparse genotype store).
-        empty_geno = Ragged.from_offsets(
-            np.empty(0, V_IDX_TYPE),
-            (R, S, P, None),
-            np.zeros(R * S * P + 1, np.int64),
-        )
-        empty_alt = RaggedAlleles.from_offsets(
-            np.empty(0, np.uint8).view("S1"), (0, None), np.zeros(1, np.int64)
-        )
-        dummy_variants = _Variants(
-            path=svar2_path,
-            start=np.empty(0, POS_TYPE),
-            ilen=np.empty(0, np.int32),
-            ref=None,
-            alt=empty_alt,
-            info={},
-        )
-
         return cls(
             path=path,
             reference=reference,
-            variants=dummy_variants,
-            genotypes=empty_geno,
-            dosages=None,
             kind=cast("type[_H]", kind),
             filter=None,
             min_af=min_af,
@@ -474,6 +466,8 @@ class Svar2Haps(Haps[_H]):
             cache=cache,
             store_contigs=list(sv.contigs),
             ds_contigs=list(contigs),
+            n_regions=R,
+            n_samples=S,
             ploidy=P,
             max_jitter=max_jitter,
             store_fields=store_fields,
@@ -582,7 +576,6 @@ class Svar2Haps(Haps[_H]):
         Callers reach this only via ``_getitem_spliced``, which asserts ``jitter == 0``
         and ``deterministic`` — hence zero shifts.
         """
-        assert self.store is not None
         regions = np.asarray(regions, np.int32)
         P = self.stored_ploidy
         b = len(idx)
@@ -695,13 +688,13 @@ class Svar2Haps(Haps[_H]):
     ) -> NDArray[np.int32]:
         """SVAR2 per-haplotype length deltas. Backs ``Dataset.haplotype_lengths``.
 
-        Must be overridden: the base :class:`Haps` implementation reads
-        ``self.genotypes``/``self.variants``, which are permanently-empty
-        SVAR1-shaped placeholders for this reconstructor, so inheriting it
-        silently yields all-zero deltas -- i.e. ``haplotype_lengths()`` reporting
-        the unadjusted reference span, and ``_output_bytes_per_instance``
-        under-sizing the ``"haplotypes"``/``"annotated"`` slots (the sibling of
-        the ``"variants"``/``"variant-windows"`` defect in #315).
+        The deltas come from the read-bound kernel, not from a stored genotype
+        array. Before the role split, ``Svar2Haps`` inherited the SVAR1 body and
+        it read empty placeholders, silently yielding all-zero deltas -- i.e.
+        ``haplotype_lengths()`` reporting the unadjusted reference span, and
+        ``_output_bytes_per_instance`` under-sizing the
+        ``"haplotypes"``/``"annotated"`` slots (the sibling of the
+        ``"variants"``/``"variant-windows"`` defect in #315). Fixed in #364.
 
         ``keep``/``keep_offsets`` carry the SVAR1 exonic *pre*-filter's output.
         The read-bound kernel applies the exonic filter itself (it is handed
@@ -911,7 +904,6 @@ class Svar2Haps(Haps[_H]):
                 "SVAR2 exonic filtering with haplotype-realigned tracks is not "
                 "supported yet."
             )
-        assert self.store is not None
         regions = np.asarray(regions, np.int32)
         P = self.stored_ploidy
         b = len(idx)
@@ -1033,9 +1025,7 @@ class Svar2Haps(Haps[_H]):
         that :meth:`_reconstruct_variants`/:meth:`_reconstruct_variant_windows` use, so
         callers that only need cheap per-instance *measures* -- not the full
         reconstructed output -- can share this single counting entry point instead of
-        re-deriving the ``p_eff``/fold logic (or, worse, reading
-        ``self.genotypes``/``self.variants``, which are permanently-empty SVAR1-shaped
-        placeholders for this reconstructor -- see issue #315). Used by
+        re-deriving the ``p_eff``/fold logic. Used by
         ``Dataset._output_bytes_per_instance`` for the ``"variants"``/``"variant-windows"``
         estimate branches.
 
@@ -1501,7 +1491,7 @@ class Svar2Haps(Haps[_H]):
         ):
             return memo[3]
 
-        R_all, S_all = int(self.genotypes.shape[0]), int(self.genotypes.shape[1])
+        R_all, S_all = self.n_regions, self.n_samples
         r_q, si_q = np.unravel_index(idx, (R_all, S_all))
         groups: list[_GatheredGroup] = [
             (ci, qsel, self._gather_inputs(r_q[qsel], si_q[qsel], regions[qsel], P))
@@ -1566,7 +1556,6 @@ class Svar2Haps(Haps[_H]):
         vk_* rows come out ``(n, P, 2)`` -> reshaped ``(n*P, 2)`` in row = q*P+p
         order, which is exactly what the kernel expects.
         """
-        assert self.cache is not None
         c = self.cache
         region_starts = np.ascontiguousarray(regions_grp[:, 1], np.uint32)
         orig_samples = np.ascontiguousarray(c.sample_cols[si_q], np.int64)

--- a/python/genvarloader/_dummy.py
+++ b/python/genvarloader/_dummy.py
@@ -11,7 +11,7 @@ from natsort import natsorted
 from ._dataset._impl import RaggedDataset
 from ._dataset._indexing import DatasetIndexer, SpliceIndexer
 from ._dataset._intervals import tracks_to_intervals
-from ._dataset._reconstruct import Haps, HapsTracks, Tracks, TrackType, _Variants
+from ._dataset._reconstruct import HapsTracks, Svar1Haps, Tracks, TrackType, _Variants
 from ._dataset._reference import Reference
 from ._dataset._splice import SpliceMap
 from ._dataset._utils import bed_to_regions
@@ -110,7 +110,7 @@ def get_dummy_dataset(spliced: bool = False):
         offsets=np.arange(0, 4 * 4 + 1, dtype=np.int64),  # every entry has 1 variant
     )
 
-    dummy_haps = Haps(
+    dummy_haps = Svar1Haps(
         path=Path("dummy"),
         reference=dummy_ref,
         variants=dummy_vars,

--- a/tests/dataset/test_svar2_dataset.py
+++ b/tests/dataset/test_svar2_dataset.py
@@ -1044,7 +1044,7 @@ def test_svar2_variant_windows_unphased_union(
         :, :
     ]
     nd = np.asarray(w2_diploid.ref_window.var_offsets)
-    P = int(ds2._seqs.genotypes.shape[-2])
+    P = int(ds2._seqs.stored_ploidy)
     # Folded per-row counts == sum of the P per-hap counts (rows q*P+p are contiguous).
     diploid_counts = np.diff(nd).reshape(-1, P).sum(1)
     union_counts = np.diff(nu)

--- a/tests/dataset/test_svar2_fields_read.py
+++ b/tests/dataset/test_svar2_fields_read.py
@@ -648,8 +648,8 @@ def test_svar2_output_bytes_per_instance_with_store_field(
     sizing path, ``_torch.py``'s ``_resolve_buffered_inputs`` ->
     ``get_dataloader(mode=...)``) must not crash when an INFO/FORMAT store
     field is requested. Before the fix, its ``else`` branch always did
-    ``haps_obj.variants.info[f].dtype`` -- but ``Svar2Haps.variants`` is the
-    dummy placeholder with ``info={}``, so any store field name raised
+    ``haps_obj.variants.info[f].dtype`` -- an SVAR1-only lookup that ``Svar2Haps``
+    answered from an empty placeholder, so any store field name raised
     ``KeyError`` there, turning a previously-working path into a crash.
     """
     import genoray
@@ -683,9 +683,8 @@ def test_svar2_output_bytes_per_instance_variant_windows_with_store_field(
     for the "variant-windows" output kind.
 
     The "variants" branch's ``else`` clause (INFO/store field dtype lookup)
-    was already guarded for ``Svar2Haps`` (whose ``.variants.info`` is an
-    empty placeholder -- store field dtypes live on ``.store_fields``
-    instead). The final-review pass found that the newer "variant-windows"
+    was already guarded for ``Svar2Haps`` (which has no variant table at all --
+    store field dtypes live on ``.store_fields`` instead). The final-review pass found that the newer "variant-windows"
     branch's scalar-field loop and its ``dummy_variant`` sub-branch did the
     SAME unguarded ``haps_obj.variants.info[f].dtype`` lookup with no such
     guard, so requesting a store field (e.g. "AF"/"NS"/"DP", all legal via

--- a/tests/integration/test_haps_ffi_cache.py
+++ b/tests/integration/test_haps_ffi_cache.py
@@ -1,19 +1,19 @@
-"""Haps caches FFI-ready sub-linear arrays once (Task 5)."""
+"""Svar1Haps caches FFI-ready sub-linear arrays once (Task 5)."""
 
 from __future__ import annotations
 
 import numpy as np
 
 import genvarloader as gvl
-from genvarloader._dataset._haps import Haps
+from genvarloader._dataset._haps import Svar1Haps
 
 
-def _haps(track_dataset_path, reference) -> Haps:
+def _haps(track_dataset_path, reference) -> Svar1Haps:
     ds = gvl.Dataset.open(track_dataset_path, reference=reference).with_seqs(
         "haplotypes"
     )
     seqs = ds._seqs
-    assert isinstance(seqs, Haps)
+    assert isinstance(seqs, Svar1Haps)
     return seqs
 
 

--- a/tests/unit/dataset/test_flat_variants_type.py
+++ b/tests/unit/dataset/test_flat_variants_type.py
@@ -325,7 +325,7 @@ def test_get_variants_flat_fills_empty_groups():
 
     NOTE: snap_dataset fixture is NOT visible from tests/unit/dataset/ (it lives
     in tests/dataset/conftest.py, a sibling not a parent). Per plan fallback,
-    this test builds a minimal synthetic Haps with controlled empty groups.
+    this test builds a minimal synthetic Svar1Haps with controlled empty groups.
     Full integration coverage is deferred to Task 5.
     """
     from dataclasses import replace
@@ -335,7 +335,7 @@ def test_get_variants_flat_fills_empty_groups():
     from seqpro.rag import Ragged
 
     from genvarloader._dataset._flat_variants import DummyVariant, get_variants_flat
-    from genvarloader._dataset._haps import Haps, _Variants
+    from genvarloader._dataset._haps import Svar1Haps, _Variants
     from genvarloader._dataset._rag_variants import RaggedVariants
     from genvarloader._variants._records import RaggedAlleles
 
@@ -363,7 +363,7 @@ def test_get_variants_flat_fills_empty_groups():
     offsets = np.array([0, 1, 1, 3, 3], np.int64)
     genotypes = Ragged.from_offsets(v_idxs, (2, 2, 1, None), offsets)
 
-    haps = Haps(
+    haps = Svar1Haps(
         path=Path("dummy"),
         reference=None,
         variants=variants,

--- a/tests/unit/dataset/test_haps_role_split.py
+++ b/tests/unit/dataset/test_haps_role_split.py
@@ -1,0 +1,91 @@
+"""The ``Haps`` role holds no storage, and the two implementations stay replaceable.
+
+``Svar2Haps`` used to inherit ``Haps``' SVAR1 fields and fabricate empty values
+for them at open time. Every caller that read one off the role got a silently
+wrong answer on the SVAR2 backend rather than a type error -- #361 and #363 are
+two instances. The split moved those fields down into ``Svar1Haps``; these tests
+pin that they cannot come back, and that the settings block on the role still
+round-trips through ``dataclasses.replace`` on both sides of the hierarchy.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from abc import ABC
+
+import pytest
+
+from genvarloader._dataset._haps import Haps, Svar1Haps
+from genvarloader._dataset._svar2_haps import Svar2Haps
+
+# The SVAR1 on-disk layout. Naming them here rather than deriving them keeps the
+# test honest: adding one back to the role has to be a deliberate edit of this list.
+SVAR1_STORAGE_FIELDS = ("variants", "genotypes", "dosages", "var_field_data")
+
+
+def _field_names(cls) -> set[str]:
+    return {f.name for f in dataclasses.fields(cls)}
+
+
+def test_role_is_abstract():
+    """``Haps`` is a role, not something you can open a dataset as."""
+    assert issubclass(Haps, ABC)
+    assert inspect.isabstract(Haps)
+    with pytest.raises(TypeError):
+        Haps()  # type: ignore[abstract]
+
+
+@pytest.mark.parametrize("name", SVAR1_STORAGE_FIELDS)
+def test_role_holds_no_svar1_storage(name):
+    """Storage belongs to the implementation, so the role must not declare it."""
+    assert name not in _field_names(Haps)
+    assert name in _field_names(Svar1Haps)
+
+
+@pytest.mark.parametrize("name", SVAR1_STORAGE_FIELDS + ("_ffi_static",))
+def test_svar2_has_no_svar1_storage(name):
+    """``Svar2Haps`` must not carry an SVAR1 field, fabricated or otherwise.
+
+    ``slots=True`` makes this an attribute-level guarantee, not just a
+    dataclass-field one: there is nowhere for a placeholder to live.
+    """
+    assert name not in _field_names(Svar2Haps)
+    assert not hasattr(Svar2Haps, name)
+
+
+def test_both_implementations_satisfy_the_role():
+    """Neither implementation may be left with an unimplemented role member."""
+    for cls in (Svar1Haps, Svar2Haps):
+        assert issubclass(cls, Haps)
+        assert not inspect.isabstract(cls), (
+            f"{cls.__name__} does not implement: "
+            f"{sorted(getattr(cls, '__abstractmethods__', ()))}"
+        )
+
+
+@pytest.mark.parametrize("cls", [Svar1Haps, Svar2Haps])
+def test_settings_fields_are_replaceable(cls):
+    """``with_settings`` and friends reach both classes through the same call.
+
+    ``Dataset`` mutates the reconstructor exclusively via
+    ``dataclasses.replace``, so a settings field that stopped being an
+    ``init=True`` field on either side would break the builder chain at runtime
+    rather than at import.
+    """
+    init_fields = {f.name for f in dataclasses.fields(cls) if f.init}
+    for name in (
+        "kind",
+        "min_af",
+        "max_af",
+        "var_fields",
+        "dummy_variant",
+        "flank_length",
+        "token_lut",
+        "token_dtype",
+        "unknown_token",
+        "token_alphabet",
+        "window_opt",
+        "unphased_union",
+    ):
+        assert name in init_fields, f"{cls.__name__}.{name} is not replace()-able"

--- a/tests/unit/dataset/test_svar2_gather_memo.py
+++ b/tests/unit/dataset/test_svar2_gather_memo.py
@@ -28,7 +28,8 @@ class _CountingGather:
         self._contigs = contigs
         self.calls = 0
         self._gather_memo = None
-        self.genotypes = type("_G", (), {"shape": (n_regions, n_samples, 2)})()
+        self.n_regions = n_regions
+        self.n_samples = n_samples
 
     _gathered_groups = Svar2Haps._gathered_groups
     _contig_groups = Svar2Haps._contig_groups

--- a/tests/unit/test_slot_fit_property.py
+++ b/tests/unit/test_slot_fit_property.py
@@ -15,7 +15,10 @@ from genvarloader._slot_overhead import slot_overhead_bytes
 def _views(ds):
     DNA = sp.alphabets.DNA
     for ref, alt in [("window", "window"), ("window", "allele"), ("allele", "allele")]:
-        if ref == "allele" and getattr(ds._seqs.variants, "ref", None) is None:
+        # Ask the reconstructor, not its storage: SVAR2 has no variant table to
+        # reach into, and the whole point of the role split is that this
+        # question has one backend-agnostic answer.
+        if ref == "allele" and not ds._seqs.has_ref_alleles:
             continue
         for uu in (True, False):
             for L in (8, 128):


### PR DESCRIPTION
**Layer 5 of 5** (the top) in the `Haps` role/implementation split. Stacked on #368.

---

`Svar2Haps` inherited `Haps`, a class whose fields *are* the SVAR1 on-disk
layout: a sparse per-region `Ragged` genotype array plus an in-memory
`_Variants` table. SVAR2 has neither, so its `from_path` fabricated empty
SVAR1-shaped values for them. Anything that read one off the role got a silently
wrong answer on that backend rather than a type error — #361 and #363 are two
instances, and #315's slot-sizing defects are downstream of the same thing.

Layers 2–4 moved every such caller onto a backend-agnostic query surface. This
layer makes that surface the class:

- **`Haps` becomes an abstract role** (`ABC`): where the dataset lives, what it
  is being asked to produce, and the settings that shape the output. It declares
  the query surface, the reconstruct entry points and the track-realign
  dispatch, and nothing about storage.
- **`Svar1Haps(Haps[_H])`** holds `variants` / `genotypes` / `dosages` /
  `var_field_data` / `_ffi_static` and every method that reads them — including
  `from_path`, which stays SVAR1's.
- **`Svar2Haps`** reparents onto the role.

## Why this is one layer and not two

The plan had the ABC hoist and the placeholder deletion as separate PRs. They
are not separable: both classes are `slots=True`, so reparenting `Svar2Haps`
onto a role that does not declare `genotypes` *removes that slot outright*.
There is nowhere left for a fabricated value to live. Deleting the placeholders
is not a follow-up to the hoist, it **is** the hoist. The stack is five PRs, not
six.

## `kw_only=True` is what makes the split possible

`Svar1Haps` adds four required fields that follow the role's defaulted ones.
Without `kw_only` that is a `TypeError` at class creation, and the workaround is
to give every storage field a meaningless default — which is exactly the shape
that let the placeholders exist in the first place. It costs nothing (every
construction site was already all-keyword) and it pays for itself on the other
side: `Svar2Haps.store` and `.cache` were `X | None = None` only to satisfy the
same ordering rule, with three `assert ... is not None` lines apologising
downstream. Both are now required and the asserts delete.

## `n_regions` / `n_samples`

The placeholder `genotypes` array was carrying one real thing: its leading
shape, which `_gathered_groups` unravels a flat dataset index against.
`Svar2Haps` now stores `n_regions` and `n_samples` directly — `from_path`
already computed both and discarded them.

`n_variants` stays on the role, because `_impl.py` reads `.shape[-1]` off it for
ploidy on any `Haps`. `Svar2Haps.__post_init__` now sets it explicitly to a
documented `zeros((R, S, P))`: same value as before, but no longer an accident
of an empty placeholder. #363 tracks making it correct.

## Callers

`Haps.from_path` → `Svar1Haps.from_path` in `_open.py`, the synthetic
reconstructor in `_dummy.py`, and `get_variants_flat` narrows from `Haps` to
`Svar1Haps`. Every other `Haps` reference in the tree is a role check, a type
annotation or a docstring and is unchanged — 33 of them in `_impl.py` alone,
which is the measure of what layers 2–4 bought.

## This obsoletes #356

#356 shrinks the placeholder allocation. There is no longer an allocation to
shrink, so it can be closed unmerged once this stack lands.

## Testing

New `tests/unit/dataset/test_haps_role_split.py` pins the split itself: that the
role is abstract, that it declares none of SVAR1's storage fields, that
`Svar2Haps` has no such field *and no such attribute*, that both implementations
satisfy the role's abstract surface, and that the 12 settings fields stay
`init=True` on both (so `dataclasses.replace` remains the mutation path).

One pre-existing test was reaching into SVAR1 storage on both backends —
`test_slot_fit_property.py` asked `ds._seqs.variants.ref is None` to decide
whether to exercise allele-anchored views. That is the exact bug class this
refactor eliminates, and on SVAR2 it only ever worked because the placeholder
answered `None`. It now asks `ds._seqs.has_ref_alleles`, which is equivalent on
both backends.

`pytest tests/dataset tests/unit tests/parity` at the top of the stack:
**957 passed, 36 skipped, 2 xfailed, 0 failed** (Slurm job 1049229). Every layer below is contained in that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Romp6JJHU4g1M7UyPyCSJH

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
