### PR TITLE
fix(dataset): clip variants on the tracks-active dispatch too (#314)

### DIFF
--- a/docs/roadmaps/streaming-dataset.md
+++ b/docs/roadmaps/streaming-dataset.md
@@ -592,7 +592,15 @@ and `docs/roadmaps/streaming-optimization-baseline.md` (baseline + profile) for 
   correct defense-in-depth and a verified no-op on all currently-passing scenarios. Follow-up
   filed for the still-unclipped `get_variants_flat(self, idx)` no-region call site
   (`_haps.py:676`, reached via `with_seqs("variants").with_tracks(...)`) — issue
-  [#314](https://github.com/mcvickerlab/GenVarLoader/issues/314).
+  [#314](https://github.com/mcvickerlab/GenVarLoader/issues/314). **Landed:** PR
+  [#387](https://github.com/mcvickerlab/GenVarLoader/pull/387) passes `regions` at that
+  site, so both dispatches clip against one window. It also **retires the verification
+  caveat above** — a literal pre-fix repro does exist, just not from the fixtures used
+  here: `extend_to_length` (on by default) widens the write window past `chromEnd` to
+  cover a deletion, which drags an out-of-window variant into the cell, and the
+  tracks-active query then returned `[60, 110]` where tracks-off returned `[60]`. Note
+  this hole is `streaming`-only: on `main`, `get_variants_flat` consumes `regions`
+  solely for flank/window computation, so the missing argument is inert there.
 - ✅ **Variants-output surface, Wave B PR-B2 (`min_af`/`max_af`) — issue
   [#317](https://github.com/mcvickerlab/GenVarLoader/issues/317), closes
   [#319](https://github.com/mcvickerlab/GenVarLoader/issues/319).** `StreamingDataset

--- a/python/genvarloader/_dataset/_haps.py
+++ b/python/genvarloader/_dataset/_haps.py
@@ -681,7 +681,11 @@ class Haps(Reconstructor[_H]):
                 )
             from ._flat_variants import get_variants_flat
 
-            out = get_variants_flat(self, idx)
+            # `regions` is the SAME array the direct dispatch in `_get_haps`
+            # passes; without it `get_variants_flat` skips the #202 clip on its
+            # own `regions is None` guard, so a tracks-active query returned
+            # variants a tracks-off query over the same cell clipped out (#314).
+            out = get_variants_flat(self, idx, regions)
         else:
             assert_never(self.kind)
 

--- a/tests/dataset/test_variants_region_clip.py
+++ b/tests/dataset/test_variants_region_clip.py
@@ -1,8 +1,12 @@
 """#202: written `with_seqs("variants")` must clip variants to the region window."""
 
+import subprocess
+
 import numpy as np
+import polars as pl
 
 import genvarloader as gvl
+from genvarloader import Table
 
 # `pgen_snp_ins_del_multi`'s `.regions` is a single full-contig region
 # `[0, 250)` -- every variant overlaps it, so the #202 leak cannot manifest
@@ -75,3 +79,120 @@ def test_annotated_variants_are_a_subset_of_clipped_variants(
                     f"cell ({r},{s}) hap {h}: annotated used a variant the clipped "
                     f"variants output dropped"
                 )
+
+
+# --- #314 -------------------------------------------------------------------
+# The clip above is reached only on the DIRECT dispatch,
+# `_haps.py::_get_haps -> get_variants_flat(self, idx, regions)`. When tracks
+# are active the same query instead routes through
+# `Haps.get_haps_and_shifts`, whose call site passed no `regions` at all -- so
+# the clip short-circuited on its own `regions is None` guard and the raw
+# genotype cell came back unfiltered.
+#
+# The fixtures above cannot show it: their written cells happen to hold only
+# in-window variants, so clipping is a no-op. Provoking it needs a cell that
+# genuinely holds an out-of-window variant, which `extend_to_length` (on by
+# default at write time) produces: a deletion inside the window makes the
+# writer read past `chromEnd` to meet the length target, pulling in variants
+# the query-time window then has to clip back out.
+
+
+def _write_extend_to_length_ds(tmp_path):
+    """A dataset whose region-0 genotype cell holds a variant outside [50, 100).
+
+    300bp of `ACGT` repeats on chr1, het in `s0` only:
+      pos 60 (0-based): 21bp REF -> 1bp ALT deletion, inside region 0
+      pos 110 (0-based): SNP, outside region 0 but inside region 1
+
+    Region 0 is `[50, 100)`; the deletion shortens `s0`'s haplotype, so
+    `extend_to_length` widens the write window past `chromEnd` and the pos-110
+    SNP lands in region 0's cell.
+    """
+    ref = "ACGT" * 75
+    del_ref = ref[60 : 60 + 21]
+    del_alt = del_ref[0]
+    snp_ref = ref[110]
+    snp_alt = {"A": "C", "C": "G", "G": "T", "T": "A"}[snp_ref]
+
+    fasta = tmp_path / "ref.fa"
+    fasta.write_text(f">chr1\n{ref}\n")
+    subprocess.run(["samtools", "faidx", str(fasta)], check=True)
+
+    vcf_txt = tmp_path / "in.vcf"
+    vcf_txt.write_text(
+        "##fileformat=VCFv4.2\n"
+        "##contig=<ID=chr1,length=300>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts0\ts1\n"
+        f"chr1\t61\t.\t{del_ref}\t{del_alt}\t.\t.\t.\tGT\t1|0\t0|0\n"
+        f"chr1\t111\t.\t{snp_ref}\t{snp_alt}\t.\t.\t.\tGT\t1|0\t0|0\n"
+    )
+    vcf_gz = tmp_path / "in.vcf.gz"
+    with vcf_gz.open("wb") as fh:
+        subprocess.run(["bgzip", "-c", str(vcf_txt)], stdout=fh, check=True)
+    subprocess.run(["tabix", "-p", "vcf", str(vcf_gz)], check=True)
+
+    regions = pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1"],
+            "chromStart": [50, 100],
+            "chromEnd": [100, 150],
+        }
+    )
+    samples = ["s0", "s1"]
+    track = Table(
+        "cov",
+        pl.DataFrame(
+            {
+                "sample_id": samples,
+                "chrom": ["chr1"] * len(samples),
+                "start": [0] * len(samples),
+                "end": [len(ref)] * len(samples),
+                "value": [1.0] * len(samples),
+            }
+        ),
+    )
+
+    gvl.write(
+        tmp_path / "ds", regions, variants=str(vcf_gz), tracks=track, overwrite=True
+    )
+    return tmp_path / "ds", fasta
+
+
+def test_tracks_active_variants_are_clipped_to_window(tmp_path):
+    """#314: the tracks-active dispatch must clip exactly like the direct one."""
+    ds_path, fasta = _write_extend_to_length_ds(tmp_path)
+    base = gvl.Dataset.open(ds_path, reference=fasta).with_seqs("variants")
+    plain = base.with_tracks(False)
+    tracked = base.with_tracks("cov")
+
+    n_regions, n_samples = base.shape
+    windows = [(50, 100), (100, 150)]
+
+    for r in range(n_regions):
+        r_start, r_end = windows[r]
+        for s in range(n_samples):
+            p = plain[r, s]
+            t = tracked[r, s]
+            t = t[0] if isinstance(t, tuple) else t
+            for h in range(base.ploidy):
+                p_starts = np.asarray(p.start[h]).astype(np.int64).tolist()
+                t_starts = np.asarray(t.start[h]).astype(np.int64).tolist()
+                assert t_starts == p_starts, (
+                    f"cell ({r},{s}) hap {h}: tracks-active variants diverge from "
+                    f"tracks-off; tracks-off={p_starts} tracks-on={t_starts}"
+                )
+                assert all(r_start <= v < r_end for v in t_starts), (
+                    f"cell ({r},{s}) hap {h}: variant outside window "
+                    f"[{r_start},{r_end}) with tracks active; starts={t_starts}"
+                )
+
+    # Non-vacuity: the pos-110 SNP really is in the dataset and really is
+    # reachable -- region 1 returns it. Its absence from region 0 above is
+    # therefore a clip, not a write-time drop.
+    r1 = tracked[1, 0]
+    r1 = r1[0] if isinstance(r1, tuple) else r1
+    assert np.asarray(r1.start[0]).astype(np.int64).tolist() == [110], (
+        "fixture no longer places the out-of-window SNP at pos 110; the clip "
+        "assertions above are vacuous"
+    )


### PR DESCRIPTION
## Problem

`with_seqs("variants")` reaches `get_variants_flat` through two call sites in `_haps.py`:

| dispatch | call | clip applied? |
|---|---|---|
| direct (`Haps._get_haps`) | `get_variants_flat(self, idx, regions)` | yes |
| tracks-active (`Haps.get_haps_and_shifts`) | `get_variants_flat(self, idx)` | **no** |

`get_variants_flat` guards the #202 region-extent clip with `if regions is not None:`, so the second site skipped it and returned the raw genotype cell. Its own comment already named the hole:

> `regions` is None on the no-region call path (`_haps.py get_variants_flat(self, idx)`); skip the clip there.

## Measured

A dataset whose region-0 cell genuinely holds an out-of-window variant. `extend_to_length` (on by default) widens the write window past `chromEnd` to cover a 20bp deletion inside region `[50, 100)` — `regions.npy` comes out `[[0, 50, 111, 1]]` — which pulls a SNP at pos 110 into the cell:

```
tracks-off: [60]
tracks-on:  [60, 110]
```

A spy on `get_variants_flat` confirms the routing directly: tracks-off passes `regions`, tracks-on passed `None`.

## Fix

Pass the `regions` that `get_haps_and_shifts` already receives — the same array the direct dispatch passes — so both sites clip against one window.

## `streaming`-only

On `main`, `get_variants_flat` consumes `regions` **solely** for flank/window computation (`needs_fetch`, `_FlatVariantWindows`, `flank_length`); for plain `RaggedVariants` it is unused, so the missing argument is inert there. Verified by running the same repro on both branches:

| branch | tracks-off | tracks-on |
|---|---|---|
| `main` @ `3c68aa9c` | `[60, 110]` | `[60, 110]` — agree, no clip exists |
| `streaming` @ `8c330689` | `[60]` | `[60, 110]` — diverge |

An earlier analysis on #314 said the bug was also on `main`; that is [corrected in the issue](https://github.com/mcvickerlab/GenVarLoader/issues/314#issuecomment-5636627094).

## Test

`test_tracks_active_variants_are_clipped_to_window` in `tests/dataset/test_variants_region_clip.py`.

The file's existing fixtures cannot catch this — `pgen_snp_ins_del_multi`'s written cells hold only in-window variants, so the clip is a no-op there and a test built on them passes unfixed (verified). The new test builds the `extend_to_length` case above and fails without the fix:

```
AssertionError: cell (0,0) hap 0: tracks-active variants diverge from tracks-off;
tracks-off=[60] tracks-on=[60, 110]
```

It also carries a non-vacuity guard: region 1 `[100, 150)` must return `[110]`, proving the SNP is in the dataset and reachable, so its absence from region 0 is a clip rather than a write-time drop.

## Verification

- Full tree: **1456 passed, 54 skipped, 6 xfailed**. One further failure, `test_rayon_stress.py::test_concurrent_spawn_workers_do_not_deadlock`, was an artifact of running the suite via an absolute-path interpreter without pixi activation (`llvmlite` `OSError: Could not find/load shared object file` in the spawned child); it passes with `LD_LIBRARY_PATH` set to the env's `lib`.
- `ruff check python/ tests/` clean; `ruff format --check` clean (290 files); `pyrefly` 0 errors.
- All prek hooks passed.

## Side finding (separate issue)

While building the fixture, `extend_to_length` turned out to be a **no-op on the PGEN writer path** — same variants written from `.pgen` give `regions.npy` `[[0, 50, 100, 1]]` instead of VCF's `[[0, 50, 111, 1]]`, and a length-50 haplotype query then silently omits the pos-110 SNP that the VCF-written dataset applies. Present on `main` too, so it is not a `streaming` regression: filed as #386, out of scope here.

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gsmxVrgQGEM2PXNYnUoV3
