### PR TITLE
fix(ci): cache the 1kg Zenodo source and retry the download

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,19 @@ jobs:
           # tests/data/generate_1kg_ground_truth.py::provision_minimal_hg38.
           # Keyed on the pinned UCSC chr21/chr22 sha256s; bump if those change.
           key: hg38-chr21chr22-c979ca1e-05f9d97d
+      - name: Cache 1kg source BCF
+        uses: actions/cache@v4
+        with:
+          # Only the raw Zenodo downloads, not the whole 1kg directory: the
+          # derived artifacts alongside them (normalized BCF, PGEN, SVAR,
+          # written datasets) are rebuilt from this source by
+          # generate_1kg_ground_truth.py and must not be restored from a key
+          # that only tracks the source's hashes.
+          path: |
+            tests/data/1kg/source.bcf
+            tests/data/1kg/source.bcf.csi
+          # Keyed on the pinned Zenodo md5s; bump if those change.
+          key: 1kg-source-bcf-3bdfed58-8f190a43
       - name: Test
         run: pixi run -e ${{ matrix.environment }} test
 
@@ -64,6 +77,19 @@ jobs:
           # tests/data/generate_1kg_ground_truth.py::provision_minimal_hg38.
           # Keyed on the pinned UCSC chr21/chr22 sha256s; bump if those change.
           key: hg38-chr21chr22-c979ca1e-05f9d97d
+      - name: Cache 1kg source BCF
+        uses: actions/cache@v4
+        with:
+          # Only the raw Zenodo downloads, not the whole 1kg directory: the
+          # derived artifacts alongside them (normalized BCF, PGEN, SVAR,
+          # written datasets) are rebuilt from this source by
+          # generate_1kg_ground_truth.py and must not be restored from a key
+          # that only tracks the source's hashes.
+          path: |
+            tests/data/1kg/source.bcf
+            tests/data/1kg/source.bcf.csi
+          # Keyed on the pinned Zenodo md5s; bump if those change.
+          key: 1kg-source-bcf-3bdfed58-8f190a43
       - name: Run pytest with polars join order perturbed
         run: pixi run -e py312 test-join-audit
 
@@ -90,6 +116,19 @@ jobs:
           # tests/data/generate_1kg_ground_truth.py::provision_minimal_hg38.
           # Keyed on the pinned UCSC chr21/chr22 sha256s; bump if those change.
           key: hg38-chr21chr22-c979ca1e-05f9d97d
+      - name: Cache 1kg source BCF
+        uses: actions/cache@v4
+        with:
+          # Only the raw Zenodo downloads, not the whole 1kg directory: the
+          # derived artifacts alongside them (normalized BCF, PGEN, SVAR,
+          # written datasets) are rebuilt from this source by
+          # generate_1kg_ground_truth.py and must not be restored from a key
+          # that only tracks the source's hashes.
+          path: |
+            tests/data/1kg/source.bcf
+            tests/data/1kg/source.bcf.csi
+          # Keyed on the pinned Zenodo md5s; bump if those change.
+          key: 1kg-source-bcf-3bdfed58-8f190a43
       - name: Run pytest with coverage
         run: pixi run -e py312 test-cov
       - name: Upload HTML coverage report

--- a/tests/data/generate_1kg_ground_truth.py
+++ b/tests/data/generate_1kg_ground_truth.py
@@ -4,7 +4,7 @@ import gzip
 import shutil
 import subprocess
 from pathlib import Path
-from time import perf_counter
+from time import perf_counter, sleep
 
 import typer
 from loguru import logger
@@ -22,6 +22,14 @@ ZENODO_BCF_URL = "https://zenodo.org/records/20132907/files/1kgp.thin.bcf"
 ZENODO_CSI_URL = "https://zenodo.org/records/20132907/files/1kgp.thin.bcf.csi"
 ZENODO_BCF_MD5 = "md5:3bdfed585e4a6b2a51c49d1d7dc7124f"
 ZENODO_CSI_MD5 = "md5:8f190a43294404ca320b45a05851d56a"
+
+# Zenodo intermittently 504s or stalls mid-transfer. Every CI job fetches this
+# file, so a degraded window used to turn all of them red at once; see issue
+# #370. CI also caches the download (.github/workflows/test.yaml), which makes
+# these retries the cold-cache path rather than the common one.
+ZENODO_ATTEMPTS = 5
+ZENODO_TIMEOUT_S = 120
+ZENODO_BACKOFF_S = 5
 
 # Minimal hg38 reference: just chr21 + chr22 (the only contigs the 1kg slow
 # tier touches). Built from UCSC single-chromosome FASTAs so the 1kg tests can
@@ -54,11 +62,53 @@ def run_shell(
 
 
 def fetch_zenodo(url: str, known_hash: str, fname: str) -> Path:
+    """Download one pinned Zenodo file, retrying through transient outages.
+
+    Returns immediately when the file is already present and matches
+    ``known_hash`` -- which is what makes the CI cache of
+    ``tests/data/1kg/source.bcf*`` effective.
+
+    Args:
+        url: Zenodo file URL.
+        known_hash: Pinned ``md5:...`` hash; pooch verifies against it.
+        fname: Destination filename under :data:`ONE_KG_DIR`.
+
+    Returns:
+        Path to the downloaded (or already-cached) file.
+
+    Raises:
+        RuntimeError: If every attempt fails.
+    """
     import pooch
 
-    return Path(
-        pooch.retrieve(url, known_hash=known_hash, fname=fname, path=ONE_KG_DIR)
-    )
+    downloader = pooch.HTTPDownloader(timeout=ZENODO_TIMEOUT_S)
+    last_err: Exception | None = None
+    for attempt in range(1, ZENODO_ATTEMPTS + 1):
+        try:
+            return Path(
+                pooch.retrieve(
+                    url,
+                    known_hash=known_hash,
+                    fname=fname,
+                    path=ONE_KG_DIR,
+                    downloader=downloader,
+                )
+            )
+        except Exception as e:  # noqa: BLE001 -- retry any transport failure
+            last_err = e
+            if attempt == ZENODO_ATTEMPTS:
+                break
+            delay = ZENODO_BACKOFF_S * 2 ** (attempt - 1)
+            logger.warning(
+                f"Zenodo fetch of {fname} failed"
+                f" (attempt {attempt}/{ZENODO_ATTEMPTS}): {e}."
+                f" Retrying in {delay}s."
+            )
+            sleep(delay)
+    raise RuntimeError(
+        f"Could not fetch {url} after {ZENODO_ATTEMPTS} attempts."
+        " Zenodo may be degraded; see issue #370."
+    ) from last_err
 
 
 def provision_minimal_hg38() -> Path:


### PR DESCRIPTION
Closes #370.

Every CI job re-downloaded the 1kg ground-truth BCF from Zenodo.
`tests/data/fasta` was cached; `tests/data/1kg` was not, so all six jobs per run
(`pytest` ×4, `coverage`, `polars join order audit`) each fetched
`1kgp.thin.bcf` independently with a 30s read timeout.

Because the four `pytest on Python py3xx` jobs are required checks, one degraded
Zenodo window turned every PR red — and `main` with them. Landing stack #367 hit
exactly that: direct probing measured roughly a 1-in-3 success rate, with even
*successful* range requests taking ~25s against the 30s timeout. #369 failed six
consecutive full retries before a stable window opened.

## Two changes, for the warm and cold paths

**Cache the raw download** in all three jobs, keyed on the pinned Zenodo md5s.

Only `source.bcf` and `source.bcf.csi` are cached, not the whole `1kg`
directory. The derived artifacts that live alongside them — normalized BCF,
PGEN, SVAR, written datasets — are rebuilt from that source by
`generate_1kg_ground_truth.py`, so restoring them from a key that tracks only
the *source's* hashes would serve stale test data whenever the generation code
changes. Caching just the download removes the network dependency and leaves
every derived step running exactly as it does today.

**Retry the download**, since a cold cache still has to reach Zenodo once.
`fetch_zenodo` now retries 5 times with exponential backoff and raises a
`RuntimeError` naming the issue if all attempts fail. It also passes a 120s read
timeout, so a slow-but-working transfer is no longer killed at 30s.

pooch already returns immediately when the file is present and matches
`known_hash`, so a restored cache costs one md5 check and no network.

## Cache scoping

A cache written by a PR run is visible only to that PR; one written by a run on
the default branch is restorable by all PRs. So the first `push`-to-`main` run
after this lands is what populates the shared entry — this PR's own run will
still download (with the new retries), and PRs opened afterwards get the hit.

## Testing

Behaviour verified directly against pooch 1.9.0 rather than assumed:

- with a stubbed transport failure, `fetch_zenodo` retries and succeeds on
  attempt 3;
- when every attempt fails, it gives up after 5 and the error names #370;
- a hash-matching local file is returned with no download at all — the property
  the cache relies on.

`ruff check` / `ruff format --check` clean; all pre-commit hooks pass, including
`check yaml` on the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Romp6JJHU4g1M7UyPyCSJH
