### PR TITLE
streaming: extract a backend-agnostic mixed variants+tracks re-align seam

### DIFF
--- a/python/genvarloader/_dataset/_streaming.py
+++ b/python/genvarloader/_dataset/_streaming.py
@@ -4,7 +4,15 @@ import copy
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Literal, NamedTuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    ClassVar,
+    Literal,
+    NamedTuple,
+    Protocol,
+    cast,
+)
 
 import numpy as np
 import polars as pl
@@ -358,18 +366,106 @@ def _tracks_from_intervals(
     return cast(RaggedTracks, result)
 
 
-class _RealignWindow(NamedTuple):
-    """The genotype views a re-aligned track window needs, or nothing.
+class _MixedRealign(Protocol):
+    """One window's haplotype-realign state PLUS the kernel that consumes it.
 
-    Exists as its own optional rather than three separately-nullable fields on
+    Mixed variants+tracks needs two things per window: state computed once
+    (per-row genotype views, deletion diffs) and a per-batch kernel that turns
+    that state plus the window's intervals into `RaggedTracks`. Different
+    variant sources need BOTH to differ -- SVAR1 and the record backends share
+    the fused `intervals_and_realign_track_fused` kernel over a CSR
+    (`_RealignWindow`), while SVAR2 has no fused kernel and must split into
+    `intervals_to_tracks` + `shift_and_realign_tracks_from_svar2_readbound`
+    (`_Svar2Realign`). Bundling state with its kernel is what keeps the drive
+    loop free of `isinstance` dispatch: the drive holds one optional and calls
+    one method on it.
+    """
+
+    def realign_batch(
+        self,
+        lo: int,
+        hi: int,
+        itvs: "list[_ItvArrays]",
+        names: list[str],
+        insertion_fill: "dict[str, InsertionFill] | None",
+        regions_batch: NDArray[np.int32],
+        row_lengths: NDArray[np.int64],
+        out_lengths: NDArray[np.int64],
+        base_seed: int,
+    ) -> "RaggedTracks":
+        """Re-align window rows ``[lo, hi)``'s tracks to haplotype coordinates.
+
+        Args:
+            lo: First window row of this batch.
+            hi: One past the last window row of this batch.
+            itvs: One `_ItvArrays` per track, covering the WHOLE window's rows
+                (already FFI-coerced once per window by `_coerce_window_itvs`).
+            names: Track names in `itvs` order.
+            insertion_fill: Per-track insertion-fill overrides, or `None`.
+            regions_batch: `(hi-lo, 3)` int32 `(0, start, end)` rows.
+            row_lengths: `(hi-lo,)` int64 reference-coordinate region lengths.
+            out_lengths: `(hi-lo, ploidy)` int64 per-hap output length, taken
+                from the batch's actual haplotype offsets.
+            base_seed: `FlankSample` base seed.
+
+        Returns:
+            `RaggedTracks` of shape `(hi-lo, n_tracks, ploidy, None)`.
+        """
+        ...
+
+
+class _RealignWindow(NamedTuple):
+    """CSR-shaped realign state: SVAR1 and the record backends (VCF/PGEN).
+
+    Exists as its own optional rather than separately-nullable fields on
     :class:`_TrackWindow` so that "re-alignment is on" and "the arrays
     re-alignment needs are present" cannot disagree: there is one thing to
-    check, and checking it hands you all three arrays already narrowed.
+    check, and checking it hands you everything already narrowed.
+
+    The last three fields are the per-variant tables the fused kernel reads.
+    They are dataset-GLOBAL for `_Svar1Backend` (memmaps over the whole store)
+    and window-LOCAL for the record backends (one decoded window's table), but
+    the kernel only ever indexes them through `geno_v_idxs`, so the two cases
+    are interchangeable here -- which is exactly why they live on the state
+    rather than being read off the backend at the call site.
     """
 
     diffs: "NDArray[np.int32]"
     geno_offsets: "NDArray[np.int64]"
     geno_offset_idx: "NDArray[np.intp]"
+    geno_v_idxs: "NDArray"
+    v_starts: "NDArray[np.int32]"
+    ilens: "NDArray[np.int32]"
+
+    def realign_batch(
+        self,
+        lo: int,
+        hi: int,
+        itvs: "list[_ItvArrays]",
+        names: list[str],
+        insertion_fill: "dict[str, InsertionFill] | None",
+        regions_batch: NDArray[np.int32],
+        row_lengths: NDArray[np.int64],
+        out_lengths: NDArray[np.int64],
+        base_seed: int,
+    ) -> "RaggedTracks":
+        """See :meth:`_MixedRealign.realign_batch`. Fused-kernel implementation."""
+        return _realigned_tracks_from_intervals(
+            itvs,
+            names,
+            insertion_fill,
+            np.arange(lo, hi, dtype=np.int64),
+            regions_batch,
+            self.geno_offset_idx[lo:hi],
+            self.geno_offsets,
+            self.geno_v_idxs,
+            self.v_starts,
+            self.ilens,
+            row_lengths,
+            self.diffs[lo:hi],
+            out_lengths,
+            base_seed,
+        )
 
 
 class _TrackWindow(NamedTuple):
@@ -387,7 +483,7 @@ class _TrackWindow(NamedTuple):
     row_starts: "NDArray[np.int32]"
     row_ends: "NDArray[np.int32]"
     row_lengths: "NDArray[np.int64]"
-    realign: "_RealignWindow | None"
+    realign: "_MixedRealign | None"
 
 
 def _realigned_tracks_from_intervals(
@@ -1243,22 +1339,21 @@ class StreamingDataset:
             # mirroring `_variants` -- threaded through `build_engine`/the engine
             # constructor and selects the `next_batch_variant_windows` puller below.
             _variant_windows = self._seq_kind is dict
-            # Issue #279 Task 7: mixed variants + tracks is SVAR1-ONLY in v1.
-            # The fused re-alignment kernel wiring below assumes
-            # `_Svar1Backend`-shaped inputs (`geno_v_idxs`/`_v_starts`/`_ilens`,
-            # window-local CSR offsets from `read_window`); VCF/PGEN/SVAR2
-            # would need their own per-backend wiring (later follow-up, not
-            # required by #279). Checked BEFORE any engine/plan work so a
-            # doomed combination fails fast, matching the SVAR2 jitter/out_len
-            # guard just below.
-            if self._track_backend is not None and not isinstance(
-                self._backend, _Svar1Backend
+            # Issue #375: mixed variants + tracks is a per-backend CAPABILITY,
+            # not an isinstance test. A backend opts in by setting
+            # `supports_mixed_tracks = True` and defining
+            # `mixed_realign_window`; the two must be added together. Checked
+            # BEFORE any engine/plan work so a doomed combination fails fast,
+            # matching the SVAR2 jitter/out_len guard just below.
+            if (
+                self._track_backend is not None
+                and not self._backend.supports_mixed_tracks
             ):
                 raise NotImplementedError(
                     "StreamingDataset tracks= combined with a variant source is "
-                    "only supported for the SVAR1 (.svar) backend; got "
-                    f"{type(self._backend).__name__}. VCF/PGEN/SVAR2 + track "
-                    "re-alignment is a later follow-up (issue #279)."
+                    f"not supported for {type(self._backend).__name__} yet; only "
+                    "the SVAR1 (.svar) backend supports mixed variants+tracks "
+                    "today (issue #375)."
                 )
             # Task 8 (spec §3.3/§8): `with_seqs("variant-windows")` + tracks +
             # `realign_tracks=True` mirrors the WRITTEN path's own `ValueError`
@@ -1533,8 +1628,6 @@ class StreamingDataset:
                     # haplotype-only stream pays nothing extra.
                     tb = self._track_backend
                     if tb is not None:
-                        from ._genotypes import get_diffs_sparse
-
                         s_idx_w = np.arange(s_lo, s_hi, dtype=np.intp)
                         if region_offsets is not None:
                             # Tracks MUST use the SAME translated bounds the
@@ -1555,69 +1648,15 @@ class StreamingDataset:
                         row_starts_w = np.repeat(t_starts, n_s).astype(np.int32)
                         row_ends_w = np.repeat(t_ends, n_s).astype(np.int32)
                         row_lengths_w = (row_ends_w - row_starts_w).astype(np.int64)
-                        P = backend.ploidy
 
                         if self._realign_tracks:
-                            # Spec section 3.2: the written path's stored
-                            # intervals were extracted over `gvl_bed` AFTER
-                            # `extend_to_length`/`max_jitter` widening; here
-                            # `_regions` is the raw BED, so a region touching a
-                            # deletion needs its track query extended by that
-                            # region's max deletion length, or the realigned
-                            # track underflows. Computed ONCE per window
-                            # (whole-window rows), reused per batch below.
-                            #
-                            # The extension below is the SAME formula the read
-                            # path uses for the rasterization buffer itself --
-                            # `track_lengths = row_lengths -
-                            # diffs.clip(max=0).min(1)` in
-                            # `_realigned_tracks_from_intervals` and, verbatim,
-                            # in the WRITTEN reader (`_reconstruct.py:191`,
-                            # `:382`). Taking the per-region max over the
-                            # window's samples makes the query a superset of
-                            # every row's buffer, so this can never under-read
-                            # for its own kernel, whatever the written store
-                            # did.
-                            #
-                            # It does NOT match the written WRITER's
-                            # `chromEnd` extension (`_write.py:1084`: the end
-                            # of the highest-indexed overlapping variant,
-                            # `POS - min(ILEN, 0)`), which for e.g. two 5 bp
-                            # deletions stores LESS than its own reader asks
-                            # for. That asymmetry can only ever leave the
-                            # written path with zeros in a tail streaming fills
-                            # with real values, and it is unobservable today
-                            # because (a) ragged re-alignment never reads past
-                            # reference index `region_len - 1`
-                            # (`shift_and_realign_track_core`'s trailing fill
-                            # bounds `writable_ref` by `track.len() -
-                            # track_idx`), and (b) `with_len(L)` is bounded by
-                            # the minimum region length on BOTH sides -- see
-                            # `with_len`, which grew that guard for this reason.
-                            # An `extend_to_length` follow-up must revisit both.
-                            o_starts, o_stops = backend.read_window(r_idx, s_idx_w)
-                            geno_offsets_w = np.stack([o_starts, o_stops])
-                            geno_offset_idx_w = np.arange(
-                                n_rows * P, dtype=np.intp
-                            ).reshape(n_rows, P)
-                            diffs_w = get_diffs_sparse(
-                                geno_offset_idx_w,
-                                backend.geno_v_idxs,
-                                geno_offsets_w,
-                                backend._ilens,
-                                q_starts=row_starts_w,
-                                q_ends=row_ends_w,
-                                v_starts=backend._v_starts,
-                            )
-                            max_del_row = -diffs_w.clip(max=0).min(1)
-                            region_max_del = max_del_row.reshape(len(r_idx), n_s).max(1)
-                            t_ends_ext = np.ascontiguousarray(
-                                t_ends.astype(np.int64) + region_max_del, np.int32
-                            )
-                            realign_w = _RealignWindow(
-                                diffs=diffs_w,
-                                geno_offsets=geno_offsets_w,
-                                geno_offset_idx=geno_offset_idx_w,
+                            realign_w, t_ends_ext = backend.mixed_realign_window(
+                                r_idx,
+                                s_idx_w,
+                                np.ascontiguousarray(t_starts, np.int32),
+                                np.ascontiguousarray(t_ends, np.int32),
+                                row_starts_w,
+                                row_ends_w,
                             )
                         else:
                             # Un-realigned tracks stay in reference coordinates
@@ -1849,19 +1888,14 @@ class StreamingDataset:
                                         self.n_samples
                                     ) + flat_s[lo:hi].astype(np.uint64)
                                     base_seed = int(np.bitwise_xor.reduce(_idx))
-                                    tracks = _realigned_tracks_from_intervals(
+                                    tracks = track_w.realign.realign_batch(
+                                        lo,
+                                        hi,
                                         track_w.itvs,
                                         track_w.names,
                                         self._insertion_fill,
-                                        np.arange(lo, hi, dtype=np.int64),
                                         regions_batch,
-                                        track_w.realign.geno_offset_idx[lo:hi],
-                                        track_w.realign.geno_offsets,
-                                        backend.geno_v_idxs,
-                                        backend._v_starts,
-                                        backend._ilens,
                                         track_w.row_lengths[lo:hi],
-                                        track_w.realign.diffs[lo:hi],
                                         out_lengths,
                                         base_seed,
                                     )
@@ -3291,6 +3325,75 @@ class _Svar1Backend:
         )
         return np.asarray(o_starts, np.int64), np.asarray(o_stops, np.int64)
 
+    #: Mixed variants+tracks is wired for this backend (issue #279).
+    supports_mixed_tracks: ClassVar[bool] = True
+
+    def mixed_realign_window(
+        self,
+        r_idx: NDArray[np.intp],
+        s_idx: NDArray[np.intp],
+        t_starts: NDArray[np.int32],
+        t_ends: NDArray[np.int32],
+        row_starts: NDArray[np.int32],
+        row_ends: NDArray[np.int32],
+    ) -> tuple["_MixedRealign", NDArray[np.int32]]:
+        """One window's fused-kernel realign state + deletion-extended track ends.
+
+        Moved verbatim out of the `to_iter` drive (issue #375): the drive used
+        to reach into `_Svar1Backend`-only attributes directly, which is what
+        made the mixed path SVAR1-only.
+
+        `t_ends` is extended per REGION by that region's max deletion length
+        across the window's samples, because `_regions` is the raw BED while
+        the written path's intervals were extracted over the post-widening
+        `gvl_bed`. The formula (`row_lengths - diffs.clip(max=0).min(1)`) is
+        the read path's own, verbatim, from `_realigned_tracks_from_intervals`
+        and the WRITTEN reader (`_reconstruct.py:191`, `:382`); taking the
+        per-region max over the window's samples makes the query a superset of
+        every row's buffer, so it can never under-read.
+
+        It deliberately does NOT match the written WRITER's `chromEnd`
+        extension (`_write.py:1084`), which stores less than its own reader
+        asks for. That asymmetry can only leave the written path with zeros in
+        a tail streaming fills with real values, and is unobservable today
+        because ragged re-alignment never reads past reference index
+        `region_len - 1` and `with_len(L)` is bounded by the minimum region
+        length on both sides. An `extend_to_length` follow-up must revisit both.
+        """
+        from ._genotypes import get_diffs_sparse
+
+        n_rows = len(row_starts)
+        P = self.ploidy
+        n_s = len(s_idx)
+        o_starts, o_stops = self.read_window(r_idx, s_idx)
+        geno_offsets_w = np.stack([o_starts, o_stops])
+        geno_offset_idx_w = np.arange(n_rows * P, dtype=np.intp).reshape(n_rows, P)
+        diffs_w = get_diffs_sparse(
+            geno_offset_idx_w,
+            self.geno_v_idxs,
+            geno_offsets_w,
+            self._ilens,
+            q_starts=row_starts,
+            q_ends=row_ends,
+            v_starts=self._v_starts,
+        )
+        max_del_row = -diffs_w.clip(max=0).min(1)
+        region_max_del = max_del_row.reshape(len(r_idx), n_s).max(1)
+        t_ends_ext = np.ascontiguousarray(
+            t_ends.astype(np.int64) + region_max_del, np.int32
+        )
+        return (
+            _RealignWindow(
+                diffs=diffs_w,
+                geno_offsets=geno_offsets_w,
+                geno_offset_idx=geno_offset_idx_w,
+                geno_v_idxs=self.geno_v_idxs,
+                v_starts=self._v_starts,
+                ilens=self._ilens,
+            ),
+            t_ends_ext,
+        )
+
     def generate_batch(
         self,
         r_idx: NDArray[np.intp],
@@ -3368,6 +3471,9 @@ class _Svar2Backend:
     multi-core (Phase 2). Still "sync" `_iter_batches` strategy -- no engine, no
     readahead.
     """
+
+    #: Mixed variants+tracks not wired for this backend yet (issue #375).
+    supports_mixed_tracks: ClassVar[bool] = False
 
     _default_strategy = "sync"
 
@@ -3688,6 +3794,9 @@ class _VcfBackend:
     not read/cached here.
     """
 
+    #: Mixed variants+tracks not wired for this backend yet (issue #375).
+    supports_mixed_tracks: ClassVar[bool] = False
+
     def __init__(
         self,
         vcf_path: str | Path,
@@ -3885,6 +3994,9 @@ class _PgenBackend:
     window-by-window by the Rust `PgenWindowFiller` inside the engine, not
     read/cached here.
     """
+
+    #: Mixed variants+tracks not wired for this backend yet (issue #375).
+    supports_mixed_tracks: ClassVar[bool] = False
 
     def __init__(
         self,

--- a/python/genvarloader/_dataset/_streaming.py
+++ b/python/genvarloader/_dataset/_streaming.py
@@ -443,7 +443,7 @@ class _MixedTracksBackend(Protocol):
         t_ends: NDArray[np.int32],
         row_starts: NDArray[np.int32],
         row_ends: NDArray[np.int32],
-    ) -> "tuple[_MixedRealign, NDArray[np.int32]]":
+    ) -> tuple[_MixedRealign, NDArray[np.int32]]:
         """Per-window realign state + deletion-extended track ends.
 
         See `_Svar1Backend.mixed_realign_window` for the full contract every
@@ -1690,16 +1690,37 @@ class StreamingDataset:
                         row_lengths_w = (row_ends_w - row_starts_w).astype(np.int64)
 
                         if self._realign_tracks:
-                            # M2 (#375 review): narrow to the checked
-                            # `_MixedTracksBackend` protocol here, at the one
-                            # call site that matters, rather than trusting the
-                            # `supports_mixed_tracks` guard above alone. The
-                            # guard already makes this assert unreachable in
-                            # practice; its job is to turn a backend that sets
-                            # the flag without (or with a wrongly-shaped)
-                            # `mixed_realign_window` into a `pyrefly` error or
-                            # a clear `AssertionError` here, instead of an
-                            # `AttributeError` deep in the batch loop.
+                            # M2 (#375 review): narrow to `_MixedTracksBackend`
+                            # here, at the one call site that matters, rather
+                            # than trusting the `supports_mixed_tracks` guard
+                            # above alone. The guard already makes this assert
+                            # unreachable in practice -- the point is what the
+                            # narrowing buys at CHECK time, and the two halves
+                            # catch different things:
+                            #
+                            # - Statically, `pyrefly` reports `unsafe-overlap`
+                            #   ON THIS LINE if ANY member of `backend`'s union
+                            #   defines `mixed_realign_window` with a shape that
+                            #   disagrees with the protocol -- swapped return
+                            #   tuple, wrong parameter types, either one.
+                            #   Verified empirically against this repo's
+                            #   pyrefly config, not assumed. This is the half
+                            #   that protects Tracks A and B: the moment SVAR2
+                            #   or VCF/PGEN grows a mis-shaped
+                            #   `mixed_realign_window`, the type check fails
+                            #   here instead of the drive failing at runtime.
+                            # - At runtime, `isinstance` against a
+                            #   `runtime_checkable` protocol checks attribute
+                            #   PRESENCE ONLY -- never signatures. So it catches
+                            #   exactly one thing the static half cannot: a
+                            #   backend that sets the flag with no
+                            #   `mixed_realign_window` at all (or a typo'd
+                            #   name), turning an `AttributeError` deep in the
+                            #   batch loop into a clear `AssertionError` naming
+                            #   the offending backend.
+                            #
+                            # Neither half alone is sufficient; do not drop
+                            # either one believing the other covers it.
                             assert isinstance(backend, _MixedTracksBackend), (
                                 f"{type(backend).__name__} sets "
                                 "supports_mixed_tracks without a conforming "
@@ -3391,7 +3412,7 @@ class _Svar1Backend:
         t_ends: NDArray[np.int32],
         row_starts: NDArray[np.int32],
         row_ends: NDArray[np.int32],
-    ) -> tuple["_MixedRealign", NDArray[np.int32]]:
+    ) -> tuple[_MixedRealign, NDArray[np.int32]]:
         """One window's fused-kernel realign state + deletion-extended track ends.
 
         Moved verbatim out of the `to_iter` drive (issue #375): the drive used
@@ -3457,9 +3478,17 @@ class _Svar1Backend:
               `geno_offset_idx` are `(n_regions * n_samples, ploidy)`,
               region-major/sample-minor like `row_starts` with ploidy as the
               FAST axis (haplotype `h` of row `i` is `geno_offset_idx[i,
-              h]`, flat index `i * ploidy + h`). `geno_offsets` is `(2,
-              n_regions * n_samples * ploidy)` and WINDOW-LOCAL (indices
-              into this window's own CSR, not the dataset-global store).
+              h]`, flat index `i * ploidy + h`). `geno_offset_idx` is the
+              WINDOW-LOCAL half of the pair: a plain `arange` over this
+              window's own rows, so it addresses `geno_offsets`' columns and
+              nothing else. `geno_offsets` itself is `(2, n_regions *
+              n_samples * ploidy)` -- CSR `[start, stop)` pairs whose values
+              index `geno_v_idxs`, and for this backend they come straight
+              out of `read_window`, so they are ABSOLUTE offsets into the
+              store's `variant_idxs` mmap, NOT window-relative. A record
+              backend hands back offsets into its own decoded window table
+              instead; both are correct because the kernel only ever reaches
+              them via `geno_offset_idx`.
               `geno_v_idxs`/`v_starts`/`ilens` are the per-variant tables
               the kernel indexes through `geno_offset_idx`; for this backend
               they are the store's dataset-GLOBAL memmaps, but a record

--- a/python/genvarloader/_dataset/_streaming.py
+++ b/python/genvarloader/_dataset/_streaming.py
@@ -12,6 +12,7 @@ from typing import (
     NamedTuple,
     Protocol,
     cast,
+    runtime_checkable,
 )
 
 import numpy as np
@@ -376,9 +377,9 @@ class _MixedRealign(Protocol):
     the fused `intervals_and_realign_track_fused` kernel over a CSR
     (`_RealignWindow`), while SVAR2 has no fused kernel and must split into
     `intervals_to_tracks` + `shift_and_realign_tracks_from_svar2_readbound`
-    (`_Svar2Realign`). Bundling state with its kernel is what keeps the drive
-    loop free of `isinstance` dispatch: the drive holds one optional and calls
-    one method on it.
+    (`_Svar2Realign` -- Track A, not yet landed). Bundling state with its
+    kernel is what keeps the drive loop free of `isinstance` dispatch: the
+    drive holds one optional and calls one method on it.
     """
 
     def realign_batch(
@@ -410,6 +411,44 @@ class _MixedRealign(Protocol):
 
         Returns:
             `RaggedTracks` of shape `(hi-lo, n_tracks, ploidy, None)`.
+        """
+        ...
+
+
+@runtime_checkable
+class _MixedTracksBackend(Protocol):
+    """A stream backend that can serve mixed variants + tracks.
+
+    The backend half of the `_MixedRealign` seam (issue #375): `_MixedRealign`
+    is the per-window STATE plus the kernel that consumes it; this is the
+    CAPABILITY a backend declares in order to produce that state in the first
+    place. Declaring it as a `@runtime_checkable` Protocol -- rather than only
+    the loose `supports_mixed_tracks` bool every backend already carries --
+    makes the pairing machine-checkable: `to_iter`'s `isinstance(backend,
+    _MixedTracksBackend)` narrows the backend union at the one call site that
+    matters, so a backend that flips `supports_mixed_tracks = True` without a
+    correctly-shaped `mixed_realign_window` (wrong return order, typo'd name,
+    wrong parameter types) is caught there -- statically by `pyrefly`, or at
+    worst by a clear `AssertionError` at the narrowing site -- instead of an
+    `AttributeError` hundreds of lines away in the batch loop.
+    """
+
+    supports_mixed_tracks: ClassVar[bool]
+
+    def mixed_realign_window(
+        self,
+        r_idx: NDArray[np.intp],
+        s_idx: NDArray[np.intp],
+        t_starts: NDArray[np.int32],
+        t_ends: NDArray[np.int32],
+        row_starts: NDArray[np.int32],
+        row_ends: NDArray[np.int32],
+    ) -> "tuple[_MixedRealign, NDArray[np.int32]]":
+        """Per-window realign state + deletion-extended track ends.
+
+        See `_Svar1Backend.mixed_realign_window` for the full contract every
+        conforming backend must satisfy (index spaces, row ordering, shapes,
+        and the exact 2-tuple return order).
         """
         ...
 
@@ -1405,8 +1444,9 @@ class StreamingDataset:
                 )
             # Deliberate seam, NOT covered by any required parity test (the
             # fixture is built with `max_jitter=None`): `_Svar1Backend.read_window`
-            # (used below, per-window, to size the deletion-extended track query)
-            # always queries the RAW unjittered `_regions` bounds, while the
+            # (used by `mixed_realign_window`, per-window, to size the
+            # deletion-extended track query) always queries the RAW unjittered
+            # `_regions` bounds, while the
             # haplotype engine and the track query itself use the jitter-translated
             # bounds (`_jitter_region_bounds`). Under jitter>0 this can miss a
             # boundary deletion and under-extend the track query. Fail fast rather
@@ -1650,6 +1690,21 @@ class StreamingDataset:
                         row_lengths_w = (row_ends_w - row_starts_w).astype(np.int64)
 
                         if self._realign_tracks:
+                            # M2 (#375 review): narrow to the checked
+                            # `_MixedTracksBackend` protocol here, at the one
+                            # call site that matters, rather than trusting the
+                            # `supports_mixed_tracks` guard above alone. The
+                            # guard already makes this assert unreachable in
+                            # practice; its job is to turn a backend that sets
+                            # the flag without (or with a wrongly-shaped)
+                            # `mixed_realign_window` into a `pyrefly` error or
+                            # a clear `AssertionError` here, instead of an
+                            # `AttributeError` deep in the batch loop.
+                            assert isinstance(backend, _MixedTracksBackend), (
+                                f"{type(backend).__name__} sets "
+                                "supports_mixed_tracks without a conforming "
+                                "mixed_realign_window."
+                            )
                             realign_w, t_ends_ext = backend.mixed_realign_window(
                                 r_idx,
                                 s_idx_w,
@@ -2755,6 +2810,9 @@ class _Svar1Backend:
     per-region live genotype reads hit the store during iteration.
     """
 
+    #: Mixed variants+tracks is wired for this backend (issue #375).
+    supports_mixed_tracks: ClassVar[bool] = True
+
     def __init__(
         self,
         svar_path: str | Path,
@@ -3325,9 +3383,6 @@ class _Svar1Backend:
         )
         return np.asarray(o_starts, np.int64), np.asarray(o_stops, np.int64)
 
-    #: Mixed variants+tracks is wired for this backend (issue #279).
-    supports_mixed_tracks: ClassVar[bool] = True
-
     def mixed_realign_window(
         self,
         r_idx: NDArray[np.intp],
@@ -3341,7 +3396,12 @@ class _Svar1Backend:
 
         Moved verbatim out of the `to_iter` drive (issue #375): the drive used
         to reach into `_Svar1Backend`-only attributes directly, which is what
-        made the mixed path SVAR1-only.
+        made the mixed path SVAR1-only. This is the backend HALF of the
+        `_MixedRealign` seam: a conforming backend must produce a
+        correctly-shaped state object plus extended ends from exactly this
+        signature -- see `_MixedTracksBackend` for the checked contract. All
+        coordinate arrays below are 0-based, half-open reference coordinates
+        unless noted.
 
         `t_ends` is extended per REGION by that region's max deletion length
         across the window's samples, because `_regions` is the raw BED while
@@ -3359,6 +3419,66 @@ class _Svar1Backend:
         because ragged re-alignment never reads past reference index
         `region_len - 1` and `with_len(L)` is bounded by the minimum region
         length on both sides. An `extend_to_length` follow-up must revisit both.
+
+        Args:
+            r_idx: `(n_regions,)` indices into `self._regions` -- region SORT
+                order, the same space the drive iterates in. NOT the public,
+                user-facing region index; the drive separately maps to that
+                via `self._sort_order[r_idx]` when it needs it.
+            s_idx: `(n_samples,)` PUBLIC (sorted-name) sample indices, the
+                same space `gvl.Dataset`'s `s` means. A backend whose native
+                storage uses a different sample order (e.g. VCF column order)
+                MUST translate internally -- the way this implementation's
+                `read_window`/`_phys_sample_idx` do -- the caller never
+                performs that translation itself.
+            t_starts: `(n_regions,)` int32, one un-extended track query start
+                per region. Present for contract symmetry with `t_ends` and
+                for a future backend that may need it; this implementation
+                does not read it (the extension below is end-only).
+            t_ends: `(n_regions,)` int32, one un-extended track query end per
+                region -- the value this method extends.
+            row_starts: `(n_regions * n_samples,)` int32, one track-row start
+                per (region, sample) pair, REGION-MAJOR SAMPLE-MINOR: row
+                `i * n_samples + j` is `(region r_idx[i], sample s_idx[j])`.
+                This is `np.repeat(t_starts, n_samples)` and MUST stay in
+                that order -- it is the same layout `geno_offset_idx`/
+                `flat_r`/`flat_s` use elsewhere in the drive, and this
+                method's own `region_max_del` reshape (`len(r_idx),
+                len(s_idx)`) depends on it.
+            row_ends: `(n_regions * n_samples,)` int32, same
+                region-major/sample-minor layout as `row_starts`, one row end
+                per (region, sample) pair.
+
+        Returns:
+            A 2-tuple `(realign_window, t_ends_ext)`, in that exact order:
+
+            - `realign_window`: a `_MixedRealign` (here, a `_RealignWindow`)
+              bundling this window's re-align state. `diffs` and
+              `geno_offset_idx` are `(n_regions * n_samples, ploidy)`,
+              region-major/sample-minor like `row_starts` with ploidy as the
+              FAST axis (haplotype `h` of row `i` is `geno_offset_idx[i,
+              h]`, flat index `i * ploidy + h`). `geno_offsets` is `(2,
+              n_regions * n_samples * ploidy)` and WINDOW-LOCAL (indices
+              into this window's own CSR, not the dataset-global store).
+              `geno_v_idxs`/`v_starts`/`ilens` are the per-variant tables
+              the kernel indexes through `geno_offset_idx`; for this backend
+              they are the store's dataset-GLOBAL memmaps, but a record
+              backend (VCF/PGEN) would hand back a window-LOCAL decoded
+              table instead (see `_RealignWindow`'s docstring) -- either
+              way the caller only ever reaches them through
+              `geno_offset_idx`, never as absolute dataset-global variant
+              indices.
+            - `t_ends_ext`: `(n_regions,)` int32, `t_ends` extended by each
+              region's max deletion length over `s_idx` -- one value PER
+              REGION, not per row. Feed this (not `t_ends`) to the track
+              backend's `read_window` so the interval query covers every
+              sample's realigned tail.
+
+            This computation assumes jitter is OFF for `_realign_tracks=True`
+            streams (the caller's `jitter>0` guard just above raises before
+            this method would ever be called with jittered bounds): an
+            un-translated extension over jittered `t_starts`/`t_ends` would
+            under-size the query relative to what the haplotype engine used.
         """
         from ._genotypes import get_diffs_sparse
 

--- a/tests/dataset/test_streaming_tracks.py
+++ b/tests/dataset/test_streaming_tracks.py
@@ -882,16 +882,44 @@ def test_supports_mixed_tracks_flags_match_mixed_realign_window_protocol():
     assert _PgenBackend.supports_mixed_tracks is False
 
     # The one backend that claims support must define `mixed_realign_window`
-    # with exactly the checked protocol's parameter names, in order -- the
-    # same shape `to_iter`'s `isinstance(backend, _MixedTracksBackend)`
-    # narrows against before calling it.
-    expected_params = list(
-        inspect.signature(_MixedTracksBackend.mixed_realign_window).parameters
+    # with exactly the checked protocol's signature -- parameter names AND
+    # their annotations AND the return annotation, not just the names. The
+    # names alone would not catch the failure this test exists for: a Track
+    # that returns `(t_ends_ext, realign_window)` instead of
+    # `(realign_window, t_ends_ext)` keeps every parameter name identical.
+    #
+    # NOTE: `pyrefly`, not this test, is the PRIMARY gate on shape -- it
+    # reports `unsafe-overlap` at the `isinstance(backend,
+    # _MixedTracksBackend)` narrowing in `to_iter` for any union member whose
+    # `mixed_realign_window` disagrees with the protocol. This test is the
+    # runtime backstop for a checker that is not run, or is run permissively.
+    # `eval_str=True` RESOLVES the string annotations rather than comparing
+    # them textually. Both declarations are `from __future__`-style strings,
+    # and the two spell the same type differently -- the protocol quotes the
+    # whole return (`"tuple[_MixedRealign, NDArray[np.int32]]"`), the backend
+    # quotes only the forward reference (`tuple["_MixedRealign", ...]`). Those
+    # are the same type, and a textual comparison would fail on the quoting
+    # alone, which is exactly the kind of false alarm that gets a test deleted
+    # instead of heeded.
+    expected_sig = inspect.signature(
+        _MixedTracksBackend.mixed_realign_window, eval_str=True
     )
-    assert (
-        list(inspect.signature(_Svar1Backend.mixed_realign_window).parameters)
-        == expected_params
+    actual_sig = inspect.signature(_Svar1Backend.mixed_realign_window, eval_str=True)
+    assert list(actual_sig.parameters) == list(expected_sig.parameters)
+    assert actual_sig.return_annotation == expected_sig.return_annotation, (
+        "_Svar1Backend.mixed_realign_window's RETURN type has drifted from "
+        "the _MixedTracksBackend protocol (a swapped 2-tuple keeps every "
+        "parameter name identical, so only this assert would catch it):\n"
+        f"  protocol: {expected_sig.return_annotation}\n"
+        f"  backend:  {actual_sig.return_annotation}"
     )
+    for name, expected_param in expected_sig.parameters.items():
+        assert actual_sig.parameters[name].annotation == expected_param.annotation, (
+            f"_Svar1Backend.mixed_realign_window parameter {name!r} has "
+            f"drifted from the _MixedTracksBackend protocol:\n"
+            f"  protocol: {expected_param.annotation}\n"
+            f"  backend:  {actual_sig.parameters[name].annotation}"
+        )
     # None of the non-supporting backends need to satisfy it, but a stray
     # `mixed_realign_window` on one of them would mask a mismatched flag --
     # guard against that too.

--- a/tests/dataset/test_streaming_tracks.py
+++ b/tests/dataset/test_streaming_tracks.py
@@ -842,6 +842,64 @@ def test_mixed_tracks_svar2_raises(streaming_svar2_case):
         next(iter(sds.to_iter(batch_size=1)))
 
 
+def test_supports_mixed_tracks_flags_match_mixed_realign_window_protocol():
+    """Pin the data the `to_iter` capability guard actually reads (issue #375).
+
+    `test_mixed_tracks_non_svar1_raises`/`test_mixed_tracks_svar2_raises`
+    above already pin the guard's user-visible BEHAVIOR (VCF/PGEN/SVAR2 +
+    ``tracks=`` raises `NotImplementedError` at `to_iter` time) -- constructing
+    another `StreamingDataset` over one of those sources would only repeat
+    that, not add coverage. What those tests can't see is the guard's
+    SOURCE OF TRUTH: each backend's `supports_mixed_tracks` `ClassVar[bool]`,
+    and -- since the #375 fix round -- whether a backend that sets it `True`
+    actually shapes `mixed_realign_window` to match the `_MixedTracksBackend`
+    protocol `to_iter` narrows to before calling it. A backend could flip the
+    flag without a conforming method and every existing raise-test would stay
+    green; this test is the one place that would catch it.
+
+    Structural conformance is checked via signature comparison rather than
+    `isinstance`/`issubclass` against `_MixedTracksBackend`: that Protocol has
+    a non-method member (`supports_mixed_tracks`), and CPython's `typing`
+    module only supports `isinstance()` against such a Protocol on a live
+    INSTANCE, not `issubclass()` against the class -- constructing a real
+    `_Svar1Backend` instance just for this check would drag in fixture
+    plumbing this test is meant to avoid.
+    """
+    import inspect
+
+    from genvarloader._dataset._streaming import (
+        _MixedTracksBackend,
+        _PgenBackend,
+        _Svar1Backend,
+        _Svar2Backend,
+        _VcfBackend,
+    )
+
+    # SVAR1 is the only backend wired for mixed variants+tracks today.
+    assert _Svar1Backend.supports_mixed_tracks is True
+    assert _Svar2Backend.supports_mixed_tracks is False
+    assert _VcfBackend.supports_mixed_tracks is False
+    assert _PgenBackend.supports_mixed_tracks is False
+
+    # The one backend that claims support must define `mixed_realign_window`
+    # with exactly the checked protocol's parameter names, in order -- the
+    # same shape `to_iter`'s `isinstance(backend, _MixedTracksBackend)`
+    # narrows against before calling it.
+    expected_params = list(
+        inspect.signature(_MixedTracksBackend.mixed_realign_window).parameters
+    )
+    assert (
+        list(inspect.signature(_Svar1Backend.mixed_realign_window).parameters)
+        == expected_params
+    )
+    # None of the non-supporting backends need to satisfy it, but a stray
+    # `mixed_realign_window` on one of them would mask a mismatched flag --
+    # guard against that too.
+    for backend in (_Svar2Backend, _VcfBackend, _PgenBackend):
+        assert not backend.supports_mixed_tracks
+        assert not hasattr(backend, "mixed_realign_window")
+
+
 def test_insertion_fill_without_tracks_raises(streaming_tracks_fixture):
     """Spec §3.1: `with_insertion_fill` on a track-less dataset is an error.
 


### PR DESCRIPTION
Serial prelude (Task 1 of the #375 plan) for mixed variants+tracks on SVAR2/VCF/PGEN. **No behavior change** — this is the seam two parallel implementation tracks build on.

Closes #389. Relates to #375.

## What this does

Mixed variants+tracks currently works only for SVAR1, because the `to_iter` drive reached directly into `_Svar1Backend`-only attributes. This extracts that into a backend-agnostic seam so SVAR2 (Track A) and VCF/PGEN (Track B) can plug in without touching the drive:

- **`_MixedRealign` Protocol** — bundles one window's re-align state with the kernel that consumes it, so the drive holds one optional and calls one method instead of dispatching on `isinstance`. SVAR1 and the record backends use the fused `intervals_and_realign_track_fused` kernel over a CSR (`_RealignWindow`); SVAR2 has no fused kernel and must split into `intervals_to_tracks` + `shift_and_realign_tracks_from_svar2_readbound`.
- **`_Svar1Backend.mixed_realign_window`** — the SVAR1 half, moved verbatim out of the drive, now with a full `Args:`/`Returns:` contract (index spaces, region-major/sample-minor row ordering, shapes, exact 2-tuple return order). Tracks A and B code against this text, so it is load-bearing documentation.
- **`_MixedTracksBackend` Protocol + `supports_mixed_tracks` capability flag** — replaces an `isinstance` guard, and makes the pairing machine-checkable.

## On the capability check

The guard has two halves that catch different things, and neither alone is sufficient:

- **Statically**, pyrefly reports `unsafe-overlap` at the `isinstance(backend, _MixedTracksBackend)` narrowing for any union member whose `mixed_realign_window` disagrees with the protocol. Verified empirically against this repo's pyrefly config: a swapped return tuple errors there, and so do wrong parameter types. This is the half that protects the two tracks.
- **At runtime**, `isinstance` against a `runtime_checkable` protocol checks attribute *presence* only, never signatures. So it catches the one case the static half cannot: a backend that sets the flag with no `mixed_realign_window` at all.

Worth knowing for anyone re-verifying this: running pyrefly on a scratch file *outside* the project silently falls back to preset `basic` and reports 0 errors. The probe has to live inside the worktree.

## Testing

- `tests/dataset/test_streaming_tracks.py` — **53 passed**, including a new conformance test pinning the guard's source of truth. It compares resolved annotations (`inspect.signature(..., eval_str=True)`), not parameter names — a swapped 2-tuple keeps every name identical. Verified non-vacuous by mutating the backend's return type and watching it fail.
- ruff format/check clean · pyrefly 0 errors · docstring style: numpy 0, mixed 0.

The byte-identical parity contract vs `gvl.write()` + `Dataset[r, s]` is unchanged and still green.

## Review history

Reviewed and accepted on spec, then two fix rounds. The second round corrected a docstring that had `geno_offsets` and `geno_offset_idx` backwards — `geno_offsets` holds absolute offsets into the store's `variant_idxs` mmap, and `geno_offset_idx` is the window-local `arange`. Since both tracks implement against that contract, an inaccurate version was worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LTUVE8PofP9FD2m7A6uBg
